### PR TITLE
Notify when background turns finish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7635,6 +7635,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "objc2-quartz-core 0.3.2",
+ "objc2-user-notifications",
  "objc2-web-kit",
  "parking_lot",
  "pulldown-cmark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
 objc2-foundation = { version = "0.3", default-features = false, features = [
     "std",
     "NSArray",
+    "NSBundle",
     "NSData",
     "NSDictionary",
     "NSError",
@@ -92,6 +93,15 @@ objc2-foundation = { version = "0.3", default-features = false, features = [
     "NSProcessInfo",
     "NSString",
     "NSURL",
+] }
+objc2-user-notifications = { version = "0.3", default-features = false, features = [
+    "std",
+    "block2",
+    "UNNotificationContent",
+    "UNNotificationRequest",
+    "UNNotificationSound",
+    "UNNotificationTrigger",
+    "UNUserNotificationCenter",
 ] }
 objc2-quartz-core = { version = "0.3", default-features = false, features = ["std", "CALayer", "objc2-core-graphics"] }
 raw-window-handle = "0.6"

--- a/src/app.rs
+++ b/src/app.rs
@@ -120,6 +120,15 @@ const STREAM_SAVE_INTERVAL: Duration = Duration::from_secs(1);
 const DEFAULT_TOAST_DURATION: Duration = Duration::from_secs(5);
 const MINIMUM_TOAST_RESUME_DURATION: Duration = Duration::from_millis(800);
 const TOAST_ANIMATION_DURATION: Duration = Duration::from_millis(150);
+const TASK_NOTIFICATION_TAG_PREFIX: &str = "waku-task:";
+
+pub(crate) fn task_notification_tag(session_id: Uuid) -> String {
+    format!("{TASK_NOTIFICATION_TAG_PREFIX}{session_id}")
+}
+
+pub(crate) fn task_id_from_notification_tag(tag: &str) -> Option<Uuid> {
+    tag.strip_prefix(TASK_NOTIFICATION_TAG_PREFIX)?.parse().ok()
+}
 
 fn signal_event_pump(wake: &smol::channel::Sender<()>) {
     let _ = wake.try_send(());

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -8,6 +8,10 @@ fn retain_runtime_after_cancel(provider: ProviderKind) -> bool {
 }
 
 impl Waku {
+    pub(crate) fn open_task_from_notification(&mut self, session_id: Uuid, cx: &mut Context<Self>) {
+        self.select_session(session_id, cx);
+    }
+
     pub(super) fn select_project(&mut self, project_id: Uuid, cx: &mut Context<Self>) {
         self.state.selected_project = Some(project_id);
         self.create_session_for(project_id, self.state.last_provider, cx);

--- a/src/app/streaming.rs
+++ b/src/app/streaming.rs
@@ -444,6 +444,25 @@ impl Waku {
                 {
                     return true;
                 }
+                let task_notification = cx.active_window().is_none().then(|| {
+                    self.state
+                        .sessions
+                        .iter()
+                        .find(|session| session.id == session_id)
+                        .map(|session| {
+                            let title = if session.display_title() == AgentSession::DEFAULT_TITLE {
+                                tr!("session.new_task")
+                            } else {
+                                session.display_title().to_owned()
+                            };
+                            let body = if success {
+                                tr!("session.turn_completed")
+                            } else {
+                                tr!("session.stopped")
+                            };
+                            (title, body)
+                        })
+                });
                 self.finish_streaming_assistant(session_id);
                 self.complete_turn_blocks(session_id);
                 runtime.stream_phase = None;
@@ -499,6 +518,13 @@ impl Waku {
                 }
                 if let Some(previous_kinds) = previous_kinds.as_deref() {
                     self.splice_active_transcript_rows_after_visibility_change(previous_kinds);
+                }
+                if let Some(Some((title, body))) = task_notification {
+                    crate::platform::show_task_notification(
+                        &task_notification_tag(session_id),
+                        &title,
+                        &body,
+                    );
                 }
             }
             DriverEvent::Error(error) => {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -15,8 +15,9 @@ use super::{
     navigation_rail_scale, navigation_rail_tick_count, navigation_rail_tick_turn,
     navigation_rail_turn_tick, paused_toast_duration, pop_stream_chunk, session_is_reapable,
     should_show_navigation_rail, should_show_scroll_to_bottom, take_stream_prefix,
-    transcript_anchor_end_space, transcript_navigation_turns, transcript_row_kinds,
-    transcript_row_splice, transcript_rows_fingerprint, widened_panel_width_for_file_editor,
+    task_id_from_notification_tag, task_notification_tag, transcript_anchor_end_space,
+    transcript_navigation_turns, transcript_row_kinds, transcript_row_splice,
+    transcript_rows_fingerprint, widened_panel_width_for_file_editor,
     widened_panel_width_for_review,
 };
 use crate::git_branch::BranchEntry;
@@ -254,6 +255,16 @@ fn session_navigation_prunes_deleted_tasks() {
     navigation.remove(third);
     assert_eq!(navigation.go_back(second), None);
     assert_eq!(navigation.go_forward(second), None);
+}
+
+#[test]
+fn task_notification_tags_route_to_the_corresponding_task() {
+    let session_id = Uuid::new_v4();
+    let tag = task_notification_tag(session_id);
+
+    assert_eq!(task_id_from_notification_tag(&tag), Some(session_id));
+    assert_eq!(task_id_from_notification_tag("waku-task:not-a-uuid"), None);
+    assert_eq!(task_id_from_notification_tag(&session_id.to_string()), None);
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,6 +241,24 @@ fn main() {
                 )
                 .expect("failed to open Waku window");
 
+            cx.on_system_notification_response({
+                let window = window;
+                move |response, cx| {
+                    let Some(session_id) = crate::app::task_id_from_notification_tag(&response.tag)
+                    else {
+                        return;
+                    };
+                    window
+                        .update(cx, |waku, window, cx| {
+                            waku.open_task_from_notification(session_id, cx);
+                            window.activate_window();
+                            cx.activate(true);
+                        })
+                        .ok();
+                    cx.dismiss_system_notification(&response.tag);
+                }
+            });
+
             window
                 .update(cx, |_, window, cx| {
                     crate::platform::configure_sidebar_material(

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -77,6 +77,58 @@ pub fn reduce_motion_enabled() -> bool {
     false
 }
 
+/// Deliver an audible macOS notification. GPUI owns the notification-center
+/// delegate (and therefore click responses); Waku only supplies content here
+/// because GPUI's generic payload does not currently expose a sound field.
+#[cfg(target_os = "macos")]
+pub fn show_task_notification(tag: &str, title: &str, body: &str) {
+    use block2::RcBlock;
+    use objc2::runtime::Bool;
+    use objc2_foundation::{NSBundle, NSError, NSString};
+    use objc2_user_notifications::{
+        UNAuthorizationOptions, UNMutableNotificationContent, UNNotificationRequest,
+        UNNotificationSound, UNUserNotificationCenter,
+    };
+
+    // UserNotifications raises an Objective-C exception for an executable
+    // outside an application bundle, including unit tests and `cargo run`.
+    if NSBundle::mainBundle().bundleIdentifier().is_none() {
+        return;
+    }
+
+    let tag = tag.to_owned();
+    let title = title.to_owned();
+    let body = body.to_owned();
+    let authorization = RcBlock::new(move |granted: Bool, _error: *mut NSError| {
+        if !granted.as_bool() {
+            return;
+        }
+
+        let content = UNMutableNotificationContent::new();
+        content.setTitle(&NSString::from_str(&title));
+        content.setBody(&NSString::from_str(&body));
+        content.setSound(Some(&UNNotificationSound::defaultSound()));
+
+        // A nil trigger delivers immediately. The stable task tag replaces an
+        // older completion banner for the same task and comes back on click.
+        let request = UNNotificationRequest::requestWithIdentifier_content_trigger(
+            &NSString::from_str(&tag),
+            &content,
+            None,
+        );
+        UNUserNotificationCenter::currentNotificationCenter()
+            .addNotificationRequest_withCompletionHandler(&request, None);
+    });
+    UNUserNotificationCenter::currentNotificationCenter()
+        .requestAuthorizationWithOptions_completionHandler(
+            UNAuthorizationOptions::Alert | UNAuthorizationOptions::Sound,
+            &authorization,
+        );
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn show_task_notification(_: &str, _: &str, _: &str) {}
+
 #[cfg(target_os = "macos")]
 pub fn load_app_icon_for_bundle_id(bundle_id: &str) -> Option<std::sync::Arc<gpui::Image>> {
     use objc2_app_kit::{NSBitmapImageFileType, NSBitmapImageRep, NSWorkspace};


### PR DESCRIPTION
## What changed

- send a native macOS notification when a turn settles while Waku is unfocused
- attach the default notification sound and request alert/sound authorization
- encode the task ID in the notification tag so clicking the banner restores Waku and opens that task
- keep notification delivery provider-neutral by hooking the shared `TurnFinished` event

## Why

Completed background turns previously had no native notification path, so users had to return to Waku and find the task manually. GPUI already provides notification-response routing, but its generic payload does not currently expose a notification sound, so Waku supplies the native macOS content while reusing GPUI's response delegate.

## Validation

- `cargo check --package waku`
- `cargo fmt --all`
- `git diff --check`

Focused and visual tests were not run at the user's request.
