### PR TITLE
Add Japanese locale

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -2,2303 +2,1553 @@ _version: 2
 
 menu.about:
   en: About %{app}
-  zh-CN: 关于 %{app}
 menu.check_for_updates:
   en: Check for Updates…
-  zh-CN: 检查更新…
 menu.settings:
   en: Settings…
-  zh-CN: 设置…
 menu.quit:
   en: Quit %{app}
-  zh-CN: 退出 %{app}
 menu.file:
   en: File
-  zh-CN: 文件
 menu.new_task:
   en: New Task
-  zh-CN: 新建任务
 menu.new_project:
   en: New Project…
-  zh-CN: 新建项目…
 menu.edit:
   en: Edit
-  zh-CN: 编辑
 menu.undo:
   en: Undo
-  zh-CN: 撤销
 menu.redo:
   en: Redo
-  zh-CN: 重做
 menu.cut:
   en: Cut
-  zh-CN: 剪切
 menu.copy:
   en: Copy
-  zh-CN: 复制
 menu.paste:
   en: Paste
-  zh-CN: 粘贴
 menu.select_all:
   en: Select All
-  zh-CN: 全选
 menu.view:
   en: View
-  zh-CN: 显示
 menu.command_palette:
   en: Command Palette…
-  zh-CN: 命令面板…
 menu.toggle_sidebar:
   en: Toggle Sidebar
-  zh-CN: 显示或隐藏侧边栏
 menu.toggle_right_panel:
   en: Toggle Right Panel
-  zh-CN: 显示或隐藏右侧面板
 menu.focus_composer:
   en: Focus Composer
-  zh-CN: 聚焦输入框
 menu.toggle_model_picker:
   en: Toggle Model Picker
-  zh-CN: 打开或关闭模型选择器
 menu.toggle_usage_panel:
   en: Toggle Usage Panel
-  zh-CN: 打开或关闭用量面板
 menu.window:
   en: Window
-  zh-CN: 窗口
 menu.toggle_fps_counter:
   en: Toggle FPS Counter
-  zh-CN: 显示或隐藏帧率
 menu.close_window:
   en: Close Window
-  zh-CN: 关闭窗口
 
 updater.update:
   en: Update
-  zh-CN: 更新
 updater.checking:
   en: Checking for updates…
-  zh-CN: 正在检查更新…
 updater.updating:
   en: Updating…
-  zh-CN: 正在更新…
 updater.up_to_date:
   en: Waku is up to date
-  zh-CN: Waku 已是最新版本
 updater.failed:
   en: "Update failed: %{error}"
-  zh-CN: "更新失败：%{error}"
 
 command_palette.placeholder:
   en: Search tasks or run a command…
-  zh-CN: 搜索任务或运行命令…
 command_palette.suggested:
   en: Suggested
-  zh-CN: 建议
 command_palette.tasks:
   en: Tasks
-  zh-CN: 任务
 command_palette.commands:
   en: Commands
-  zh-CN: 命令
 command_palette.settings:
   en: Settings
-  zh-CN: 设置
 command_palette.new_task:
   en: New task
-  zh-CN: 新建任务
 command_palette.open_project:
   en: Open project…
-  zh-CN: 打开项目…
 command_palette.choose_model:
   en: Choose model…
-  zh-CN: 选择模型…
 command_palette.show_sidebar:
   en: Show sidebar
-  zh-CN: 显示侧边栏
 command_palette.hide_sidebar:
   en: Hide sidebar
-  zh-CN: 隐藏侧边栏
 command_palette.show_right_panel:
   en: Show right panel
-  zh-CN: 显示右侧面板
 command_palette.hide_right_panel:
   en: Hide right panel
-  zh-CN: 隐藏右侧面板
 command_palette.current:
   en: Current
-  zh-CN: 当前
 command_palette.you:
   en: You
-  zh-CN: 你
 command_palette.agent:
   en: Agent
-  zh-CN: 助手
 command_palette.no_results:
   en: No matching tasks or commands
-  zh-CN: 未找到匹配的任务或命令
 command_palette.no_results_hint:
   en: Try a task title, message, project, setting, or command
-  zh-CN: 可尝试搜索任务标题、消息、项目、设置或命令
 
 language.title:
   en: Language
-  zh-CN: 语言
 language.system:
   en: System
-  zh-CN: 跟随系统
 language.description:
   en: Choose the language used throughout Waku
-  zh-CN: 选择 Waku 的界面语言
 
 settings.general:
   en: General
-  zh-CN: 通用
 settings.appearance:
   en: Appearance
-  zh-CN: 外观
 settings.providers:
   en: Providers
-  zh-CN: 模型服务商
 settings.usage:
   en: Usage
-  zh-CN: 用量
 settings.computer_use:
   en: Computer Use
-  zh-CN: 电脑操作
 settings.general_keywords:
   en: general local projects conversations privacy analytics telemetry anonymous sharing updates automatic sparkle version
-  zh-CN: 通用 本地 项目 对话 隐私 匿名 使用数据 分析 分享 更新 自动 版本
 settings.appearance_keywords:
   en: appearance theme system light dark language english chinese simplified
-  zh-CN: 外观 主题 系统 浅色 深色 语言 英语 中文 简体
 settings.providers_keywords:
   en: providers agents models cli version install detect claude codex cursor opencode amp grok pi
-  zh-CN: 模型服务商 智能体 模型 命令行 版本 安装 检测 claude codex cursor opencode amp grok pi
 settings.skills:
   en: Skills
-  zh-CN: 技能
 settings.skills_keywords:
   en: skills skill library agent disable enable delete claude codex cursor opencode pi amp shared
-  zh-CN: 技能 技能库 智能体 禁用 启用 删除 claude codex cursor opencode pi amp 共享
 settings.usage_keywords:
   en: usage tokens cost spend cache daily chart model breakdown history claude codex
-  zh-CN: 用量 令牌 费用 支出 缓存 每日 图表 模型 明细 历史 claude codex
 settings.computer_use_keywords:
   en: computer use screen recording accessibility apps control codex
-  zh-CN: 电脑操作 屏幕录制 辅助功能 应用 控制 codex
 settings.back:
   en: Back
-  zh-CN: 返回
 settings.search:
   en: Search Settings
-  zh-CN: 搜索设置
 settings.theme:
   en: Theme
-  zh-CN: 主题
 settings.theme_description:
   en: Choose between system, light, or dark themes
-  zh-CN: 选择跟随系统、浅色或深色主题
 settings.theme_system:
   en: System
-  zh-CN: 跟随系统
 settings.theme_light:
   en: Light
-  zh-CN: 浅色
 settings.theme_dark:
   en: Dark
-  zh-CN: 深色
 
 input.do_anything:
   en: Do anything…
-  zh-CN: 交代任何任务…
 input.search_models:
   en: Search models…
-  zh-CN: 搜索模型…
 input.search_branches:
   en: Search branches
-  zh-CN: 搜索分支
 input.new_branch_name:
   en: New branch name
-  zh-CN: 新分支名称
 input.detected_automatically:
   en: Detected automatically
-  zh-CN: 自动检测
 input.filter_projects:
   en: Filter projects
-  zh-CN: 筛选项目
 input.search_or_enter_address:
   en: Search or enter address
-  zh-CN: 搜索或输入网址
 input.find:
   en: Find
-  zh-CN: 查找
 input.replace:
   en: Replace
-  zh-CN: 替换
 
 common.checking:
   en: Checking…
-  zh-CN: 正在检查…
 common.refresh:
   en: Refresh
-  zh-CN: 刷新
 common.recheck:
   en: Recheck
-  zh-CN: 重新检查
 common.reset:
   en: Reset
-  zh-CN: 重置
 common.revoke:
   en: Revoke
-  zh-CN: 撤销授权
 
 settings.local_by_default:
   en: Local by default
-  zh-CN: 默认存储在本地
 settings.local_by_default_description:
   en: Projects, conversations, and settings are stored on this Mac
-  zh-CN: 项目、对话和设置均存储在这台 Mac 上
 settings.automatic_updates:
   en: Automatic updates
-  zh-CN: 自动更新
 settings.automatic_updates_description:
   en: Check for new versions in the background and offer to install them
-  zh-CN: 在后台检查新版本，并在发现更新时提示安装
 settings.share_anonymous_usage_data:
   en: Share anonymous usage data
-  zh-CN: 分享匿名使用数据
 settings.share_anonymous_usage_data_description:
   en: Help improve Waku by sharing feature usage and reliability data. Prompts, responses, project names, file paths, and other perosnal data are never included
-  zh-CN: 分享功能使用情况和可靠性数据，帮助改进 Waku。不会包含提示词、回复、项目名称、文件路径等个人信息
 
 providers.coding_agents:
   en: Coding agents
-  zh-CN: 编程智能体
 providers.description:
   en: Waku drives agent CLIs installed on this Mac. Install or sign in with each agent's own CLI, then refresh
-  zh-CN: Waku 调用安装在这台 Mac 上的智能体命令行工具。请先安装相应工具或完成登录，然后刷新
 providers.disabled_for_new_tasks:
   en: Disabled for new tasks
-  zh-CN: 已对新任务停用
 providers.model_count_one:
   en: "%{count} model"
-  zh-CN: "%{count} 个模型"
 providers.model_count_many:
   en: "%{count} models"
-  zh-CN: "%{count} 个模型"
 providers.not_detected_as:
   en: Not detected on PATH as %{command}
-  zh-CN: 未在 PATH 中找到 %{command}
 providers.using_override:
   en: Using %{path} instead of PATH detection
-  zh-CN: 正在使用 %{path}，不再从 PATH 自动检测
 providers.invalid_override:
   en: Nothing runnable at this path. Clear it to detect from PATH
-  zh-CN: 此路径下没有可执行文件。清空后可恢复从 PATH 自动检测
 providers.detected_at:
   en: Detected at %{path}
-  zh-CN: 已在 %{path} 检测到
 providers.searches_path:
   en: Waku did not detect %{command} in PATH
-  zh-CN: Waku 未在 PATH 中找到 %{command}
 providers.binary_path:
   en: Binary path
-  zh-CN: 可执行文件路径
 providers.binary_path_description:
   en: The executable Waku launches for %{provider}. Press Return to apply; leave empty to detect from PATH
-  zh-CN: Waku 用于启动 %{provider} 的可执行文件。按 Return 应用；留空则从 PATH 自动检测
 providers.checked_just_now:
   en: Checked just now
-  zh-CN: 刚刚检查过
 providers.checked_minutes_ago:
   en: Checked %{count}m ago
-  zh-CN: "%{count} 分钟前检查过"
 providers.checked_hours_ago:
   en: Checked %{count}h ago
-  zh-CN: "%{count} 小时前检查过"
 
 computer_use.allow_apps:
   en: Let Waku use apps
-  zh-CN: 允许 Waku 操作其他应用
 computer_use.availability:
   en: Computer Use is available with Codex, OpenCode, Grok, and Pi
-  zh-CN: Codex、OpenCode、Grok 和 Pi 支持电脑操作功能
 computer_use.macos_access:
   en: macOS access
-  zh-CN: macOS 权限
 computer_use.helper_access:
   en: Grant access to %{helper}, Waku's isolated control helper
-  zh-CN: 请向 Waku 的独立控制助手 %{helper} 授予权限
 computer_use.screen_recording:
   en: Screen Recording
-  zh-CN: 屏幕录制
 computer_use.screen_recording_description:
   en: Captures only the approved app window
-  zh-CN: 仅捕捉获准操作的应用窗口
 computer_use.accessibility:
   en: Accessibility
-  zh-CN: 辅助功能
 computer_use.accessibility_description:
   en: Posts pointer and keyboard events after approval
-  zh-CN: 获得批准后发送鼠标与键盘操作
 computer_use.always_allowed_apps:
   en: Always allowed apps
-  zh-CN: 始终允许的应用
 computer_use.always_allowed_apps_description:
   en: Waku pins these grants to the app's bundle ID and signing team
-  zh-CN: Waku 会将授权绑定到应用的 Bundle ID 和签名团队
 computer_use.no_always_allowed_apps:
   en: No apps are always allowed. Task-scoped grants stay in memory only
-  zh-CN: 尚未始终允许任何应用。仅限当前任务的授权只会保存在内存中
 computer_use.access_granted:
   en: Access Granted
-  zh-CN: 已授权
 computer_use.grant_access:
   en: Grant Access
-  zh-CN: 授予权限
 computer_use.permission_check_failed:
   en: Could not check Computer Use permissions
-  zh-CN: 无法检查电脑操作权限
 
 common.settings:
   en: Settings
-  zh-CN: 设置
 common.remove:
   en: Remove
-  zh-CN: 移除
 common.rename:
   en: Rename
-  zh-CN: 重命名
 
 session.new_task:
   en: New task
-  zh-CN: 新任务
 
 sidebar.today:
   en: Today
-  zh-CN: 今天
 sidebar.search:
   en: Search
-  zh-CN: 搜索
 sidebar.yesterday:
   en: Yesterday
-  zh-CN: 昨天
 sidebar.this_week:
   en: This Week
-  zh-CN: 本周
 sidebar.this_month:
   en: This Month
-  zh-CN: 本月
 sidebar.this_year:
   en: This Year
-  zh-CN: 今年
 sidebar.more:
   en: More
-  zh-CN: 更早
 sidebar.working:
   en: Working for %{elapsed}
-  zh-CN: 工作中 · %{elapsed}
 sidebar.just_now:
   en: just now
-  zh-CN: 刚刚
 sidebar.minutes_ago:
   en: "%{count}m"
-  zh-CN: "%{count} 分钟前"
 sidebar.hours_ago:
   en: "%{count}h"
-  zh-CN: "%{count} 小时前"
 sidebar.days_ago:
   en: "%{count}d"
-  zh-CN: "%{count} 天前"
 sidebar.unknown_project:
   en: Unknown project
-  zh-CN: 未知项目
 
 project.new_project:
   en: New project…
-  zh-CN: 新建项目…
 project.no_project:
   en: Don't work in a project
-  zh-CN: 不使用项目
 project.no_project_name:
   en: No project
-  zh-CN: 无项目
 project.choose_project:
   en: choose a project
-  zh-CN: 选择项目
 project.project_lower:
   en: project
-  zh-CN: 项目
 project.without_a_project:
   en: without a project
-  zh-CN: 不使用项目
 project.your_project:
   en: your project
-  zh-CN: 你的项目
 
 onboarding.open_project_to_begin:
   en: Open a project to begin
-  zh-CN: 打开一个项目即可开始
 onboarding.description:
   en: Waku runs coding agents in folders you choose. Your code, sessions, and history stay on this Mac
-  zh-CN: Waku 会在你选择的文件夹中运行编程智能体。代码、任务和历史记录都保留在这台 Mac 上
 onboarding.open_project_folder:
   en: Open project folder…
-  zh-CN: 打开项目文件夹…
 onboarding.what_should_we_build:
   en: What should we build?
-  zh-CN: 想构建什么？
 onboarding.what_should_we_build_in:
   en: "What should we build in "
-  zh-CN: "想在 "
 onboarding.question_mark:
   en: "?"
-  zh-CN: " 中构建什么？"
 
 common.copied:
   en: Copied
-  zh-CN: 已复制
 common.copy_message:
   en: Copy message
-  zh-CN: 复制消息
 common.copy_message_title:
   en: Copy Message
-  zh-CN: 复制消息
 common.copy_selection:
   en: Copy Selection
-  zh-CN: 复制所选内容
 common.copy_to_composer:
   en: Copy to Composer
-  zh-CN: 复制到输入框
 common.copy_code:
   en: Copy Code
-  zh-CN: 复制代码
 common.cancel:
   en: Cancel
-  zh-CN: 取消
 common.send:
   en: Send
-  zh-CN: 发送
 
 session.fork_task:
   en: Fork task
-  zh-CN: 从此处派生任务
 session.fork_task_title:
   en: Fork Task
-  zh-CN: 从此处派生任务
 session.forking_task:
   en: Forking task…
-  zh-CN: 正在派生任务…
 session.forking_task_title:
   en: Forking Task…
-  zh-CN: 正在派生任务…
 session.revert_to_here:
   en: Revert to here
-  zh-CN: 回退到这里
 session.revert_to_here_title:
   en: Revert to Here
-  zh-CN: 回退到这里
 
 time.yesterday_at:
   en: Yesterday %{time}
-  zh-CN: 昨天 %{time}
 time.weekday_at:
   en: "%{weekday} %{time}"
-  zh-CN: "%{weekday} %{time}"
 time.date_at:
   en: "%{month}/%{day}, %{time}"
-  zh-CN: "%{month}月%{day}日 %{time}"
 time.full_date_at:
   en: "%{year}/%{month}/%{day}, %{time}"
-  zh-CN: "%{year}年%{month}月%{day}日 %{time}"
 time.monday:
   en: Monday
-  zh-CN: 周一
 time.tuesday:
   en: Tuesday
-  zh-CN: 周二
 time.wednesday:
   en: Wednesday
-  zh-CN: 周三
 time.thursday:
   en: Thursday
-  zh-CN: 周四
 time.friday:
   en: Friday
-  zh-CN: 周五
 time.saturday:
   en: Saturday
-  zh-CN: 周六
 time.sunday:
   en: Sunday
-  zh-CN: 周日
 
 activity.count:
   en: "%{count} %{activity}"
-  zh-CN: "%{count} 次%{activity}"
 activity.running:
   en: Running %{activities}
-  zh-CN: 正在执行：%{activities}
 activity.ran:
   en: Ran %{activities}
-  zh-CN: 已执行：%{activities}
 activity.arguments:
   en: Arguments
-  zh-CN: 参数
 activity.output:
   en: Output
-  zh-CN: 输出
 activity.image_output:
   en: Image output
-  zh-CN: 图片输出
 activity.search_for:
   en: Search for %{query}
-  zh-CN: 搜索：%{query}
 activity.searched_web:
   en: Searched the web
-  zh-CN: 已搜索网页
 activity.open_url:
   en: Open %{url}
-  zh-CN: 打开 %{url}
 activity.opened_web_page:
   en: Opened a web page
-  zh-CN: 已打开网页
 activity.find_in_url:
   en: Find %{pattern} in %{url}
-  zh-CN: 在 %{url} 中查找 %{pattern}
 activity.find_on_page:
   en: Find %{pattern} on the page
-  zh-CN: 在页面中查找 %{pattern}
 activity.search_within_url:
   en: Search within %{url}
-  zh-CN: 在 %{url} 中搜索
 activity.searched_within_page:
   en: Searched within a web page
-  zh-CN: 已在网页内搜索
 activity.browsed_page:
   en: Browsed %{count} page
-  zh-CN: 已浏览 %{count} 个页面
 activity.browsed_pages:
   en: Browsed %{count} pages
-  zh-CN: 已浏览 %{count} 个页面
 activity.browsed_web:
   en: Browsed the web
-  zh-CN: 已浏览网页
 activity.exit_code:
   en: "Exit code: %{code}"
-  zh-CN: "退出代码：%{code}"
 activity.output_with_exit_code:
   en: "%{output}\n\nExit code: %{code}"
-  zh-CN: "%{output}\n\n退出代码：%{code}"
 activity.run_command:
   en: Run command
-  zh-CN: 运行命令
 activity.running_named_command:
   en: Running %{command}
-  zh-CN: 正在运行 %{command}
 activity.ran_named_command:
   en: Ran %{command}
-  zh-CN: 已运行 %{command}
 activity.named_command_failed:
   en: "Command failed: %{command}"
-  zh-CN: "命令执行失败：%{command}"
 activity.running_command:
   en: Running command
-  zh-CN: 正在运行命令
 activity.ran_command:
   en: Ran command
-  zh-CN: 已运行命令
 activity.command_failed:
   en: Command failed
-  zh-CN: 命令执行失败
 activity.edit_file:
   en: Edit file
-  zh-CN: 编辑文件
 activity.write_file:
   en: Write file
-  zh-CN: 写入文件
 activity.editing_named_file:
   en: Editing %{file}
-  zh-CN: 正在编辑 %{file}
 activity.edited_named_file:
   en: Edited %{file}
-  zh-CN: 已编辑 %{file}
 activity.edit_failed_named_file:
   en: Failed to edit %{file}
-  zh-CN: 编辑 %{file} 失败
 activity.editing_files:
   en: Editing files
-  zh-CN: 正在编辑文件
 activity.edited_files:
   en: Edited files
-  zh-CN: 已编辑文件
 activity.edit_failed:
   en: Failed to edit files
-  zh-CN: 编辑文件失败
 activity.file_count:
   en: "%{count} files"
-  zh-CN: "%{count} 个文件"
 activity.read_file:
   en: Read file
-  zh-CN: 读取文件
 activity.reading_named_file:
   en: Reading %{file}
-  zh-CN: 正在读取 %{file}
 activity.read_named_file:
   en: Read %{file}
-  zh-CN: 已读取 %{file}
 activity.read_named_file_failed:
   en: Failed to read %{file}
-  zh-CN: 读取 %{file} 失败
 activity.reading_file:
   en: Reading file
-  zh-CN: 正在读取文件
 activity.read_file_completed:
   en: Read file
-  zh-CN: 已读取文件
 activity.read_file_failed:
   en: Failed to read file
-  zh-CN: 读取文件失败
 activity.search_files:
   en: Search files
-  zh-CN: 搜索文件
 activity.find_files:
   en: Find files
-  zh-CN: 查找文件
 activity.searching_files_for:
   en: Searching files for %{query}
-  zh-CN: 正在文件中搜索 %{query}
 activity.searched_files_for:
   en: Searched files for %{query}
-  zh-CN: 已在文件中搜索 %{query}
 activity.file_search_failed_for:
   en: Failed to search files for %{query}
-  zh-CN: 在文件中搜索 %{query} 失败
 activity.searching_files:
   en: Searching files
-  zh-CN: 正在搜索文件
 activity.searched_files:
   en: Searched files
-  zh-CN: 已搜索文件
 activity.file_search_failed:
   en: Failed to search files
-  zh-CN: 搜索文件失败
 activity.list_files:
   en: List files
-  zh-CN: 列出文件
 activity.listing_files_in:
   en: Listing files in %{directory}
-  zh-CN: 正在列出 %{directory} 中的文件
 activity.listed_files_in:
   en: Listed files in %{directory}
-  zh-CN: 已列出 %{directory} 中的文件
 activity.file_list_failed_in:
   en: Failed to list files in %{directory}
-  zh-CN: 无法列出 %{directory} 中的文件
 activity.listing_files:
   en: Listing files
-  zh-CN: 正在列出文件
 activity.listed_files:
   en: Listed files
-  zh-CN: 已列出文件
 activity.file_list_failed:
   en: Failed to list files
-  zh-CN: 无法列出文件
 activity.searching_web_for:
   en: Searching the web for %{query}
-  zh-CN: 正在网页中搜索 %{query}
 activity.searched_web_for:
   en: Searched the web for %{query}
-  zh-CN: 已在网页中搜索 %{query}
 activity.web_search_failed_for:
   en: Failed to search the web for %{query}
-  zh-CN: 在网页中搜索 %{query} 失败
 activity.searching_web:
   en: Searching the web
-  zh-CN: 正在搜索网页
 activity.searched_the_web:
   en: Searched the web
-  zh-CN: 已搜索网页
 activity.web_search_failed:
   en: Failed to search the web
-  zh-CN: 搜索网页失败
 activity.updating_plan:
   en: Updating plan
-  zh-CN: 正在更新计划
 activity.updated_plan:
   en: Updated plan
-  zh-CN: 已更新计划
 activity.plan_update_failed:
   en: Failed to update plan
-  zh-CN: 更新计划失败
 activity.activity:
   en: Activity
-  zh-CN: 操作
 activity.tool:
   en: Tool
-  zh-CN: 工具
 activity.plan_updated:
   en: Plan updated
-  zh-CN: 计划已更新
 activity.output_truncated:
   en: "\n\n… output truncated"
-  zh-CN: "\n\n… 输出已截断"
 activity.thought:
   en: thought
-  zh-CN: 思考
 activity.thoughts:
   en: thoughts
-  zh-CN: 思考
 activity.command:
   en: command
-  zh-CN: 命令
 activity.commands:
   en: commands
-  zh-CN: 命令
 activity.file_edit:
   en: file edit
-  zh-CN: 文件修改
 activity.file_edits:
   en: file edits
-  zh-CN: 文件修改
 activity.file_read:
   en: file read
-  zh-CN: 文件读取
 activity.file_reads:
   en: file reads
-  zh-CN: 文件读取
 activity.file_search:
   en: file search
-  zh-CN: 文件搜索
 activity.file_searches:
   en: file searches
-  zh-CN: 文件搜索
 activity.file_list:
   en: file listing
-  zh-CN: 文件列表
 activity.file_lists:
   en: file listings
-  zh-CN: 文件列表
 activity.search:
   en: search
-  zh-CN: 搜索
 activity.searches:
   en: searches
-  zh-CN: 搜索
 activity.plan_step:
   en: plan step
-  zh-CN: 计划步骤
 activity.plan_steps:
   en: plan steps
-  zh-CN: 计划步骤
 activity.tool_call:
   en: tool call
-  zh-CN: 工具调用
 activity.tool_calls:
   en: tool calls
-  zh-CN: 工具调用
 
 mode.build:
   en: Build
-  zh-CN: 构建
 mode.plan:
   en: Plan
-  zh-CN: 计划
 mode.supervised:
   en: Supervised
-  zh-CN: 监督模式
 mode.auto_accept_edits:
   en: Auto-accept edits
-  zh-CN: 自动接受修改
 mode.auto:
   en: Auto
-  zh-CN: 自动
 mode.full_access:
   en: Full access
-  zh-CN: 完全访问
 mode.plan_description:
   en: Inspect and plan without making changes
-  zh-CN: 仅检查并制定计划，不进行任何修改
 mode.supervised_description:
   en: Ask before commands and file changes
-  zh-CN: 执行命令或修改文件前先征求许可
 mode.auto_accept_edits_description:
   en: Auto-approve edits, ask before other actions
-  zh-CN: 自动批准文件修改，执行其他操作前先询问
 mode.auto_description:
   en: An AI reviewer approves routine actions; risky ones still ask
-  zh-CN: 由 AI 审核并批准常规操作；高风险操作仍会询问
 mode.full_access_description:
   en: Allow commands and edits without prompts
-  zh-CN: 无需确认即可执行命令和修改文件
 
 computer_use.allow_for_task:
   en: Allow for task
-  zh-CN: 本次任务允许
 computer_use.always_allow_app:
   en: Always allow app
-  zh-CN: 始终允许此应用
 computer_use.allow_control:
   en: Allow Waku to control %{app}?
-  zh-CN: 允许 Waku 控制“%{app}”吗？
 computer_use.screenshot_shared:
   en: A screenshot of this window will be shared with the active Codex model
-  zh-CN: 此窗口的截图将发送给当前使用的 Codex 模型
 computer_use.sensitive_action:
   en: This action can type text or press keys
-  zh-CN: 此操作可以输入文字或按下按键
 computer_use.bundle_id:
   en: "Bundle ID: %{id}"
-  zh-CN: "Bundle ID：%{id}"
 computer_use.no_bundle_id:
   en: This app has no bundle identifier, so it cannot be always allowed
-  zh-CN: 此应用没有 Bundle ID，因此无法设为始终允许
 computer_use.stopped:
   en: Stopped
-  zh-CN: 已停止
 computer_use.controlling:
   en: Controlling
-  zh-CN: 正在控制
 computer_use.captured:
   en: Captured
-  zh-CN: 已捕捉
 computer_use.take_control:
   en: Take Control
-  zh-CN: 接管
 computer_use.preparing_preview:
   en: Preparing preview…
-  zh-CN: 正在准备预览…
 
 common.deny:
   en: Deny
-  zh-CN: 拒绝
 permission.allow_once:
   en: Allow once
-  zh-CN: 仅允许一次
 permission.allow_for_session:
   en: Allow for session
-  zh-CN: 本次任务允许
 permission.always_allow:
   en: Always allow
-  zh-CN: 始终允许
 permission.a_tool:
   en: a tool
-  zh-CN: 某个工具
 permission.run_a_tool:
   en: Run a tool
-  zh-CN: 运行工具
 permission.run_a_tool_lower:
   en: run a tool
-  zh-CN: 运行工具
 permission.blocked_path:
   en: "Blocked path: %{path}"
-  zh-CN: "路径已被阻止：%{path}"
 permission.agent_wants_to_run:
   en: The agent wants to run %{tool}
-  zh-CN: 智能体想要运行 %{tool}
 permission.run_tool:
   en: Run %{tool}?
-  zh-CN: 是否运行 %{tool}？
 permission.allow_named_permission:
   en: Allow %{permission}?
-  zh-CN: 是否授予“%{permission}”权限？
 permission.agent_asks_for_named_permission:
   en: The agent is asking for the %{permission} permission
-  zh-CN: 智能体正在请求“%{permission}”权限
 permission.agent_asks_for_permission:
   en: The agent is asking for permission
-  zh-CN: 智能体正在请求权限
 permission.agent_wants_to:
   en: The agent wants to %{action}
-  zh-CN: 智能体想要执行“%{action}”
 common.close:
   en: Close
-  zh-CN: 关闭
 common.default:
   en: Default
-  zh-CN: 默认
 
 models.none_found:
   en: No models found
-  zh-CN: 未找到模型
 models.favorite_hint:
   en: Star a model to keep it here
-  zh-CN: 为模型加星标即可固定在这里
 models.loading:
   en: Loading models…
-  zh-CN: 正在加载模型…
 models.none_reported:
   en: No models reported by this provider
-  zh-CN: 此服务商未提供任何模型
 models.standard:
   en: Standard
-  zh-CN: 标准
 models.reasoning:
   en: Reasoning
-  zh-CN: 推理强度
 models.service_tier:
   en: Service Tier
-  zh-CN: 服务等级
 
 model_option.none:
   en: None
-  zh-CN: 无
 model_option.minimal:
   en: Minimal
-  zh-CN: 最低
 model_option.low:
   en: Low
-  zh-CN: 低
 model_option.medium:
   en: Medium
-  zh-CN: 中
 model_option.high:
   en: High
-  zh-CN: 高
 model_option.extra_high:
   en: Extra High
-  zh-CN: 极高
 model_option.max:
   en: Max
-  zh-CN: 最高
 model_option.ultra:
   en: Ultra
-  zh-CN: 超高
 model_option.auto:
   en: Auto
-  zh-CN: 自动
 model_option.fast:
   en: Fast
-  zh-CN: 快速
 model_option.amp_fast_description:
   en: Use Amp's faster serving tier at a higher usage rate
-  zh-CN: 使用 Amp 的快速服务等级，但会消耗更多用量
 model_option.fast_description:
   en: Faster responses at a higher usage rate
-  zh-CN: 更快获得回复，但会消耗更多用量
 
 command_scope.project:
   en: project
-  zh-CN: 项目
 command_scope.user:
   en: user
-  zh-CN: 用户
 command_scope.skill:
   en: skill
-  zh-CN: 技能
 command_scope.builtin:
   en: built-in
-  zh-CN: 内置
 
 skills.search:
   en: Search skills…
-  zh-CN: 搜索技能…
 skills.count_one:
   en: 1 skill
-  zh-CN: 1 个技能
 skills.count_many:
   en: "%{count} skills"
-  zh-CN: "%{count} 个技能"
 skills.count_disabled:
   en: "%{count} disabled"
-  zh-CN: "已禁用 %{count} 个"
 skills.filter_caption:
   en: "%{shown} of %{total} shown"
-  zh-CN: "显示 %{shown} / %{total} 个"
 skills.scanning:
   en: Scanning skill folders…
-  zh-CN: 正在扫描技能目录…
 skills.no_match:
   en: No skills match your search
-  zh-CN: 没有匹配的技能
 skills.section_user:
   en: User
-  zh-CN: 用户
 skills.source_shared:
   en: Shared
-  zh-CN: 共享
 skills.scope_user_detail:
   en: available in every project
-  zh-CN: 在所有项目中可用
 skills.scope_in_project:
   en: "in %{project}"
-  zh-CN: "位于 %{project}"
 skills.filter_all:
   en: All skills
-  zh-CN: 全部技能
 skills.select_placeholder:
   en: Select a skill
-  zh-CN: 选择一个技能
 skills.detail_invoke:
   en: Invoke
-  zh-CN: 调用
 skills.detail_location:
   en: Location
-  zh-CN: 位置
 skills.detail_contents:
   en: Contents
-  zh-CN: 内容
 skills.detail_updated:
   en: Updated
-  zh-CN: 更新
 skills.no_description:
   en: No description
-  zh-CN: 暂无描述
 skills.disabled_badge:
   en: Disabled
-  zh-CN: 已禁用
 skills.file_count_one:
   en: 1 supporting file
-  zh-CN: 1 个附属文件
 skills.file_count_many:
   en: "%{count} supporting files"
-  zh-CN: "%{count} 个附属文件"
 skills.updated_just_now:
   en: Just now
-  zh-CN: 刚刚
 skills.updated_minutes:
   en: "%{count}m ago"
-  zh-CN: "%{count} 分钟前"
 skills.updated_hours:
   en: "%{count}h ago"
-  zh-CN: "%{count} 小时前"
 skills.updated_days:
   en: "%{count}d ago"
-  zh-CN: "%{count} 天前"
 skills.allowed_tools:
   en: Tools
-  zh-CN: 工具
 skills.duplicate_one:
   en: Same name in 1 other location — the most specific copy wins
-  zh-CN: 另有 1 处同名技能 — 更具体的一份生效
 skills.duplicate_many:
   en: "Same name in %{count} other locations — the most specific copy wins"
-  zh-CN: "另有 %{count} 处同名技能 — 更具体的一份生效"
 skills.open_file:
   en: Open SKILL.md
-  zh-CN: 打开 SKILL.md
 skills.reveal:
   en: Reveal in Finder
-  zh-CN: 在访达中显示
 skills.copy_path:
   en: Copy Path
-  zh-CN: 拷贝路径
 skills.path_copied:
   en: Path copied
-  zh-CN: 已拷贝路径
 skills.delete:
   en: Delete
-  zh-CN: 删除
 skills.confirm_delete:
   en: Confirm delete
-  zh-CN: 确认删除
 skills.deleted_toast:
   en: "Moved “%{name}” to the Trash"
-  zh-CN: "已将“%{name}”移到废纸篓"
 skills.delete_failed:
   en: "Couldn’t delete the skill: %{error}"
-  zh-CN: "无法删除技能：%{error}"
 skills.toggle_failed:
   en: "Couldn’t update the skill: %{error}"
-  zh-CN: "无法更新技能：%{error}"
 skills.empty_title:
   en: No skills yet
-  zh-CN: 还没有技能
 skills.empty_description:
   en: A skill is a folder with a SKILL.md — reusable instructions any agent can load, like a deploy runbook or a review checklist. Skills installed for Claude Code, Codex, and every other agent show up here, invoked as /name.
-  zh-CN: 技能是一个包含 SKILL.md 的文件夹 — 任何智能体都能加载的可复用指令，例如部署手册或评审清单。为 Claude Code、Codex 等所有智能体安装的技能都会显示在这里，以 /名称 调用。
 
 commands.init_description:
   en: Create or update %{instructions_file} for this project
-  zh-CN: 为此项目创建或更新 %{instructions_file}
 commands.review_description:
   en: Review the pending changes on this branch
-  zh-CN: 审查当前分支中尚未合并的更改
 commands.commit_description:
   en: Stage and commit the current changes
-  zh-CN: 暂存并提交当前更改
 commands.claude_compact:
   en: Free up context by summarizing the conversation
-  zh-CN: 总结对话以释放上下文空间
 commands.claude_context:
   en: Show what is occupying the context window
-  zh-CN: 查看上下文窗口的占用情况
 commands.claude_cost:
   en: Show token usage and cost for this session
-  zh-CN: 查看当前任务的令牌用量与费用
 commands.claude_init:
   en: Analyze the project and write CLAUDE.md
-  zh-CN: 分析项目并编写 CLAUDE.md
 commands.claude_pr_comments:
   en: Fetch review comments for the current PR
-  zh-CN: 获取当前拉取请求的审查意见
 commands.claude_review:
   en: Review a pull request
-  zh-CN: 审查拉取请求
 commands.claude_security_review:
   en: Security review of the pending changes
-  zh-CN: 对尚未合并的更改进行安全审查
 commands.claude_todos:
   en: List the current todo items
-  zh-CN: 列出当前待办事项
 
 composer.edit_in_composer:
   en: Edit in composer
-  zh-CN: 在输入框中编辑
 composer.queued_followups:
   en: Queued follow-ups
-  zh-CN: 已排队的后续消息
 composer.queued_followups_description:
   en: Queued follow-ups · sends when the current turn finishes
-  zh-CN: 已排队的后续消息 · 当前回复结束后发送
 composer.preparing_task:
   en: Preparing task…
-  zh-CN: 正在准备任务…
 composer.steer_turn:
   en: Steer the running turn (⌘↩)
-  zh-CN: 补充当前任务（⌘↩）
 composer.queue_followup:
   en: Queue as follow-up (⏎)
-  zh-CN: 排队为后续消息（⏎）
 
 branches.detached_head:
   en: Detached HEAD
-  zh-CN: 游离 HEAD
 branches.search_project:
   en: Search %{project} branches
-  zh-CN: 搜索 %{project} 的分支
 branches.switching:
   en: Switching…
-  zh-CN: 正在切换…
 branches.create_and_checkout:
   en: Create and checkout new branch
-  zh-CN: 创建并切换到新分支
 branches.create_hint:
   en: Press Return to create · Esc to cancel
-  zh-CN: 按 Return 创建 · 按 Esc 取消
 branches.none_found:
   en: No branches found
-  zh-CN: 未找到分支
 branches.create_and_checkout_ellipsis:
   en: Create and checkout new branch…
-  zh-CN: 创建并切换到新分支…
 branches.title:
   en: Branches
-  zh-CN: 分支
 
 workspace.work_in:
   en: Work in
-  zh-CN: 工作位置
 workspace.local:
   en: Local
-  zh-CN: 本地
 workspace.new_worktree:
   en: New worktree
-  zh-CN: 新建工作树
 workspace.workspace:
   en: workspace
-  zh-CN: 工作区
 workspace.worktree:
   en: Worktree
-  zh-CN: 工作树
 
 terminal.starting:
   en: Starting terminal…
-  zh-CN: 正在启动终端…
 
 project.add_project:
   en: Add project
-  zh-CN: 添加项目
 
 session.stopped:
   en: Stopped
-  zh-CN: 已停止
 session.turn_completed:
   en: Turn completed
-  zh-CN: 任务已完成
 session.stopped_before_response:
   en: The agent stopped before returning a response
-  zh-CN: 智能体在返回回复前停止了
 session.codex_exited_before_response:
   en: Codex app-server exited before returning a response
-  zh-CN: Codex app-server 在返回回复前退出了
 session.steer_rejected:
   en: The agent couldn't be steered (%{error}); the message was queued as a follow-up
-  zh-CN: 无法向智能体补充指示（%{error}）；消息已排队，将作为后续消息发送
 session.agent_ran_out_of_context:
   en: The agent ran out of context for this turn
-  zh-CN: 智能体在本轮任务中耗尽了上下文空间
 session.agent_declined_turn:
   en: The agent declined this turn
-  zh-CN: 智能体拒绝执行本轮任务
 session.agent_stopped_reason:
   en: "The agent stopped: %{reason}"
-  zh-CN: "智能体已停止：%{reason}"
 
 errors.open_session:
   en: "Could not open that session: %{error}"
-  zh-CN: "无法打开该任务：%{error}"
 errors.create_projectless_task:
   en: "Could not create a task beneath ~/.waku: %{error}"
-  zh-CN: "无法在 ~/.waku 下创建任务：%{error}"
 errors.save_projectless_migration:
   en: "Could not save the projectless task migration: %{error}"
-  zh-CN: "无法保存无项目任务的迁移结果：%{error}"
 errors.move_projectless_task:
   en: "Could not move the old root-level projectless task beneath ~/.waku: %{error}"
-  zh-CN: "无法将旧的根目录无项目任务移至 ~/.waku：%{error}"
 errors.change_branch:
   en: "Could not change branch: %{error}"
-  zh-CN: "无法切换分支：%{error}"
 errors.capture_pre_turn_checkpoint:
   en: "Could not capture the pre-turn checkpoint: %{error}"
-  zh-CN: "无法创建任务开始前的检查点：%{error}"
 errors.capture_turn_checkpoint:
   en: "Could not capture the turn checkpoint: %{error}"
-  zh-CN: "无法创建本轮任务的检查点：%{error}"
 errors.save_local_state:
   en: "Could not save local state: %{error}"
-  zh-CN: "无法保存本地状态：%{error}"
 errors.task_project_not_found:
   en: The task's project could not be found
-  zh-CN: 找不到该任务所属的项目
 errors.provider_native_session_unavailable:
   en: "%{provider}'s native session is unavailable"
-  zh-CN: "%{provider} 的原生会话不可用"
 errors.provider_native_thread_unavailable:
   en: "%{provider}'s native thread is unavailable"
-  zh-CN: "%{provider} 的原生线程不可用"
 errors.provider_native_cursor_unavailable:
   en: "%{provider}'s native session cursor is unavailable"
-  zh-CN: "%{provider} 的原生会话位置不可用"
 errors.provider_native_thread_cursor_unavailable:
   en: "%{provider}'s native thread cursor is unavailable"
-  zh-CN: "%{provider} 的原生线程位置不可用"
 errors.provider_waku_task_unavailable:
   en: "%{provider}'s Waku task is unavailable"
-  zh-CN: "%{provider} 对应的 Waku 任务不可用"
 errors.provider_not_installed:
   en: "%{provider} is not installed"
-  zh-CN: "尚未安装 %{provider}"
 errors.provider_not_found:
   en: "%{provider} is not installed or could not be found"
-  zh-CN: "尚未安装 %{provider}，或无法找到该程序"
 errors.claude_fork_checkpoint_missing:
   en: Claude omitted the fork checkpoint
-  zh-CN: Claude 未返回派生任务所需的检查点
 errors.claude_turn_checkpoint_unavailable:
   en: "Claude's native checkpoint for that turn is unavailable: %{error}"
-  zh-CN: "Claude 中该轮任务的原生检查点不可用：%{error}"
 errors.pi_session_file_unavailable:
   en: Pi's native session file is unavailable
-  zh-CN: Pi 的原生会话文件不可用
 errors.fork_task:
   en: "Could not fork the task: %{error}"
-  zh-CN: "无法派生任务：%{error}"
 errors.create_rewind_snapshot:
   en: "Could not create a rewind safety snapshot: %{error}"
-  zh-CN: "无法创建回退前的安全快照：%{error}"
 errors.restore_checkpoint:
   en: "Could not restore the checkpoint: %{error}"
-  zh-CN: "无法恢复检查点：%{error}"
 errors.restore_checkpoint_and_safety:
   en: "Checkpoint restore failed (%{error}); safety restore also failed (%{restore_error}). Recovery ref retained at %{safety_ref}"
-  zh-CN: "检查点恢复失败（%{error}），安全快照也未能恢复（%{restore_error}）。恢复引用已保留在 %{safety_ref}"
 errors.rollback_rejected_workspace_restored:
   en: "The provider rejected the rollback, so the workspace was restored: %{error}"
-  zh-CN: "服务商拒绝回退，工作区已恢复：%{error}"
 errors.rollback_and_safety_failed:
   en: "Provider rollback failed (%{error}) and the safety snapshot could not be restored (%{restore_error}). Recovery ref retained at %{safety_ref}"
-  zh-CN: "服务商回退失败（%{error}），安全快照也未能恢复（%{restore_error}）。恢复引用已保留在 %{safety_ref}"
 errors.no_session_selected:
   en: No session selected
-  zh-CN: 尚未选择任务
 errors.session_not_found:
   en: Session not found
-  zh-CN: 找不到任务
 errors.project_not_found:
   en: Project not found
-  zh-CN: 找不到项目
 errors.prepare_task_project_not_found:
   en: "Could not prepare the task: project not found"
-  zh-CN: 无法准备任务：找不到项目
 errors.store_pasted_image:
   en: "Could not attach the pasted image: %{error}"
-  zh-CN: "无法添加粘贴的图片：%{error}"
 errors.create_worktree:
   en: "Could not create the worktree: %{error}"
-  zh-CN: "无法创建工作树：%{error}"
 errors.prepared_runtime_unavailable:
   en: The prepared agent runtime is unavailable
-  zh-CN: 已准备的智能体运行环境不可用
 errors.start_agent:
   en: "Could not start the agent: %{error}"
-  zh-CN: "无法启动智能体：%{error}"
 errors.provider_no_active_turn:
   en: "%{provider} has no active turn to steer"
-  zh-CN: "%{provider} 当前没有可补充指示的任务"
 errors.provider_transport_write:
   en: "%{provider} transport write failed: %{error}"
-  zh-CN: "%{provider} 通信写入失败：%{error}"
 errors.provider_transport_write_short:
   en: "%{provider} transport write failed"
-  zh-CN: "%{provider} 通信写入失败"
 errors.provider_transport_read:
   en: "%{provider} transport read failed: %{error}"
-  zh-CN: "%{provider} 通信读取失败：%{error}"
 errors.provider_invalid_json:
   en: "%{provider} sent invalid JSON: %{error}"
-  zh-CN: "%{provider} 发来了无效的 JSON：%{error}"
 errors.provider_exited:
   en: "%{provider} exited with %{status}"
-  zh-CN: "%{provider} 已退出（%{status}）"
 errors.provider_rpc_exited:
   en: "%{provider} RPC exited with %{status}"
-  zh-CN: "%{provider} RPC 已退出（%{status}）"
 errors.read_provider_exit_status:
   en: "Could not read %{provider} exit status: %{error}"
-  zh-CN: "无法读取 %{provider} 的退出状态：%{error}"
 errors.initialize_provider:
   en: "Could not initialize %{provider}: %{error}"
-  zh-CN: "无法初始化 %{provider}：%{error}"
 errors.provider_no_session_id:
   en: "%{provider} did not report a session ID"
-  zh-CN: "%{provider} 未返回会话 ID"
 errors.provider_rejected_prompt_detail:
   en: "%{provider} rejected the prompt: %{error}"
-  zh-CN: "%{provider} 拒绝了消息：%{error}"
 errors.stop_provider:
   en: "Could not stop %{provider}: %{error}"
-  zh-CN: "无法停止 %{provider}：%{error}"
 errors.switch_provider_model:
   en: "Could not switch the %{provider} model: %{error}"
-  zh-CN: "无法切换 %{provider} 模型：%{error}"
 errors.change_provider_thinking:
   en: "Could not change %{provider}'s thinking level: %{error}"
-  zh-CN: "无法更改 %{provider} 的思考强度：%{error}"
 errors.open_provider_session:
   en: "Could not open a %{provider} session: %{error}"
-  zh-CN: "无法打开 %{provider} 会话：%{error}"
 errors.select_model:
   en: "Could not select the model: %{error}"
-  zh-CN: "无法选择模型：%{error}"
 errors.read_provider_event_stream:
   en: "Could not read the %{provider} event stream: %{error}"
-  zh-CN: "无法读取 %{provider} 事件流：%{error}"
 errors.answer_provider_permission:
   en: "Could not answer %{provider}'s permission request: %{error}"
-  zh-CN: "无法响应 %{provider} 的权限请求：%{error}"
 errors.initialize_codex_app_server:
   en: Failed to initialize Codex app-server
-  zh-CN: 无法初始化 Codex app-server
 errors.register_computer_use_skill:
   en: Failed to register Waku Computer Use skill with Codex
-  zh-CN: 无法向 Codex 注册 Waku 电脑操作技能
 errors.codex_thread_open_incomplete:
   en: Codex did not finish opening its thread
-  zh-CN: Codex 未能完成线程打开操作
 errors.provider_receive_prompt:
   en: "%{provider} could not receive the prompt"
-  zh-CN: "%{provider} 未能接收消息"
 errors.provider_start_turn:
   en: "%{provider} could not start the turn"
-  zh-CN: "%{provider} 未能开始任务"
 errors.provider_rejected_steer:
   en: "%{provider} rejected the steer: %{error}"
-  zh-CN: "%{provider} 拒绝了补充指示：%{error}"
 errors.provider_stopped_receiving:
   en: "%{provider} stopped receiving messages"
-  zh-CN: "%{provider} 已停止接收消息"
 errors.provider_initialize_session:
   en: "%{provider} could not initialize this session"
-  zh-CN: "%{provider} 未能初始化此任务"
 errors.provider_rejected_prompt:
   en: "%{provider} rejected the prompt before it ran"
-  zh-CN: "%{provider} 在开始处理前拒绝了消息"
 errors.provider_complete_turn:
   en: "%{provider} could not complete this turn"
-  zh-CN: "%{provider} 未能完成本轮任务"
 errors.pi_reported_error:
   en: Pi reported an error
-  zh-CN: Pi 报告了错误
 
 session.response_unavailable:
   en: That response is no longer available
-  zh-CN: 该回复已不可用
 session.response_cannot_fork:
   en: That response cannot be forked right now
-  zh-CN: 目前无法从该回复派生任务
 session.response_fork_in_progress:
   en: Wait for the task fork to finish before removing its source task
-  zh-CN: 请等待任务派生完成后再移除原任务
 session.response_cannot_copy:
   en: That response could not be copied into a new task
-  zh-CN: 无法将该回复复制到新任务中
 session.forked_with_checkpoint_warning:
   en: "Forked task; some Git checkpoints could not be copied: %{error}"
-  zh-CN: "任务已派生，但部分 Git 检查点未能复制：%{error}"
 session.forked_from_response:
   en: Forked task from this response
-  zh-CN: 已从该回复派生新任务
 session.message_not_editable:
   en: That message is not editable right now
-  zh-CN: 目前无法编辑该消息
 session.edited_message_empty:
   en: The edited message cannot be empty
-  zh-CN: 编辑后的消息不能为空
 session.message_unavailable:
   en: That message is no longer available
-  zh-CN: 该消息已不可用
 session.select_before_rewind:
   en: Select the task before rewinding its conversation
-  zh-CN: 请先选择该任务，再回退对话
 session.stop_before_rewind:
   en: Stop the current turn before rewinding the conversation
-  zh-CN: 请先停止当前任务，再回退对话
 session.provider_cannot_rewind:
   en: "%{provider} cannot safely roll back its native conversation yet"
-  zh-CN: "%{provider} 目前还无法安全回退原生会话"
 session.pre_turn_checkpoint_missing:
   en: The message's pre-turn Git checkpoint is missing
-  zh-CN: 缺少该消息发送前的 Git 检查点
 session.rewind_title:
   en: "%{title} (rewind)"
-  zh-CN: "%{title}（回退）"
 session.rewound:
   en: Rewound to before turn %{turn}
-  zh-CN: 已回退到第 %{turn} 轮任务之前
 session.rewound_with_stale_refs:
   en: "Rewound to before turn %{turn}; stale refs remain: %{error}"
-  zh-CN: "已回退到第 %{turn} 轮任务之前，但仍有过期引用：%{error}"
 
 right_panel.browser:
   en: Browser
-  zh-CN: 浏览器
 right_panel.terminal:
   en: Terminal
-  zh-CN: 终端
 right_panel.files:
   en: Files
-  zh-CN: 文件
 right_panel.diff:
   en: Review
-  zh-CN: 审阅
 right_panel.toggle:
   en: Toggle right panel
-  zh-CN: 显示或隐藏右侧面板
 right_panel.open_surface:
   en: Open a surface
-  zh-CN: 打开一个面板
 right_panel.choose_surface:
   en: Choose what to show in the right panel
-  zh-CN: 选择要在右侧面板中显示的内容
 right_panel.browser_description:
   en: Open a local app or URL
-  zh-CN: 打开本地应用或网址
 right_panel.terminal_description:
   en: Start a shell in this workspace
-  zh-CN: 在此工作区中启动 Shell
 right_panel.files_description:
   en: Browse and read workspace files
-  zh-CN: 浏览并阅读工作区文件
 right_panel.diff_description:
   en: Review file changes
-  zh-CN: 查看已修改文件
 right_panel.terminal_unavailable:
   en: Terminal unavailable
-  zh-CN: 终端不可用
 right_panel.terminal_unavailable_description:
   en: Open the Terminal surface again to start a shell
-  zh-CN: 请重新打开终端面板以启动 Shell
 
 environment.title:
   en: Environment
-  zh-CN: 环境
 environment.summary:
   en: Environment and background work
-  zh-CN: 环境和后台工作
 environment.changes:
   en: Changes
-  zh-CN: 更改
 environment.commit_or_push:
   en: Commit or push
-  zh-CN: 提交或推送
 environment.compare_branch:
   en: Compare branch
-  zh-CN: 比较分支
 
 commit.message_placeholder:
   en: Commit message (leave blank to generate)…
-  zh-CN: 提交信息（留空以自动生成）…
 commit.include_unstaged:
   en: Include unstaged changes
-  zh-CN: 包含未暂存的更改
 commit.commit:
   en: Commit
-  zh-CN: 提交
 commit.commit_and_push:
   en: Commit and push
-  zh-CN: 提交并推送
 commit.push:
   en: Push
-  zh-CN: 推送
 commit.generating_message:
   en: Generating commit message…
-  zh-CN: 正在生成提交信息…
 commit.committing:
   en: Committing…
-  zh-CN: 正在提交…
 commit.committing_and_pushing:
   en: Committing and pushing…
-  zh-CN: 正在提交并推送…
 commit.pushing:
   en: Pushing…
-  zh-CN: 正在推送…
 commit.no_task:
   en: No task is available to commit
-  zh-CN: 没有可提交的任务
 commit.no_workspace:
   en: This task has no workspace
-  zh-CN: 当前任务没有工作区
 commit.no_changes:
   en: There are no changes to commit
-  zh-CN: 没有可提交的更改
 commit.agent_unavailable:
   en: The current agent CLI is unavailable, so it cannot generate a commit message
-  zh-CN: 当前智能体命令行不可用，无法生成提交信息
 commit.committed:
   en: Committed changes
-  zh-CN: 已提交更改
 commit.committed_and_pushed:
   en: Committed and pushed changes
-  zh-CN: 已提交并推送更改
 commit.pushed:
   en: Pushed changes
-  zh-CN: 已推送更改
 
 background.title:
   en: Background
-  zh-CN: 后台工作
 background.description:
   en: Inspect agent-started processes and subagents
-  zh-CN: 查看代理启动的进程和子代理
 background.processes:
   en: Background processes
-  zh-CN: 后台进程
 background.agents:
   en: Subagents
-  zh-CN: 子代理
 background.process:
   en: Process
-  zh-CN: 进程
 background.monitor:
   en: Monitor
-  zh-CN: 监控任务
 background.subagent:
   en: Subagent
-  zh-CN: 子代理
 background.no_work:
   en: No background work
-  zh-CN: 暂无后台工作
 background.no_work_description:
   en: Long-running commands and subagents will appear here.
-  zh-CN: 长时间运行的命令和子代理会显示在这里。
 background.view:
   en: View
-  zh-CN: 查看
 background.stop:
   en: Stop
-  zh-CN: 停止
 background.stop_all:
   en: Stop all
-  zh-CN: 全部停止
 background.stop_not_running:
   en: The process is no longer running.
-  zh-CN: 该进程已不再运行。
 background.output:
   en: Output
-  zh-CN: 输出
 background.no_output:
   en: No output yet
-  zh-CN: 暂无输出
 background.command:
   en: Command
-  zh-CN: 命令
 background.prompt:
   en: Prompt
-  zh-CN: 提示词
 background.cwd:
   en: Working directory
-  zh-CN: 工作目录
 background.role:
   en: Role
-  zh-CN: 角色
 background.model:
   en: Model
-  zh-CN: 模型
 background.latest_update:
   en: Latest update
-  zh-CN: 最新进展
 background.exit_code:
   en: Exit code
-  zh-CN: 退出代码
 background.output_truncated:
   en: Earlier output was truncated
-  zh-CN: 较早的输出已截断
 background.process_count:
   en: "%{count} background processes"
-  zh-CN: "%{count} 个后台进程"
 background.process_count_one:
   en: 1 background process
-  zh-CN: 1 个后台进程
 background.agent_count:
   en: "%{count} subagents"
-  zh-CN: "%{count} 个子代理"
 background.agent_count_one:
   en: 1 subagent
-  zh-CN: 1 个子代理
 background.status.starting:
   en: Starting
-  zh-CN: 正在启动
 background.status.running:
   en: Running
-  zh-CN: 正在运行
 background.status.monitoring:
   en: Monitoring
-  zh-CN: 正在监控
 background.status.stopping:
   en: Stopping
-  zh-CN: 正在停止
 background.status.completed:
   en: Completed
-  zh-CN: 已完成
 background.status.failed:
   en: Failed
-  zh-CN: 失败
 background.status.stopped:
   en: Stopped
-  zh-CN: 已停止
 background.status.lost:
   en: Disconnected
-  zh-CN: 已断开
 
 files.unsaved_changes:
   en: Unsaved changes — ⌘S to save
-  zh-CN: 有未保存的更改 — 按 ⌘S 保存
 files.no_project_open:
   en: No project open
-  zh-CN: 尚未打开项目
 files.no_project_open_description:
   en: Open a project to browse its files
-  zh-CN: 打开一个项目即可浏览其中的文件
 files.no_project_is_open:
   en: No project is open
-  zh-CN: 尚未打开项目
 files.unable_to_edit:
   en: "Unable to edit this file: %{error}"
-  zh-CN: "无法编辑此文件：%{error}"
 files.could_not_save_opening:
   en: "Could not save %{path}: still opening"
-  zh-CN: "无法保存 %{path}：文件仍在打开"
 files.could_not_save_read_only:
   en: "Could not save %{path}: file is not editable"
-  zh-CN: "无法保存 %{path}：文件不可编辑"
 files.could_not_save:
   en: "Could not save %{path}: %{error}"
-  zh-CN: "无法保存 %{path}：%{error}"
 
 diff.no_changes:
   en: No changes
-  zh-CN: 没有更改
 diff.no_changes_description:
   en: This source has no file changes to review
-  zh-CN: 此来源没有可审阅的文件更改
 diff.filter_files:
   en: Filter files…
-  zh-CN: 筛选文件…
 diff.source_last_turn:
   en: Last Turn
-  zh-CN: 上一轮
 diff.source_turn:
   en: Turn %{turn}
-  zh-CN: 第 %{turn} 轮
 diff.source_uncommitted:
   en: Uncommitted
-  zh-CN: 未提交
 diff.source_unstaged:
   en: Unstaged
-  zh-CN: 未暂存
 diff.source_staged:
   en: Staged
-  zh-CN: 已暂存
 diff.source_committed:
   en: Committed
-  zh-CN: 已提交
 diff.source_branch:
   en: Branch
-  zh-CN: 分支
 diff.loading:
   en: Loading changes…
-  zh-CN: 正在加载更改…
 diff.loading_description:
   en: Capturing a consistent Git snapshot for review
-  zh-CN: 正在捕获一致的 Git 快照以供审阅
 diff.unavailable:
   en: Changes unavailable
-  zh-CN: 无法查看更改
 diff.refresh:
   en: Refresh changes
-  zh-CN: 刷新更改
 diff.refresh_failed:
   en: "Could not refresh changes: %{error}"
-  zh-CN: "无法刷新更改：%{error}"
 diff.truncated:
   en: Large diff · showing first 50,000 lines
-  zh-CN: 大型差异 · 仅显示前 50,000 行
 diff.unmodified_lines:
   en: "%{count} unmodified lines"
-  zh-CN: "%{count} 行未更改"
 diff.expand_all_context:
   en: Expand all unmodified lines
-  zh-CN: 展开所有未更改的行
 diff.expand_context:
   en: Expand unmodified lines · Shift-click for all
-  zh-CN: 展开未更改的行 · 按住 Shift 点击可全部展开
 diff.expand_context_above:
   en: Show 100 lines above · Shift-click for all
-  zh-CN: 显示上方 100 行 · 按住 Shift 点击可全部展开
 diff.expand_context_below:
   en: Show 100 lines below · Shift-click for all
-  zh-CN: 显示下方 100 行 · 按住 Shift 点击可全部展开
 
 browser.back:
   en: Back (⌘[)
-  zh-CN: 后退（⌘[）
 browser.forward:
   en: Forward (⌘])
-  zh-CN: 前进（⌘]）
 browser.stop_loading:
   en: Stop loading (Esc)
-  zh-CN: 停止加载（Esc）
 browser.reload:
   en: Reload (⌘R)
-  zh-CN: 重新加载（⌘R）
 browser.open_external:
   en: Open in default browser
-  zh-CN: 在默认浏览器中打开
 browser.browse_web:
   en: Browse the web
-  zh-CN: 浏览网页
 browser.start_hint:
   en: Enter a URL or search above — ⌘L focuses the address bar
-  zh-CN: 在上方输入网址或搜索内容 — 按 ⌘L 聚焦地址栏
 browser.unavailable:
   en: Browser unavailable
-  zh-CN: 浏览器不可用
 browser.requires_macos:
   en: The browser surface requires macOS
-  zh-CN: 浏览器面板仅支持 macOS
 
 find.bad_pattern:
   en: Bad pattern
-  zh-CN: 表达式无效
 find.no_results:
   en: No results
-  zh-CN: 无结果
 find.result_count:
   en: "%{current} of %{total}"
-  zh-CN: "%{current} / %{total}"
 find.match_case:
   en: Match case (⌥⌘C)
-  zh-CN: 区分大小写（⌥⌘C）
 find.match_whole_word:
   en: Match whole word (⌥⌘W)
-  zh-CN: 全字匹配（⌥⌘W）
 find.use_regex:
   en: Use regular expression (⌥⌘R)
-  zh-CN: 使用正则表达式（⌥⌘R）
 find.previous_match:
   en: Previous match (⇧Enter)
-  zh-CN: 上一个匹配项（⇧Enter）
 find.next_match:
   en: Next match (Enter)
-  zh-CN: 下一个匹配项（Enter）
 find.close:
   en: Close (Esc)
-  zh-CN: 关闭（Esc）
 find.replace:
   en: Replace (Enter)
-  zh-CN: 替换（Enter）
 find.replace_all:
   en: Replace all (⌥⌘Enter)
-  zh-CN: 全部替换（⌥⌘Enter）
 find.toggle_replace:
   en: Toggle replace
-  zh-CN: 展开或收起替换栏
 
 common.dismiss_notification:
   en: Dismiss notification
-  zh-CN: 关闭通知
 
 common.reveal_in_finder:
   en: Reveal in Finder
-  zh-CN: 在访达中显示
 
 attachments.close_preview:
   en: Close image preview
-  zh-CN: 关闭图像预览
 
 attachments.preview_unavailable:
   en: Image unavailable
-  zh-CN: 无法显示图像
 
 common.copy_named:
   en: Copy %{name}
-  zh-CN: 复制%{name}
 
 transcript.worked:
   en: Worked
-  zh-CN: 已完成
 transcript.worked_for:
   en: Worked for %{duration}
-  zh-CN: 用时 %{duration}
 transcript.you_stopped_after:
   en: You stopped after %{duration}
-  zh-CN: 你在 %{duration} 后停止了任务
 transcript.working_for:
   en: Working for %{duration}
-  zh-CN: 已工作 %{duration}
 transcript.thinking:
   en: Thinking
-  zh-CN: 正在思考
 transcript.thought_for:
   en: Thought for %{duration}
-  zh-CN: 思考用时 %{duration}
 transcript.changed_file:
   en: Changed %{count} file
-  zh-CN: 更改了 %{count} 个文件
 transcript.changed_files:
   en: Changed %{count} files
-  zh-CN: 更改了 %{count} 个文件
 transcript.review_changes:
   en: Review
-  zh-CN: 查看
 transcript.show_more_files:
   en: Show %{count} more files
-  zh-CN: 再显示 %{count} 个文件
 transcript.show_fewer_files:
   en: Show fewer files
-  zh-CN: 收起文件列表
 transcript.showing_first_files:
   en: Showing first %{count} of %{total}
-  zh-CN: 仅显示前 %{count}/%{total} 个
 
 duration.second:
   en: "%{count} second"
-  zh-CN: "%{count} 秒"
 duration.seconds:
   en: "%{count} seconds"
-  zh-CN: "%{count} 秒"
 duration.minute:
   en: "%{count} minute"
-  zh-CN: "%{count} 分钟"
 duration.minutes:
   en: "%{count} minutes"
-  zh-CN: "%{count} 分钟"
 duration.hour:
   en: "%{count} hour"
-  zh-CN: "%{count} 小时"
 duration.hours:
   en: "%{count} hours"
-  zh-CN: "%{count} 小时"
 duration.seconds_short:
   en: "%{count}s"
-  zh-CN: "%{count} 秒"
 duration.minutes_short:
   en: "%{count}m"
-  zh-CN: "%{count} 分"
 duration.hours_short:
   en: "%{count}h"
-  zh-CN: "%{count} 小时"
 duration.two_units:
   en: "%{first} %{second}"
-  zh-CN: "%{first} %{second}"
 
 usage.scan_summary:
   en: Scanned %{scanned} transcripts (%{skipped} outside the window) · %{records} usage records · %{seconds}s
-  zh-CN: 已扫描 %{scanned} 份对话记录（%{skipped} 份不在所选时段内）· %{records} 条用量记录 · %{seconds} 秒
 usage.daily:
   en: Daily
-  zh-CN: 每日
 usage.monthly:
   en: Monthly
-  zh-CN: 每月
 usage.projects:
   en: Projects
-  zh-CN: 项目
 usage.scanning:
   en: Scanning provider transcripts…
-  zh-CN: 正在扫描服务商的对话记录…
 usage.rescan:
   en: Rescan provider transcripts
-  zh-CN: 重新扫描服务商的对话记录
 usage.range:
   en: "%{start} to %{end}"
-  zh-CN: "%{start}至%{end}"
 usage.full_api_rate_note:
   en: "* if billed at full API rate"
-  zh-CN: "* 按完整 API 费率估算"
 usage.sessions_summary:
   en: Input, cache reads and output across %{count} sessions
-  zh-CN: 汇总 %{count} 个任务的输入、缓存读取和输出
 usage.raw_token_cost:
   en: RAW TOKEN COST
-  zh-CN: 原始令牌费用
 usage.processed_tokens_upper:
   en: PROCESSED TOKENS
-  zh-CN: 已处理令牌
 usage.cost_share:
   en: "%{share} of cost · %{tokens} tokens"
-  zh-CN: 占费用的 %{share} · %{tokens} 个令牌
 usage.token_share:
   en: "%{share} of tokens · %{cost}"
-  zh-CN: 占令牌的 %{share} · %{cost}
 usage.no_activity_window:
   en: No activity in this window
-  zh-CN: 所选时段内没有活动
 usage.cost_upper:
   en: COST
-  zh-CN: 费用
 usage.tokens_upper:
   en: TOKENS
-  zh-CN: 令牌
 usage.daily_cost:
   en: Daily cost
-  zh-CN: 每日费用
 usage.daily_processed_tokens:
   en: Daily processed tokens
-  zh-CN: 每日已处理令牌
 usage.model_upper:
   en: MODEL
-  zh-CN: 模型
 usage.day_upper:
   en: DAY
-  zh-CN: 日期
 usage.breakdown:
   en: Breakdown
-  zh-CN: 明细
 usage.no_projects_match:
   en: No projects match the filter
-  zh-CN: 没有符合筛选条件的项目
 usage.by_project:
   en: By project
-  zh-CN: 按项目
 usage.projects_caption:
   en: "%{projects} · %{tokens} tokens · %{sessions}"
-  zh-CN: "%{projects} · %{tokens} 个令牌 · %{sessions}"
 usage.projects_shown:
   en: "%{shown} of %{projects} shown"
-  zh-CN: "共 %{projects}，当前显示 %{shown} 个"
 usage.percent_of_cost:
   en: "%{share} of cost"
-  zh-CN: 占费用的 %{share}
 usage.token_count:
   en: "%{count} tokens"
-  zh-CN: "%{count} 个令牌"
 usage.last_active:
   en: last active %{date}
-  zh-CN: 最后活跃于 %{date}
 usage.show_models:
   en: Show %{models} with spend details
-  zh-CN: 查看 %{models}的费用明细
 usage.other_sessions:
   en: Other sessions
-  zh-CN: 其他任务
 usage.rates_unavailable:
   en: Model rates are unavailable, so costs read as unpriced until the rate table loads
-  zh-CN: 模型费率暂不可用；费率表加载完成前，相关费用会显示为未定价
 usage.total:
   en: Total
-  zh-CN: 总计
 usage.processed_tokens:
   en: Processed tokens
-  zh-CN: 已处理令牌
 usage.per_active_day:
   en: "%{count} per active day"
-  zh-CN: 每个活跃日 %{count}
 usage.cached_input:
   en: Cached input
-  zh-CN: 缓存输入
 usage.observed_input_share:
   en: "%{share} of observed input"
-  zh-CN: 占已统计输入的 %{share}
 usage.uncached_input:
   en: Uncached input
-  zh-CN: 未缓存输入
 usage.cache_writes:
   en: "%{count} cache writes"
-  zh-CN: "%{count} 个缓存写入令牌"
 usage.output:
   en: Output
-  zh-CN: 输出
 usage.includes_reasoning:
   en: includes %{count} reasoning
-  zh-CN: 其中推理令牌 %{count}
 usage.cache_savings:
   en: Cache savings
-  zh-CN: 缓存节省
 usage.raw_cost_multiple:
   en: "%{multiple}x the raw token cost"
-  zh-CN: 相当于原始令牌费用的 %{multiple} 倍
 usage.vs_full_input_rates:
   en: vs full input rates
-  zh-CN: 与完整输入费率相比
 usage.model:
   en: Model
-  zh-CN: 模型
 usage.cost:
   en: Cost
-  zh-CN: 费用
 usage.share:
   en: Share
-  zh-CN: 占比
 usage.tokens:
   en: Tokens
-  zh-CN: 令牌
 usage.day:
   en: Day
-  zh-CN: 日期
 usage.cost_quality:
   en: Cost quality
-  zh-CN: 费用可信度
 usage.provider_reported:
   en: Provider reported
-  zh-CN: 服务商报告
 usage.model_priced:
   en: Model priced
-  zh-CN: 按模型定价
 usage.unpriced:
   en: Unpriced
-  zh-CN: 未定价
 usage.no_activity_12_months:
   en: No activity in the last 12 months
-  zh-CN: 过去 12 个月内没有活动
 usage.last_12_months:
   en: Last 12 months
-  zh-CN: 过去 12 个月
 usage.so_far:
   en: so far
-  zh-CN: 截至目前
 usage.no_activity:
   en: No activity
-  zh-CN: 没有活动
 usage.models_by_spend:
   en: "%{models} · by spend"
-  zh-CN: "%{models} · 按费用排序"
 usage.tokens_and_sessions:
   en: "%{tokens} tokens · %{sessions}"
-  zh-CN: "%{tokens} 个令牌 · %{sessions}"
 usage.month_caption:
   en: "%{tokens} tokens · %{sessions} · %{days}"
-  zh-CN: "%{tokens} 个令牌 · %{sessions} · %{days}"
 usage.last_7_days:
   en: Last 7 days
-  zh-CN: 过去 7 天
 usage.last_30_days:
   en: Last 30 days
-  zh-CN: 过去 30 天
 usage.last_90_days:
   en: Last 90 days
-  zh-CN: 过去 90 天
 usage.this_month:
   en: This month
-  zh-CN: 本月
 usage.last_month:
   en: Last month
-  zh-CN: 上月
 usage.custom:
   en: Custom
-  zh-CN: 自定义
 usage.project_one:
   en: "%{count} project"
-  zh-CN: "%{count} 个项目"
 usage.project_many:
   en: "%{count} projects"
-  zh-CN: "%{count} 个项目"
 usage.session_one:
   en: "%{count} session"
-  zh-CN: "%{count} 个任务"
 usage.session_many:
   en: "%{count} sessions"
-  zh-CN: "%{count} 个任务"
 usage.model_one:
   en: "%{count} model"
-  zh-CN: "%{count} 个模型"
 usage.model_many:
   en: "%{count} models"
-  zh-CN: "%{count} 个模型"
 usage.active_day_one:
   en: "%{count} active day"
-  zh-CN: "%{count} 个活跃日"
 usage.active_day_many:
   en: "%{count} active days"
-  zh-CN: "%{count} 个活跃日"
 
 usage.refresh_failed:
   en: "Usage refresh failed: %{error}"
-  zh-CN: "用量刷新失败：%{error}"
 usage.context_used:
   en: Context window %{percent}% used (⌘U)
-  zh-CN: 上下文窗口已使用 %{percent}%（⌘U）
 usage.shortcut:
   en: Usage (⌘U)
-  zh-CN: 用量（⌘U）
 usage.context_window:
   en: Context window
-  zh-CN: 上下文窗口
 usage.plan_limits:
   en: Plan usage limits
-  zh-CN: 套餐用量限额
 usage.plan_limits_named:
   en: Plan usage limits · %{plan}
-  zh-CN: 套餐用量限额 · %{plan}
 usage.open_account_settings:
   en: Open the account's usage settings
-  zh-CN: 打开账户用量设置
 usage.unavailable:
   en: Unavailable — %{error}
-  zh-CN: 不可用 — %{error}
 usage.usage_limit:
   en: Usage limit
-  zh-CN: 用量限额
 usage.hour_limit:
   en: "%{count}-hour limit"
-  zh-CN: "%{count} 小时限额"
 usage.day_limit:
   en: "%{count}-day limit"
-  zh-CN: "%{count} 天限额"
 usage.weekly_limit:
   en: Weekly limit
-  zh-CN: 每周限额
 usage.daily_limit:
   en: Daily limit
-  zh-CN: 每日限额
 usage.monthly_limit:
   en: Monthly limit
-  zh-CN: 每月限额
 usage.limit_suffix:
   en: " limit"
-  zh-CN: 限额
 usage.scoped_limit:
   en: "%{period} · %{name}"
-  zh-CN: "%{period} · %{name}"
 usage.weekly_all_models:
   en: Weekly · all models
-  zh-CN: 每周 · 所有模型
 usage.weekly_model:
   en: Weekly · %{model}
-  zh-CN: 每周 · %{model}
 usage.resets_soon:
   en: Resets soon
-  zh-CN: 即将重置
 usage.resets_in_minutes:
   en: Resets in %{count} min
-  zh-CN: "%{count} 分钟后重置"
 usage.resets_in_hours:
   en: Resets in %{count} hr
-  zh-CN: "%{count} 小时后重置"
 usage.resets_in_hours_minutes:
   en: Resets in %{hours} hr %{minutes} min
-  zh-CN: "%{hours} 小时 %{minutes} 分钟后重置"
 usage.resets_date:
   en: Resets %{date}
-  zh-CN: 将于 %{date} 重置
 
 usage_error.signin_cannot_read:
   en: "%{provider} sign-in can't read usage (HTTP %{status}). Running a %{provider} turn refreshes it"
-  zh-CN: "%{provider} 登录状态无法读取用量（HTTP %{status}）。运行一次 %{provider} 任务后即可刷新"
 usage_error.rate_limited:
   en: The usage endpoint is rate limited right now
-  zh-CN: 用量接口当前受到速率限制，请稍后再试
 usage_error.http_status:
   en: The usage endpoint answered HTTP %{status}
-  zh-CN: 用量接口返回了 HTTP %{status}
 usage_error.invalid_json:
   en: The usage endpoint returned invalid JSON
-  zh-CN: 用量接口返回了无效的 JSON
 usage_error.no_home_directory:
   en: No home directory
-  zh-CN: 找不到用户主目录
 usage_error.read_file:
   en: Failed to read %{path}
-  zh-CN: 无法读取 %{path}
 usage_error.codex_auth_invalid:
   en: Codex auth.json is not JSON
-  zh-CN: Codex auth.json 不是有效的 JSON
 usage_error.codex_access_token_missing:
   en: Codex auth.json has no access token; run `codex login`
-  zh-CN: Codex auth.json 中没有访问令牌；请运行 `codex login`
 usage_error.no_rate_limit_windows:
   en: The usage endpoint reported no rate-limit windows
-  zh-CN: 用量接口未返回任何速率限制周期
 usage_error.start_grok_probe:
   en: Failed to start `grok agent stdio`
-  zh-CN: 无法启动 `grok agent stdio`
 usage_error.grok_stdin_unavailable:
   en: Grok stdin is unavailable
-  zh-CN: Grok 的标准输入不可用
 usage_error.grok_stdout_unavailable:
   en: Grok stdout is unavailable
-  zh-CN: Grok 的标准输出不可用
 usage_error.start_grok_reader:
   en: Failed to start the Grok probe reader
-  zh-CN: 无法启动 Grok 探测读取器
 usage_error.grok_billing_timeout:
   en: Grok did not answer the billing request in time
-  zh-CN: Grok 未在规定时间内响应账单请求
 usage_error.grok_answered:
   en: "Grok answered: %{error}"
-  zh-CN: "Grok 返回：%{error}"
 usage_error.grok_no_billing_data:
   en: Grok reported no billing data; run `grok` to sign in
-  zh-CN: Grok 未返回账单数据；请运行 `grok` 登录
 usage_error.claude_credentials_missing:
   en: No Claude Code credentials in the keychain or ~/.claude
-  zh-CN: 钥匙串和 ~/.claude 中均未找到 Claude Code 凭据
 usage_error.run_security:
   en: Failed to run /usr/bin/security
-  zh-CN: 无法运行 /usr/bin/security
 usage_error.keychain_item_missing:
   en: The keychain has no %{service} item
-  zh-CN: 钥匙串中没有 %{service} 项目
 usage_error.claude_credentials_invalid:
   en: Claude Code credentials are not JSON
-  zh-CN: Claude Code 凭据不是有效的 JSON
 usage_error.claude_oauth_missing:
   en: Claude Code credentials have no claudeAiOauth entry
-  zh-CN: Claude Code 凭据中没有 claudeAiOauth 项
 usage_error.claude_access_token_missing:
   en: Claude Code credentials have no access token
-  zh-CN: Claude Code 凭据中没有访问令牌
 usage_error.run_curl:
   en: Failed to run /usr/bin/curl
-  zh-CN: 无法运行 /usr/bin/curl
 usage_error.curl_stdin_unavailable:
   en: curl stdin is unavailable
-  zh-CN: curl 的标准输入不可用
 usage_error.configure_curl:
   en: Failed to pass the configuration to curl
-  zh-CN: 无法向 curl 传递配置
 usage_error.curl_did_not_finish:
   en: curl did not finish
-  zh-CN: curl 未能完成请求
 usage_error.curl_failed:
   en: "curl failed: %{error}"
-  zh-CN: "curl 失败：%{error}"
 usage_error.unknown_error:
   en: unknown error
-  zh-CN: 未知错误
 usage_error.curl_no_status:
   en: curl returned no HTTP status line
-  zh-CN: curl 未返回 HTTP 状态行

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -1,0 +1,803 @@
+_version: 1
+
+menu.about: "%{app} について"
+menu.check_for_updates: アップデートを確認…
+menu.settings: 設定…
+menu.quit: "%{app} を終了"
+menu.file: ファイル
+menu.new_task: 新規タスク
+menu.new_project: 新規プロジェクト…
+menu.edit: 編集
+menu.undo: 取り消す
+menu.redo: やり直す
+menu.cut: カット
+menu.copy: コピー
+menu.paste: ペースト
+menu.select_all: すべてを選択
+menu.view: 表示
+menu.command_palette: コマンドパレット…
+menu.toggle_sidebar: サイドバーの表示を切り替える
+menu.toggle_right_panel: 右パネルの表示を切り替える
+menu.focus_composer: 入力欄にフォーカスを移動
+menu.toggle_model_picker: モデル選択の表示を切り替える
+menu.toggle_usage_panel: 使用状況パネルの表示を切り替える
+menu.window: ウインドウ
+menu.toggle_fps_counter: FPS カウンターの表示を切り替える
+menu.close_window: ウインドウを閉じる
+
+updater.update: アップデート
+updater.checking: アップデートを確認中…
+updater.updating: アップデート中…
+updater.up_to_date: Waku は最新です
+updater.failed: "アップデートに失敗しました：%{error}"
+
+command_palette.placeholder: タスクを検索、またはコマンドを実行…
+command_palette.suggested: おすすめ
+command_palette.tasks: タスク
+command_palette.commands: コマンド
+command_palette.settings: 設定
+command_palette.new_task: 新規タスク
+command_palette.open_project: プロジェクトを開く…
+command_palette.choose_model: モデルを選択…
+command_palette.show_sidebar: サイドバーを表示
+command_palette.hide_sidebar: サイドバーを隠す
+command_palette.show_right_panel: 右パネルを表示
+command_palette.hide_right_panel: 右パネルを隠す
+command_palette.current: 現在
+command_palette.you: あなた
+command_palette.agent: エージェント
+command_palette.no_results: 一致するタスクやコマンドはありません
+command_palette.no_results_hint: タスク名、メッセージ、プロジェクト、設定、コマンドで検索してください
+
+language.title: 言語
+language.system: システム
+language.description: Waku 全体で使用する言語を選択します
+
+settings.general: 一般
+settings.appearance: 外観
+settings.providers: プロバイダー
+settings.usage: 使用状況
+settings.computer_use: コンピュータ操作
+settings.general_keywords: 一般 ローカル プロジェクト 会話 プライバシー 分析 テレメトリ 匿名 共有 アップデート 自動 バージョン
+settings.appearance_keywords: 外観 テーマ システム ライト ダーク 言語 英語 中国語 簡体字 日本語
+settings.providers_keywords: プロバイダー エージェント モデル CLI バージョン インストール 検出 claude codex cursor opencode amp grok pi
+settings.skills: スキル
+settings.skills_keywords: スキル ライブラリ エージェント 無効 有効 削除 claude codex cursor opencode pi amp 共有
+settings.usage_keywords: 使用状況 トークン コスト 支出 キャッシュ 日別 グラフ モデル 内訳 履歴 claude codex
+settings.computer_use_keywords: コンピュータ 操作 画面収録 アクセシビリティ アプリ 制御 codex
+settings.back: 戻る
+settings.search: 設定を検索
+settings.theme: テーマ
+settings.theme_description: システム、ライト、ダークのいずれかのテーマを選択します
+settings.theme_system: システム
+settings.theme_light: ライト
+settings.theme_dark: ダーク
+
+input.do_anything: 何でも依頼できます…
+input.search_models: モデルを検索…
+input.search_branches: ブランチを検索
+input.new_branch_name: 新しいブランチ名
+input.detected_automatically: 自動検出
+input.filter_projects: プロジェクトを絞り込む
+input.search_or_enter_address: 検索またはアドレスを入力
+input.find: 検索
+input.replace: 置換
+
+common.checking: 確認中…
+common.refresh: 更新
+common.recheck: 再確認
+common.reset: リセット
+common.revoke: 許可を解除
+
+settings.local_by_default: デフォルトでローカルに保存
+settings.local_by_default_description: プロジェクト、会話、設定はこの Mac に保存されます
+settings.automatic_updates: 自動アップデート
+settings.automatic_updates_description: バックグラウンドで新しいバージョンを確認し、インストールを案内します
+settings.share_anonymous_usage_data: 匿名の使用状況データを共有
+settings.share_anonymous_usage_data_description: 機能の利用状況と信頼性に関するデータを共有して、Waku の改善にご協力ください。プロンプト、回答、プロジェクト名、ファイルパスなどの個人データは一切含まれません
+
+providers.coding_agents: コーディングエージェント
+providers.description: Waku はこの Mac にインストールされたエージェントの CLI を使用します。各エージェントの CLI をインストールするかログインしてから、更新してください
+providers.disabled_for_new_tasks: 新規タスクでは無効
+providers.model_count_one: "%{count} 個のモデル"
+providers.model_count_many: "%{count} 個のモデル"
+providers.not_detected_as: PATH 上に %{command} が見つかりません
+providers.using_override: PATH の自動検出ではなく %{path} を使用しています
+providers.invalid_override: このパスには実行可能なファイルがありません。空欄にすると PATH から自動検出します
+providers.detected_at: "%{path} で検出されました"
+providers.searches_path: Waku は PATH で %{command} を検出できませんでした
+providers.binary_path: 実行ファイルのパス
+providers.binary_path_description: Waku が %{provider} の起動に使用する実行ファイルです。Return キーで適用します。空欄にすると PATH から自動検出します
+providers.checked_just_now: たった今確認済み
+providers.checked_minutes_ago: "%{count} 分前に確認済み"
+providers.checked_hours_ago: "%{count} 時間前に確認済み"
+
+computer_use.allow_apps: Waku にアプリの操作を許可
+computer_use.availability: コンピュータ操作は Codex、OpenCode、Grok、Pi で利用できます
+computer_use.macos_access: macOS のアクセス権
+computer_use.helper_access: Waku の分離された操作ヘルパー %{helper} にアクセスを許可してください
+computer_use.screen_recording: 画面収録
+computer_use.screen_recording_description: 許可されたアプリのウインドウのみを取り込みます
+computer_use.accessibility: アクセシビリティ
+computer_use.accessibility_description: 承認後にポインタとキーボードのイベントを送信します
+computer_use.always_allowed_apps: 常に許可するアプリ
+computer_use.always_allowed_apps_description: Waku はこれらの許可をアプリの Bundle ID と署名チームに紐付けます
+computer_use.no_always_allowed_apps: 常に許可されているアプリはありません。タスクごとの許可はメモリにのみ保持されます
+computer_use.access_granted: アクセス許可済み
+computer_use.grant_access: アクセスを許可
+computer_use.permission_check_failed: コンピュータ操作の権限を確認できませんでした
+
+common.settings: 設定
+common.remove: 削除
+common.rename: 名前を変更
+
+session.new_task: 新規タスク
+
+sidebar.today: 今日
+sidebar.search: 検索
+sidebar.yesterday: 昨日
+sidebar.this_week: 今週
+sidebar.this_month: 今月
+sidebar.this_year: 今年
+sidebar.more: さらに前
+sidebar.working: 作業中 · %{elapsed}
+sidebar.just_now: たった今
+sidebar.minutes_ago: "%{count} 分前"
+sidebar.hours_ago: "%{count} 時間前"
+sidebar.days_ago: "%{count} 日前"
+sidebar.unknown_project: 不明なプロジェクト
+
+project.new_project: 新規プロジェクト…
+project.no_project: プロジェクトを使用しない
+project.no_project_name: プロジェクトなし
+project.choose_project: プロジェクトを選択
+project.project_lower: プロジェクト
+project.without_a_project: プロジェクトなし
+project.your_project: あなたのプロジェクト
+
+onboarding.open_project_to_begin: プロジェクトを開いて始めましょう
+onboarding.description: Waku は選択したフォルダでコーディングエージェントを実行します。コード、タスク、履歴はこの Mac に保存されます
+onboarding.open_project_folder: プロジェクトフォルダを開く…
+onboarding.what_should_we_build: 何を作りましょうか？
+onboarding.what_should_we_build_in: ""
+onboarding.question_mark: " で何を作りましょうか？"
+
+common.copied: コピーしました
+common.copy_message: メッセージをコピー
+common.copy_message_title: メッセージをコピー
+common.copy_selection: 選択範囲をコピー
+common.copy_to_composer: 入力欄にコピー
+common.copy_code: コードをコピー
+common.cancel: キャンセル
+common.send: 送信
+
+session.fork_task: タスクをフォーク
+session.fork_task_title: タスクをフォーク
+session.forking_task: タスクをフォーク中…
+session.forking_task_title: タスクをフォーク中…
+session.revert_to_here: ここまで戻す
+session.revert_to_here_title: ここまで戻す
+
+time.yesterday_at: 昨日 %{time}
+time.weekday_at: "%{weekday} %{time}"
+time.date_at: "%{month}月%{day}日 %{time}"
+time.full_date_at: "%{year}年%{month}月%{day}日 %{time}"
+time.monday: 月曜日
+time.tuesday: 火曜日
+time.wednesday: 水曜日
+time.thursday: 木曜日
+time.friday: 金曜日
+time.saturday: 土曜日
+time.sunday: 日曜日
+
+activity.count: "%{activity} %{count} 件"
+activity.running: 実行中：%{activities}
+activity.ran: 実行済み：%{activities}
+activity.arguments: 引数
+activity.output: 出力
+activity.image_output: 画像出力
+activity.search_for: "%{query} を検索"
+activity.searched_web: ウェブを検索しました
+activity.open_url: "%{url} を開く"
+activity.opened_web_page: ウェブページを開きました
+activity.find_in_url: "%{url} で %{pattern} を検索"
+activity.find_on_page: ページ内で %{pattern} を検索
+activity.search_within_url: "%{url} 内を検索"
+activity.searched_within_page: ウェブページ内を検索しました
+activity.browsed_page: "%{count} ページを閲覧しました"
+activity.browsed_pages: "%{count} ページを閲覧しました"
+activity.browsed_web: ウェブを閲覧しました
+activity.exit_code: "終了コード：%{code}"
+activity.output_with_exit_code: "%{output}\n\n終了コード：%{code}"
+activity.run_command: コマンドを実行
+activity.running_named_command: "%{command} を実行中"
+activity.ran_named_command: "%{command} を実行しました"
+activity.named_command_failed: "コマンドの実行に失敗しました：%{command}"
+activity.running_command: コマンドを実行中
+activity.ran_command: コマンドを実行しました
+activity.command_failed: コマンドの実行に失敗しました
+activity.edit_file: ファイルを編集
+activity.write_file: ファイルに書き込む
+activity.editing_named_file: "%{file} を編集中"
+activity.edited_named_file: "%{file} を編集しました"
+activity.edit_failed_named_file: "%{file} の編集に失敗しました"
+activity.editing_files: ファイルを編集中
+activity.edited_files: ファイルを編集しました
+activity.edit_failed: ファイルの編集に失敗しました
+activity.file_count: "%{count} 個のファイル"
+activity.read_file: ファイルを読み込む
+activity.reading_named_file: "%{file} を読み込み中"
+activity.read_named_file: "%{file} を読み込みました"
+activity.read_named_file_failed: "%{file} の読み込みに失敗しました"
+activity.reading_file: ファイルを読み込み中
+activity.read_file_completed: ファイルを読み込みました
+activity.read_file_failed: ファイルの読み込みに失敗しました
+activity.search_files: ファイルを検索
+activity.find_files: ファイルを探す
+activity.searching_files_for: "ファイル内で %{query} を検索中"
+activity.searched_files_for: "ファイル内で %{query} を検索しました"
+activity.file_search_failed_for: "ファイル内での %{query} の検索に失敗しました"
+activity.searching_files: ファイルを検索中
+activity.searched_files: ファイルを検索しました
+activity.file_search_failed: ファイルの検索に失敗しました
+activity.list_files: ファイル一覧を表示
+activity.listing_files_in: "%{directory} のファイル一覧を取得中"
+activity.listed_files_in: "%{directory} のファイル一覧を取得しました"
+activity.file_list_failed_in: "%{directory} のファイル一覧の取得に失敗しました"
+activity.listing_files: ファイル一覧を取得中
+activity.listed_files: ファイル一覧を取得しました
+activity.file_list_failed: ファイル一覧の取得に失敗しました
+activity.searching_web_for: "ウェブで %{query} を検索中"
+activity.searched_web_for: "ウェブで %{query} を検索しました"
+activity.web_search_failed_for: "ウェブでの %{query} の検索に失敗しました"
+activity.searching_web: ウェブを検索中
+activity.searched_the_web: ウェブを検索しました
+activity.web_search_failed: ウェブ検索に失敗しました
+activity.updating_plan: プランを更新中
+activity.updated_plan: プランを更新しました
+activity.plan_update_failed: プランの更新に失敗しました
+activity.activity: アクティビティ
+activity.tool: ツール
+activity.plan_updated: プランを更新しました
+activity.output_truncated: "\n\n… 出力は省略されました"
+activity.thought: 思考
+activity.thoughts: 思考
+activity.command: コマンド
+activity.commands: コマンド
+activity.file_edit: ファイル編集
+activity.file_edits: ファイル編集
+activity.file_read: ファイル読み込み
+activity.file_reads: ファイル読み込み
+activity.file_search: ファイル検索
+activity.file_searches: ファイル検索
+activity.file_list: ファイル一覧
+activity.file_lists: ファイル一覧
+activity.search: 検索
+activity.searches: 検索
+activity.plan_step: プランのステップ
+activity.plan_steps: プランのステップ
+activity.tool_call: ツール呼び出し
+activity.tool_calls: ツール呼び出し
+
+mode.build: 実装
+mode.plan: プラン
+mode.supervised: 監督モード
+mode.auto_accept_edits: 編集を自動承認
+mode.auto: 自動
+mode.full_access: フルアクセス
+mode.plan_description: 変更を加えずに調査してプランを作成します
+mode.supervised_description: コマンドの実行とファイル変更の前に確認します
+mode.auto_accept_edits_description: 編集は自動承認し、その他の操作は事前に確認します
+mode.auto_description: 通常の操作は AI レビュアーが承認し、リスクのある操作は事前に確認します
+mode.full_access_description: 確認なしでコマンドの実行と編集を許可します
+
+computer_use.allow_for_task: このタスクで許可
+computer_use.always_allow_app: このアプリを常に許可
+computer_use.allow_control: Waku に「%{app}」の操作を許可しますか？
+computer_use.screenshot_shared: このウインドウのスクリーンショットが、使用中の Codex モデルと共有されます
+computer_use.sensitive_action: この操作ではテキストの入力やキー操作が行われる可能性があります
+computer_use.bundle_id: "Bundle ID：%{id}"
+computer_use.no_bundle_id: このアプリには Bundle ID がないため、常に許可することはできません
+computer_use.stopped: 停止しました
+computer_use.controlling: 操作中
+computer_use.captured: キャプチャ済み
+computer_use.take_control: 操作を引き継ぐ
+computer_use.preparing_preview: プレビューを準備中…
+
+common.deny: 拒否
+
+permission.allow_once: 1 回だけ許可
+permission.allow_for_session: このセッションで許可
+permission.always_allow: 常に許可
+permission.a_tool: ツール
+permission.run_a_tool: ツールを実行
+permission.run_a_tool_lower: ツールを実行
+permission.blocked_path: "ブロックされたパス：%{path}"
+permission.agent_wants_to_run: エージェントが %{tool} を実行しようとしています
+permission.run_tool: "%{tool} を実行しますか？"
+permission.allow_named_permission: "%{permission} を許可しますか？"
+permission.agent_asks_for_named_permission: エージェントが %{permission} の権限を求めています
+permission.agent_asks_for_permission: エージェントが権限を求めています
+permission.agent_wants_to: エージェントが次の操作を実行しようとしています：%{action}
+
+common.close: 閉じる
+common.default: デフォルト
+
+models.none_found: モデルが見つかりません
+models.favorite_hint: モデルにスターを付けると、ここに固定できます
+models.loading: モデルを読み込み中…
+models.none_reported: このプロバイダーにモデルがありません
+models.standard: 標準
+models.reasoning: 推論レベル
+models.service_tier: サービスティア
+
+model_option.none: なし
+model_option.minimal: 最小
+model_option.low: 低
+model_option.medium: 中
+model_option.high: 高
+model_option.extra_high: 非常に高い
+model_option.max: 最大
+model_option.ultra: 超高
+model_option.auto: 自動
+model_option.fast: 高速
+model_option.amp_fast_description: 使用量が増える代わりに、Amp の高速な処理階層を使用します
+model_option.fast_description: 使用量が増える代わりに、応答を高速化します
+
+command_scope.project: プロジェクト
+command_scope.user: ユーザー
+command_scope.skill: スキル
+command_scope.builtin: 組み込み
+
+skills.search: スキルを検索…
+skills.count_one: 1 個のスキル
+skills.count_many: "%{count} 個のスキル"
+skills.count_disabled: "無効 %{count} 件"
+skills.filter_caption: "%{total} 件中 %{shown} 件を表示"
+skills.scanning: スキルフォルダをスキャン中…
+skills.no_match: 検索に一致するスキルはありません
+skills.section_user: ユーザー
+skills.source_shared: 共有
+skills.scope_user_detail: すべてのプロジェクトで利用可能
+skills.scope_in_project: "%{project} 内"
+skills.filter_all: すべてのスキル
+skills.select_placeholder: スキルを選択
+skills.detail_invoke: 呼び出し
+skills.detail_location: 場所
+skills.detail_contents: 内容
+skills.detail_updated: 更新日時
+skills.no_description: 説明なし
+skills.disabled_badge: 無効
+skills.file_count_one: 補助ファイル 1 件
+skills.file_count_many: "補助ファイル %{count} 件"
+skills.updated_just_now: たった今
+skills.updated_minutes: "%{count} 分前"
+skills.updated_hours: "%{count} 時間前"
+skills.updated_days: "%{count} 日前"
+skills.allowed_tools: ツール
+skills.duplicate_one: 同名のスキルが他の 1 か所にもあります — 最も限定的な場所にあるスキルが優先されます
+skills.duplicate_many: "同名のスキルが他の %{count} か所にもあります — 最も限定的な場所にあるスキルが優先されます"
+skills.open_file: SKILL.md を開く
+skills.reveal: Finder に表示
+skills.copy_path: パスをコピー
+skills.path_copied: パスをコピーしました
+skills.delete: 削除
+skills.confirm_delete: 削除を確認
+skills.deleted_toast: "「%{name}」をゴミ箱に移動しました"
+skills.delete_failed: "スキルを削除できませんでした：%{error}"
+skills.toggle_failed: "スキルを更新できませんでした：%{error}"
+skills.empty_title: スキルはまだありません
+skills.empty_description: スキルは SKILL.md を含むフォルダです。デプロイ手順やレビューチェックリストのように、どのエージェントでも読み込める再利用可能な指示をまとめられます。Claude Code、Codex、その他のエージェント向けにインストールされたスキルがここに表示され、/name で呼び出せます。
+
+commands.init_description: このプロジェクトの %{instructions_file} を作成または更新
+commands.review_description: このブランチの保留中の変更をレビュー
+commands.commit_description: 現在の変更をステージしてコミット
+commands.claude_compact: 会話を要約してコンテキストを空ける
+commands.claude_context: コンテキストウインドウの使用状況を表示
+commands.claude_cost: このセッションのトークン使用量とコストを表示
+commands.claude_init: プロジェクトを分析して CLAUDE.md を作成
+commands.claude_pr_comments: 現在の PR のレビューコメントを取得
+commands.claude_review: プルリクエストをレビュー
+commands.claude_security_review: 保留中の変更をセキュリティレビュー
+commands.claude_todos: 現在の TODO 項目を一覧表示
+
+composer.edit_in_composer: 入力欄で編集
+composer.queued_followups: キューに追加したフォローアップ
+composer.queued_followups_description: キューに追加したフォローアップ · 現在のターンが完了すると送信されます
+composer.preparing_task: タスクを準備中…
+composer.steer_turn: 実行中のターンに指示を追加（⌘↩）
+composer.queue_followup: フォローアップとしてキューに追加（⏎）
+
+branches.detached_head: Detached HEAD
+branches.search_project: "%{project} のブランチを検索"
+branches.switching: 切り替え中…
+branches.create_and_checkout: 新しいブランチを作成してチェックアウト
+branches.create_hint: Return キーで作成 · Esc キーでキャンセル
+branches.none_found: ブランチが見つかりません
+branches.create_and_checkout_ellipsis: 新しいブランチを作成してチェックアウト…
+branches.title: ブランチ
+
+workspace.work_in: 作業場所
+workspace.local: ローカル
+workspace.new_worktree: 新しいワークツリー
+workspace.workspace: ワークスペース
+workspace.worktree: ワークツリー
+
+terminal.starting: ターミナルを起動中…
+
+project.add_project: プロジェクトを追加
+
+session.stopped: 停止しました
+session.turn_completed: ターンが完了しました
+session.stopped_before_response: エージェントは回答を返す前に停止しました
+session.codex_exited_before_response: Codex app-server は回答を返す前に終了しました
+session.steer_rejected: エージェントに追加の指示を送れませんでした（%{error}）。メッセージはフォローアップとしてキューに追加されました
+session.agent_ran_out_of_context: このターンでエージェントのコンテキストが不足しました
+session.agent_declined_turn: エージェントはこのターンを辞退しました
+session.agent_stopped_reason: "エージェントが停止しました：%{reason}"
+
+errors.open_session: "そのタスクを開けませんでした：%{error}"
+errors.create_projectless_task: "~/.waku 内にタスクを作成できませんでした：%{error}"
+errors.save_projectless_migration: "プロジェクトなしタスクの移行を保存できませんでした：%{error}"
+errors.move_projectless_task: "以前のルート直下のプロジェクトなしタスクを ~/.waku 内に移動できませんでした：%{error}"
+errors.change_branch: "ブランチを変更できませんでした：%{error}"
+errors.capture_pre_turn_checkpoint: "ターン開始前のチェックポイントを取得できませんでした：%{error}"
+errors.capture_turn_checkpoint: "ターンのチェックポイントを取得できませんでした：%{error}"
+errors.save_local_state: "ローカルの状態を保存できませんでした：%{error}"
+errors.task_project_not_found: タスクのプロジェクトが見つかりませんでした
+errors.provider_native_session_unavailable: "%{provider} のネイティブセッションは利用できません"
+errors.provider_native_thread_unavailable: "%{provider} のネイティブスレッドは利用できません"
+errors.provider_native_cursor_unavailable: "%{provider} のネイティブセッションカーソルは利用できません"
+errors.provider_native_thread_cursor_unavailable: "%{provider} のネイティブスレッドカーソルは利用できません"
+errors.provider_waku_task_unavailable: "%{provider} の Waku タスクは利用できません"
+errors.provider_not_installed: "%{provider} はインストールされていません"
+errors.provider_not_found: "%{provider} はインストールされていないか、見つかりませんでした"
+errors.claude_fork_checkpoint_missing: Claude からフォーク用チェックポイントが返されませんでした
+errors.claude_turn_checkpoint_unavailable: "そのターンの Claude ネイティブチェックポイントは利用できません：%{error}"
+errors.pi_session_file_unavailable: Pi のネイティブセッションファイルは利用できません
+errors.fork_task: "タスクをフォークできませんでした：%{error}"
+errors.create_rewind_snapshot: "巻き戻し用の安全スナップショットを作成できませんでした：%{error}"
+errors.restore_checkpoint: "チェックポイントを復元できませんでした：%{error}"
+errors.restore_checkpoint_and_safety: "チェックポイントの復元に失敗し（%{error}）、安全スナップショットの復元にも失敗しました（%{restore_error}）。復旧用 ref は %{safety_ref} に保持されています"
+errors.rollback_rejected_workspace_restored: "プロバイダーがロールバックを拒否したため、ワークスペースを復元しました：%{error}"
+errors.rollback_and_safety_failed: "プロバイダーのロールバックに失敗し（%{error}）、安全スナップショットも復元できませんでした（%{restore_error}）。復旧用 ref は %{safety_ref} に保持されています"
+errors.no_session_selected: タスクが選択されていません
+errors.session_not_found: タスクが見つかりません
+errors.project_not_found: プロジェクトが見つかりません
+errors.prepare_task_project_not_found: タスクを準備できませんでした：プロジェクトが見つかりません
+errors.store_pasted_image: "ペーストした画像を添付できませんでした：%{error}"
+errors.create_worktree: "ワークツリーを作成できませんでした：%{error}"
+errors.prepared_runtime_unavailable: 準備したエージェントランタイムは利用できません
+errors.start_agent: "エージェントを起動できませんでした：%{error}"
+errors.provider_no_active_turn: "%{provider} には指示を追加できる実行中のターンがありません"
+errors.provider_transport_write: "%{provider} の通信への書き込みに失敗しました：%{error}"
+errors.provider_transport_write_short: "%{provider} の通信への書き込みに失敗しました"
+errors.provider_transport_read: "%{provider} の通信の読み込みに失敗しました：%{error}"
+errors.provider_invalid_json: "%{provider} から無効な JSON が送信されました：%{error}"
+errors.provider_exited: "%{provider} が %{status} で終了しました"
+errors.provider_rpc_exited: "%{provider} RPC が %{status} で終了しました"
+errors.read_provider_exit_status: "%{provider} の終了ステータスを読み取れませんでした：%{error}"
+errors.initialize_provider: "%{provider} を初期化できませんでした：%{error}"
+errors.provider_no_session_id: "%{provider} からセッション ID が返されませんでした"
+errors.provider_rejected_prompt_detail: "%{provider} がプロンプトを拒否しました：%{error}"
+errors.stop_provider: "%{provider} を停止できませんでした：%{error}"
+errors.switch_provider_model: "%{provider} のモデルを切り替えられませんでした：%{error}"
+errors.change_provider_thinking: "%{provider} の思考レベルを変更できませんでした：%{error}"
+errors.open_provider_session: "%{provider} のセッションを開けませんでした：%{error}"
+errors.select_model: "モデルを選択できませんでした：%{error}"
+errors.read_provider_event_stream: "%{provider} のイベントストリームを読み取れませんでした：%{error}"
+errors.answer_provider_permission: "%{provider} の権限リクエストに回答できませんでした：%{error}"
+errors.initialize_codex_app_server: Codex app-server を初期化できませんでした
+errors.register_computer_use_skill: Waku のコンピュータ操作スキルを Codex に登録できませんでした
+errors.codex_thread_open_incomplete: Codex はスレッドを開く処理を完了しませんでした
+errors.provider_receive_prompt: "%{provider} はプロンプトを受信できませんでした"
+errors.provider_start_turn: "%{provider} はターンを開始できませんでした"
+errors.provider_rejected_steer: "%{provider} が追加の指示を拒否しました：%{error}"
+errors.provider_stopped_receiving: "%{provider} はメッセージの受信を停止しました"
+errors.provider_initialize_session: "%{provider} はこのセッションを初期化できませんでした"
+errors.provider_rejected_prompt: "%{provider} は実行前にプロンプトを拒否しました"
+errors.provider_complete_turn: "%{provider} はこのターンを完了できませんでした"
+errors.pi_reported_error: Pi からエラーが報告されました
+
+session.response_unavailable: その回答は利用できなくなりました
+session.response_cannot_fork: その回答からは現在タスクをフォークできません
+session.response_fork_in_progress: フォーク元のタスクを削除する前に、タスクのフォークが完了するまでお待ちください
+session.response_cannot_copy: その回答を新しいタスクにコピーできませんでした
+session.forked_with_checkpoint_warning: "タスクをフォークしましたが、一部の Git チェックポイントをコピーできませんでした：%{error}"
+session.forked_from_response: この回答からタスクをフォークしました
+session.message_not_editable: そのメッセージは現在編集できません
+session.edited_message_empty: 編集したメッセージを空にはできません
+session.message_unavailable: そのメッセージは利用できなくなりました
+session.select_before_rewind: 会話を巻き戻す前にタスクを選択してください
+session.stop_before_rewind: 会話を巻き戻す前に現在のターンを停止してください
+session.provider_cannot_rewind: "%{provider} はまだネイティブの会話を安全にロールバックできません"
+session.pre_turn_checkpoint_missing: メッセージのターン開始前の Git チェックポイントがありません
+session.rewind_title: "%{title}（巻き戻し）"
+session.rewound: タスクをターン %{turn} の前まで巻き戻しました
+session.rewound_with_stale_refs: "タスクをターン %{turn} の前まで巻き戻しましたが、古い ref が残っています：%{error}"
+
+right_panel.browser: ブラウザ
+right_panel.terminal: ターミナル
+right_panel.files: ファイル
+right_panel.diff: レビュー
+right_panel.toggle: 右パネルの表示を切り替える
+right_panel.open_surface: パネルを開く
+right_panel.choose_surface: 右パネルに表示する内容を選択します
+right_panel.browser_description: ローカルアプリまたは URL を開きます
+right_panel.terminal_description: このワークスペースでシェルを起動します
+right_panel.files_description: ワークスペースのファイルを閲覧します
+right_panel.diff_description: ファイルの変更をレビューします
+right_panel.terminal_unavailable: ターミナルを利用できません
+right_panel.terminal_unavailable_description: ターミナルパネルをもう一度開くとシェルが起動します
+
+environment.title: 環境
+environment.summary: 環境とバックグラウンド作業
+environment.changes: 変更
+environment.commit_or_push: コミットまたはプッシュ
+environment.compare_branch: ブランチを比較
+
+commit.message_placeholder: コミットメッセージ（空欄の場合は自動生成）…
+commit.include_unstaged: ステージしていない変更を含める
+commit.commit: コミット
+commit.commit_and_push: コミットしてプッシュ
+commit.push: プッシュ
+commit.generating_message: コミットメッセージを生成中…
+commit.committing: コミット中…
+commit.committing_and_pushing: コミットしてプッシュ中…
+commit.pushing: プッシュ中…
+commit.no_task: コミットできるタスクがありません
+commit.no_workspace: このタスクにはワークスペースがありません
+commit.no_changes: コミットする変更はありません
+commit.agent_unavailable: 現在のエージェント CLI を利用できないため、コミットメッセージを生成できません
+commit.committed: 変更をコミットしました
+commit.committed_and_pushed: 変更をコミットしてプッシュしました
+commit.pushed: 変更をプッシュしました
+
+background.title: バックグラウンド
+background.description: エージェントが起動したプロセスとサブエージェントを確認します
+background.processes: バックグラウンドプロセス
+background.agents: サブエージェント
+background.process: プロセス
+background.monitor: モニター
+background.subagent: サブエージェント
+background.no_work: バックグラウンドの作業はありません
+background.no_work_description: 長時間実行されるコマンドとサブエージェントがここに表示されます。
+background.view: 表示
+background.stop: 停止
+background.stop_all: すべて停止
+background.stop_not_running: プロセスはすでに停止しています。
+background.output: 出力
+background.no_output: まだ出力はありません
+background.command: コマンド
+background.prompt: プロンプト
+background.cwd: 作業ディレクトリ
+background.role: ロール
+background.model: モデル
+background.latest_update: 最新の更新
+background.exit_code: 終了コード
+background.output_truncated: 以前の出力は省略されました
+background.process_count: "バックグラウンドプロセス %{count} 件"
+background.process_count_one: バックグラウンドプロセス 1 件
+background.agent_count: "サブエージェント %{count} 件"
+background.agent_count_one: サブエージェント 1 件
+background.status.starting: 起動中
+background.status.running: 実行中
+background.status.monitoring: 監視中
+background.status.stopping: 停止中
+background.status.completed: 完了
+background.status.failed: 失敗
+background.status.stopped: 停止
+background.status.lost: 切断
+
+files.unsaved_changes: 未保存の変更があります — ⌘S で保存
+files.no_project_open: プロジェクトが開かれていません
+files.no_project_open_description: プロジェクトを開くとファイルを閲覧できます
+files.no_project_is_open: 開いているプロジェクトはありません
+files.unable_to_edit: "このファイルを編集できません：%{error}"
+files.could_not_save_opening: "%{path} を保存できませんでした：まだ開いています"
+files.could_not_save_read_only: "%{path} を保存できませんでした：このファイルは編集できません"
+files.could_not_save: "%{path} を保存できませんでした：%{error}"
+
+diff.no_changes: 変更はありません
+diff.no_changes_description: このソースにはレビューするファイル変更がありません
+diff.filter_files: ファイルを絞り込む…
+diff.source_last_turn: 前回のターン
+diff.source_turn: ターン %{turn}
+diff.source_uncommitted: 未コミット
+diff.source_unstaged: 未ステージ
+diff.source_staged: ステージ済み
+diff.source_committed: コミット済み
+diff.source_branch: ブランチ
+diff.loading: 変更を読み込み中…
+diff.loading_description: レビュー用に一貫した Git スナップショットを取得しています
+diff.unavailable: 変更を利用できません
+diff.refresh: 変更を更新
+diff.refresh_failed: "変更を更新できませんでした：%{error}"
+diff.truncated: 大きな差分 · 先頭 50,000 行を表示
+diff.unmodified_lines: "未変更の行 %{count} 行"
+diff.expand_all_context: 未変更の行をすべて展開
+diff.expand_context: 未変更の行を展開 · Shift キーを押しながらクリックですべて展開
+diff.expand_context_above: 上の 100 行を表示 · Shift キーを押しながらクリックですべて表示
+diff.expand_context_below: 下の 100 行を表示 · Shift キーを押しながらクリックですべて表示
+
+browser.back: 戻る（⌘[）
+browser.forward: 進む（⌘]）
+browser.stop_loading: 読み込みを停止（Esc）
+browser.reload: 再読み込み（⌘R）
+browser.open_external: デフォルトのブラウザで開く
+browser.browse_web: ウェブを閲覧
+browser.start_hint: 上に URL または検索語句を入力してください — ⌘L でアドレスバーにフォーカス
+browser.unavailable: ブラウザを利用できません
+browser.requires_macos: ブラウザパネルは macOS でのみ利用できます
+
+find.bad_pattern: 無効なパターン
+find.no_results: 結果なし
+find.result_count: "%{total} 件中 %{current} 件目"
+find.match_case: 大文字と小文字を区別（⌥⌘C）
+find.match_whole_word: 単語単位で検索（⌥⌘W）
+find.use_regex: 正規表現を使用（⌥⌘R）
+find.previous_match: 前の一致項目（⇧Enter）
+find.next_match: 次の一致項目（Enter）
+find.close: 閉じる（Esc）
+find.replace: 置換（Enter）
+find.replace_all: すべて置換（⌥⌘Enter）
+find.toggle_replace: 置換欄の表示を切り替える
+
+common.dismiss_notification: 通知を閉じる
+common.reveal_in_finder: Finder に表示
+
+attachments.close_preview: 画像プレビューを閉じる
+attachments.preview_unavailable: 画像を表示できません
+
+common.copy_named: "%{name} をコピー"
+
+transcript.worked: 完了
+transcript.worked_for: 作業時間 %{duration}
+transcript.you_stopped_after: "%{duration} 後にタスクを停止しました"
+transcript.working_for: 作業中 · %{duration}
+transcript.thinking: 思考中
+transcript.thought_for: 思考時間 %{duration}
+transcript.changed_file: "%{count} 個のファイルを変更"
+transcript.changed_files: "%{count} 個のファイルを変更"
+transcript.review_changes: レビュー
+transcript.show_more_files: "さらに %{count} 個のファイルを表示"
+transcript.show_fewer_files: 表示するファイルを減らす
+transcript.showing_first_files: "%{total} 個中、先頭 %{count} 個を表示"
+
+duration.second: "%{count} 秒"
+duration.seconds: "%{count} 秒"
+duration.minute: "%{count} 分"
+duration.minutes: "%{count} 分"
+duration.hour: "%{count} 時間"
+duration.hours: "%{count} 時間"
+duration.seconds_short: "%{count}秒"
+duration.minutes_short: "%{count}分"
+duration.hours_short: "%{count}時間"
+duration.two_units: "%{first} %{second}"
+
+usage.scan_summary: "%{scanned} 件の会話記録をスキャン（対象期間外 %{skipped} 件）· 使用量レコード %{records} 件 · %{seconds} 秒"
+usage.daily: 日別
+usage.monthly: 月別
+usage.projects: プロジェクト
+usage.scanning: プロバイダーの会話記録をスキャン中…
+usage.rescan: プロバイダーの会話記録を再スキャン
+usage.range: "%{start}〜%{end}"
+usage.full_api_rate_note: "* API の通常料金で請求された場合"
+usage.sessions_summary: "%{count} セッションの入力、キャッシュ読み込み、出力の合計"
+usage.raw_token_cost: 元のトークンコスト
+usage.processed_tokens_upper: 処理済みトークン
+usage.cost_share: "コストの %{share} · %{tokens} トークン"
+usage.token_share: "トークンの %{share} · %{cost}"
+usage.no_activity_window: この期間のアクティビティはありません
+usage.cost_upper: コスト
+usage.tokens_upper: トークン
+usage.daily_cost: 日別コスト
+usage.daily_processed_tokens: 日別の処理済みトークン
+usage.model_upper: モデル
+usage.day_upper: 日付
+usage.breakdown: 内訳
+usage.no_projects_match: フィルタに一致するプロジェクトはありません
+usage.by_project: プロジェクト別
+usage.projects_caption: "%{projects} · %{tokens} トークン · %{sessions}"
+usage.projects_shown: "%{projects} 件中 %{shown} 件を表示"
+usage.percent_of_cost: "コストの %{share}"
+usage.token_count: "%{count} トークン"
+usage.last_active: 最終利用 %{date}
+usage.show_models: "%{models} の支出詳細を表示"
+usage.other_sessions: その他のセッション
+usage.rates_unavailable: モデルの料金を取得できないため、料金表が読み込まれるまでコストは未算出として表示されます
+usage.total: 合計
+usage.processed_tokens: 処理済みトークン
+usage.per_active_day: "アクティブな 1 日あたり %{count}"
+usage.cached_input: キャッシュ済み入力
+usage.observed_input_share: "実測入力の %{share}"
+usage.uncached_input: キャッシュなしの入力
+usage.cache_writes: "キャッシュ書き込み %{count}"
+usage.output: 出力
+usage.includes_reasoning: "うち推論 %{count}"
+usage.cache_savings: キャッシュによる節約
+usage.raw_cost_multiple: "元のトークンコストの %{multiple} 倍"
+usage.vs_full_input_rates: 通常の入力料金との比較
+usage.model: モデル
+usage.cost: コスト
+usage.share: 割合
+usage.tokens: トークン
+usage.day: 日付
+usage.cost_quality: コストの信頼度
+usage.provider_reported: プロバイダー報告値
+usage.model_priced: モデル料金から算出
+usage.unpriced: 未算出
+usage.no_activity_12_months: 過去 12 か月間のアクティビティはありません
+usage.last_12_months: 過去 12 か月
+usage.so_far: 現在まで
+usage.no_activity: アクティビティなし
+usage.models_by_spend: "%{models} · 支出順"
+usage.tokens_and_sessions: "%{tokens} トークン · %{sessions}"
+usage.month_caption: "%{tokens} トークン · %{sessions} · %{days}"
+usage.last_7_days: 過去 7 日間
+usage.last_30_days: 過去 30 日間
+usage.last_90_days: 過去 90 日間
+usage.this_month: 今月
+usage.last_month: 先月
+usage.custom: カスタム
+usage.project_one: "%{count} 個のプロジェクト"
+usage.project_many: "%{count} 個のプロジェクト"
+usage.session_one: "%{count} 件のセッション"
+usage.session_many: "%{count} 件のセッション"
+usage.model_one: "%{count} 個のモデル"
+usage.model_many: "%{count} 個のモデル"
+usage.active_day_one: "アクティブ %{count} 日"
+usage.active_day_many: "アクティブ %{count} 日"
+usage.refresh_failed: "使用状況の更新に失敗しました：%{error}"
+usage.context_used: コンテキストウインドウを %{percent}% 使用（⌘U）
+usage.shortcut: 使用状況（⌘U）
+usage.context_window: コンテキストウインドウ
+usage.plan_limits: プランの使用量上限
+usage.plan_limits_named: プランの使用量上限 · %{plan}
+usage.open_account_settings: アカウントの使用状況設定を開く
+usage.unavailable: 利用不可 — %{error}
+usage.usage_limit: 使用量の上限
+usage.hour_limit: "%{count} 時間の上限"
+usage.day_limit: "%{count} 日間の上限"
+usage.weekly_limit: 週間の上限
+usage.daily_limit: 1 日の上限
+usage.monthly_limit: 月間の上限
+usage.limit_suffix: の上限
+usage.scoped_limit: "%{period} · %{name}"
+usage.weekly_all_models: 週間 · すべてのモデル
+usage.weekly_model: 週間 · %{model}
+usage.resets_soon: まもなくリセット
+usage.resets_in_minutes: "%{count} 分後にリセット"
+usage.resets_in_hours: "%{count} 時間後にリセット"
+usage.resets_in_hours_minutes: "%{hours} 時間 %{minutes} 分後にリセット"
+usage.resets_date: "%{date} にリセット"
+
+usage_error.signin_cannot_read: "%{provider} のログイン情報では使用量を取得できません（HTTP %{status}）。%{provider} でタスクを 1 回実行すると更新されます"
+usage_error.rate_limited: 使用量 API は現在レート制限されています
+usage_error.http_status: 使用量 API から HTTP %{status} が返されました
+usage_error.invalid_json: 使用量 API から無効な JSON が返されました
+usage_error.no_home_directory: ホームディレクトリが見つかりません
+usage_error.read_file: "%{path} を読み込めませんでした"
+usage_error.codex_auth_invalid: Codex の auth.json は有効な JSON ではありません
+usage_error.codex_access_token_missing: Codex の auth.json にアクセストークンがありません。`codex login` を実行してください
+usage_error.no_rate_limit_windows: 使用量 API からレート制限期間が返されませんでした
+usage_error.start_grok_probe: "`grok agent stdio` を起動できませんでした"
+usage_error.grok_stdin_unavailable: Grok の標準入力を利用できません
+usage_error.grok_stdout_unavailable: Grok の標準出力を利用できません
+usage_error.start_grok_reader: Grok のプローブリーダーを起動できませんでした
+usage_error.grok_billing_timeout: Grok は時間内に課金リクエストへ応答しませんでした
+usage_error.grok_answered: "Grok からの応答：%{error}"
+usage_error.grok_no_billing_data: Grok から課金データが返されませんでした。`grok` を実行してログインしてください
+usage_error.claude_credentials_missing: キーチェーンにも ~/.claude にも Claude Code の認証情報がありません
+usage_error.run_security: /usr/bin/security を実行できませんでした
+usage_error.keychain_item_missing: キーチェーンに %{service} の項目がありません
+usage_error.claude_credentials_invalid: Claude Code の認証情報は有効な JSON ではありません
+usage_error.claude_oauth_missing: Claude Code の認証情報に claudeAiOauth の項目がありません
+usage_error.claude_access_token_missing: Claude Code の認証情報にアクセストークンがありません
+usage_error.run_curl: /usr/bin/curl を実行できませんでした
+usage_error.curl_stdin_unavailable: curl の標準入力を利用できません
+usage_error.configure_curl: curl に設定を渡せませんでした
+usage_error.curl_did_not_finish: curl がリクエストを完了しませんでした
+usage_error.curl_failed: "curl に失敗しました：%{error}"
+usage_error.unknown_error: 不明なエラー
+usage_error.curl_no_status: curl から HTTP ステータス行が返されませんでした

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -1,0 +1,752 @@
+_version: 1
+
+menu.about: 关于 %{app}
+menu.check_for_updates: 检查更新…
+menu.settings: 设置…
+menu.quit: 退出 %{app}
+menu.file: 文件
+menu.new_task: 新建任务
+menu.new_project: 新建项目…
+menu.edit: 编辑
+menu.undo: 撤销
+menu.redo: 重做
+menu.cut: 剪切
+menu.copy: 复制
+menu.paste: 粘贴
+menu.select_all: 全选
+menu.view: 显示
+menu.command_palette: 命令面板…
+menu.toggle_sidebar: 显示或隐藏侧边栏
+menu.toggle_right_panel: 显示或隐藏右侧面板
+menu.focus_composer: 将焦点移到输入框
+menu.toggle_model_picker: 打开或关闭模型选择器
+menu.toggle_usage_panel: 打开或关闭用量面板
+menu.window: 窗口
+menu.toggle_fps_counter: 显示或隐藏帧率
+menu.close_window: 关闭窗口
+updater.update: 更新
+updater.checking: 正在检查更新…
+updater.updating: 正在更新…
+updater.up_to_date: Waku 已是最新版本
+updater.failed: "更新失败：%{error}"
+command_palette.placeholder: 搜索任务或运行命令…
+command_palette.suggested: 建议
+command_palette.tasks: 任务
+command_palette.commands: 命令
+command_palette.settings: 设置
+command_palette.new_task: 新建任务
+command_palette.open_project: 打开项目…
+command_palette.choose_model: 选择模型…
+command_palette.show_sidebar: 显示侧边栏
+command_palette.hide_sidebar: 隐藏侧边栏
+command_palette.show_right_panel: 显示右侧面板
+command_palette.hide_right_panel: 隐藏右侧面板
+command_palette.current: 当前
+command_palette.you: 你
+command_palette.agent: 智能体
+command_palette.no_results: 未找到匹配的任务或命令
+command_palette.no_results_hint: 可尝试搜索任务标题、消息、项目、设置或命令
+language.title: 语言
+language.system: 跟随系统
+language.description: 选择 Waku 的界面语言
+settings.general: 通用
+settings.appearance: 外观
+settings.providers: 服务商
+settings.usage: 用量
+settings.computer_use: 电脑操作
+settings.general_keywords: 通用 本地 项目 对话 隐私 匿名 使用数据 分析 分享 更新 自动 版本
+settings.appearance_keywords: 外观 主题 系统 浅色 深色 语言 英语 中文 简体
+settings.providers_keywords: 服务商 智能体 模型 命令行 版本 安装 检测 claude codex cursor opencode amp grok pi
+settings.skills: 技能
+settings.skills_keywords: 技能 技能库 智能体 禁用 启用 删除 claude codex cursor opencode pi amp 共享
+settings.usage_keywords: 用量 令牌 费用 支出 缓存 每日 图表 模型 明细 历史 claude codex
+settings.computer_use_keywords: 电脑操作 屏幕录制 辅助功能 应用 控制 codex
+settings.back: 返回
+settings.search: 搜索设置
+settings.theme: 主题
+settings.theme_description: 选择跟随系统、浅色或深色主题
+settings.theme_system: 跟随系统
+settings.theme_light: 浅色
+settings.theme_dark: 深色
+input.do_anything: 做什么都可以…
+input.search_models: 搜索模型…
+input.search_branches: 搜索分支
+input.new_branch_name: 新分支名称
+input.detected_automatically: 自动检测
+input.filter_projects: 筛选项目
+input.search_or_enter_address: 搜索或输入网址
+input.find: 查找
+input.replace: 替换
+common.checking: 正在检查…
+common.refresh: 刷新
+common.recheck: 重新检查
+common.reset: 重置
+common.revoke: 撤销授权
+settings.local_by_default: 默认存储在本地
+settings.local_by_default_description: 项目、对话和设置均存储在这台 Mac 上
+settings.automatic_updates: 自动更新
+settings.automatic_updates_description: 在后台检查新版本，并在发现更新时提示安装
+settings.share_anonymous_usage_data: 分享匿名使用数据
+settings.share_anonymous_usage_data_description: 分享功能使用情况和可靠性数据，帮助改进 Waku。不会包含提示词、回复、项目名称、文件路径等个人信息
+providers.coding_agents: 编程智能体
+providers.description: Waku 调用安装在这台 Mac 上的智能体命令行工具。请先安装相应工具或完成登录，然后刷新
+providers.disabled_for_new_tasks: 新建任务时不可用
+providers.model_count_one: "%{count} 个模型"
+providers.model_count_many: "%{count} 个模型"
+providers.not_detected_as: 未在 PATH 中找到 %{command}
+providers.using_override: 正在使用 %{path}，不再从 PATH 自动检测
+providers.invalid_override: 此路径下没有可执行文件。清空后可恢复从 PATH 自动检测
+providers.detected_at: 已在 %{path} 检测到
+providers.searches_path: Waku 未在 PATH 中找到 %{command}
+providers.binary_path: 可执行文件路径
+providers.binary_path_description: Waku 用于启动 %{provider} 的可执行文件。按 Return 应用；留空则从 PATH 自动检测
+providers.checked_just_now: 刚刚检查过
+providers.checked_minutes_ago: "%{count} 分钟前检查过"
+providers.checked_hours_ago: "%{count} 小时前检查过"
+computer_use.allow_apps: 允许 Waku 操作其他应用
+computer_use.availability: Codex、OpenCode、Grok 和 Pi 支持电脑操作功能
+computer_use.macos_access: macOS 权限
+computer_use.helper_access: 请向 Waku 的独立控制助手 %{helper} 授予权限
+computer_use.screen_recording: 屏幕录制
+computer_use.screen_recording_description: 仅截取已允许应用的窗口
+computer_use.accessibility: 辅助功能
+computer_use.accessibility_description: 获得批准后发送鼠标与键盘操作
+computer_use.always_allowed_apps: 始终允许的应用
+computer_use.always_allowed_apps_description: Waku 会将授权绑定到应用的 Bundle ID 和签名团队
+computer_use.no_always_allowed_apps: 尚未始终允许任何应用。仅限当前任务的授权只会保存在内存中
+computer_use.access_granted: 已授权
+computer_use.grant_access: 授予权限
+computer_use.permission_check_failed: 无法检查电脑操作权限
+common.settings: 设置
+common.remove: 移除
+common.rename: 重命名
+session.new_task: 新任务
+sidebar.today: 今天
+sidebar.search: 搜索
+sidebar.yesterday: 昨天
+sidebar.this_week: 本周
+sidebar.this_month: 本月
+sidebar.this_year: 今年
+sidebar.more: 更早
+sidebar.working: 工作中 · %{elapsed}
+sidebar.just_now: 刚刚
+sidebar.minutes_ago: "%{count} 分钟前"
+sidebar.hours_ago: "%{count} 小时前"
+sidebar.days_ago: "%{count} 天前"
+sidebar.unknown_project: 未知项目
+project.new_project: 新建项目…
+project.no_project: 不使用项目
+project.no_project_name: 无项目
+project.choose_project: 选择项目
+project.project_lower: 项目
+project.without_a_project: 不使用项目
+project.your_project: 你的项目
+onboarding.open_project_to_begin: 打开一个项目即可开始
+onboarding.description: Waku 会在你选择的文件夹中运行编程智能体。代码、任务和历史记录都保留在这台 Mac 上
+onboarding.open_project_folder: 打开项目文件夹…
+onboarding.what_should_we_build: 想构建什么？
+onboarding.what_should_we_build_in: "想在 "
+onboarding.question_mark: " 中构建什么？"
+common.copied: 已复制
+common.copy_message: 复制消息
+common.copy_message_title: 复制消息
+common.copy_selection: 复制所选内容
+common.copy_to_composer: 复制到输入框
+common.copy_code: 复制代码
+common.cancel: 取消
+common.send: 发送
+session.fork_task: 从此处派生任务
+session.fork_task_title: 从此处派生任务
+session.forking_task: 正在派生任务…
+session.forking_task_title: 正在派生任务…
+session.revert_to_here: 回退到这里
+session.revert_to_here_title: 回退到这里
+time.yesterday_at: 昨天 %{time}
+time.weekday_at: "%{weekday} %{time}"
+time.date_at: "%{month}月%{day}日 %{time}"
+time.full_date_at: "%{year}年%{month}月%{day}日 %{time}"
+time.monday: 周一
+time.tuesday: 周二
+time.wednesday: 周三
+time.thursday: 周四
+time.friday: 周五
+time.saturday: 周六
+time.sunday: 周日
+activity.count: "%{count} 次%{activity}"
+activity.running: 正在执行：%{activities}
+activity.ran: 已执行：%{activities}
+activity.arguments: 参数
+activity.output: 输出
+activity.image_output: 图片输出
+activity.search_for: 搜索：%{query}
+activity.searched_web: 已搜索网页
+activity.open_url: 打开 %{url}
+activity.opened_web_page: 已打开网页
+activity.find_in_url: 在 %{url} 中查找 %{pattern}
+activity.find_on_page: 在页面中查找 %{pattern}
+activity.search_within_url: 在 %{url} 中搜索
+activity.searched_within_page: 已在网页内搜索
+activity.browsed_page: 已浏览 %{count} 个页面
+activity.browsed_pages: 已浏览 %{count} 个页面
+activity.browsed_web: 已浏览网页
+activity.exit_code: "退出码：%{code}"
+activity.output_with_exit_code: "%{output}\n\n退出码：%{code}"
+activity.run_command: 运行命令
+activity.running_named_command: 正在运行 %{command}
+activity.ran_named_command: 已运行 %{command}
+activity.named_command_failed: "命令执行失败：%{command}"
+activity.running_command: 正在运行命令
+activity.ran_command: 已运行命令
+activity.command_failed: 命令执行失败
+activity.edit_file: 编辑文件
+activity.write_file: 写入文件
+activity.editing_named_file: 正在编辑 %{file}
+activity.edited_named_file: 已编辑 %{file}
+activity.edit_failed_named_file: 编辑 %{file} 失败
+activity.editing_files: 正在编辑文件
+activity.edited_files: 已编辑文件
+activity.edit_failed: 编辑文件失败
+activity.file_count: "%{count} 个文件"
+activity.read_file: 读取文件
+activity.reading_named_file: 正在读取 %{file}
+activity.read_named_file: 已读取 %{file}
+activity.read_named_file_failed: 读取 %{file} 失败
+activity.reading_file: 正在读取文件
+activity.read_file_completed: 已读取文件
+activity.read_file_failed: 读取文件失败
+activity.search_files: 搜索文件
+activity.find_files: 查找文件
+activity.searching_files_for: 正在文件中搜索 %{query}
+activity.searched_files_for: 已在文件中搜索 %{query}
+activity.file_search_failed_for: 在文件中搜索 %{query} 失败
+activity.searching_files: 正在搜索文件
+activity.searched_files: 已搜索文件
+activity.file_search_failed: 搜索文件失败
+activity.list_files: 列出文件
+activity.listing_files_in: 正在列出 %{directory} 中的文件
+activity.listed_files_in: 已列出 %{directory} 中的文件
+activity.file_list_failed_in: 无法列出 %{directory} 中的文件
+activity.listing_files: 正在列出文件
+activity.listed_files: 已列出文件
+activity.file_list_failed: 无法列出文件
+activity.searching_web_for: 正在网上搜索 %{query}
+activity.searched_web_for: 已在网上搜索 %{query}
+activity.web_search_failed_for: 网上搜索 %{query} 失败
+activity.searching_web: 正在搜索网页
+activity.searched_the_web: 已搜索网页
+activity.web_search_failed: 搜索网页失败
+activity.updating_plan: 正在更新计划
+activity.updated_plan: 已更新计划
+activity.plan_update_failed: 更新计划失败
+activity.activity: 操作
+activity.tool: 工具
+activity.plan_updated: 计划已更新
+activity.output_truncated: "\n\n… 输出已截断"
+activity.thought: 思考
+activity.thoughts: 思考
+activity.command: 命令
+activity.commands: 命令
+activity.file_edit: 文件修改
+activity.file_edits: 文件修改
+activity.file_read: 文件读取
+activity.file_reads: 文件读取
+activity.file_search: 文件搜索
+activity.file_searches: 文件搜索
+activity.file_list: 文件列表
+activity.file_lists: 文件列表
+activity.search: 搜索
+activity.searches: 搜索
+activity.plan_step: 计划步骤
+activity.plan_steps: 计划步骤
+activity.tool_call: 工具调用
+activity.tool_calls: 工具调用
+mode.build: 构建
+mode.plan: 计划
+mode.supervised: 监督
+mode.auto_accept_edits: 自动接受修改
+mode.auto: 自动
+mode.full_access: 完全访问
+mode.plan_description: 仅检查并制定计划，不进行任何修改
+mode.supervised_description: 执行命令或修改文件前先征求许可
+mode.auto_accept_edits_description: 自动批准文件修改，执行其他操作前先询问
+mode.auto_description: 由 AI 审核并批准常规操作；高风险操作仍会询问
+mode.full_access_description: 无需确认即可执行命令和修改文件
+computer_use.allow_for_task: 本次任务允许
+computer_use.always_allow_app: 始终允许此应用
+computer_use.allow_control: 允许 Waku 控制“%{app}”吗？
+computer_use.screenshot_shared: 此窗口的截图将发送给当前使用的 Codex 模型
+computer_use.sensitive_action: 此操作可以输入文字或按下按键
+computer_use.bundle_id: "Bundle ID：%{id}"
+computer_use.no_bundle_id: 此应用没有 Bundle ID，因此无法设为始终允许
+computer_use.stopped: 已停止
+computer_use.controlling: 正在控制
+computer_use.captured: 已截取
+computer_use.take_control: 接管
+computer_use.preparing_preview: 正在准备预览…
+common.deny: 拒绝
+permission.allow_once: 仅允许一次
+permission.allow_for_session: 本次任务允许
+permission.always_allow: 始终允许
+permission.a_tool: 某个工具
+permission.run_a_tool: 运行工具
+permission.run_a_tool_lower: 运行工具
+permission.blocked_path: "路径已被阻止：%{path}"
+permission.agent_wants_to_run: 智能体想要运行 %{tool}
+permission.run_tool: 是否运行 %{tool}？
+permission.allow_named_permission: 是否授予“%{permission}”权限？
+permission.agent_asks_for_named_permission: 智能体正在请求“%{permission}”权限
+permission.agent_asks_for_permission: 智能体正在请求权限
+permission.agent_wants_to: 智能体想要执行 %{action}
+common.close: 关闭
+common.default: 默认
+models.none_found: 未找到模型
+models.favorite_hint: 为模型加星标即可固定在这里
+models.loading: 正在加载模型…
+models.none_reported: 此服务商未提供任何模型
+models.standard: 标准
+models.reasoning: 推理强度
+models.service_tier: 服务等级
+model_option.none: 无
+model_option.minimal: 最低
+model_option.low: 低
+model_option.medium: 中
+model_option.high: 高
+model_option.extra_high: 极高
+model_option.max: 最高
+model_option.ultra: 超高
+model_option.auto: 自动
+model_option.fast: 快速
+model_option.amp_fast_description: 使用 Amp 的快速服务等级，但会消耗更多用量
+model_option.fast_description: 更快获得回复，但会消耗更多用量
+command_scope.project: 项目
+command_scope.user: 用户
+command_scope.skill: 技能
+command_scope.builtin: 内置
+skills.search: 搜索技能…
+skills.count_one: 1 个技能
+skills.count_many: "%{count} 个技能"
+skills.count_disabled: "已禁用 %{count} 个"
+skills.filter_caption: "显示 %{shown} / %{total} 个"
+skills.scanning: 正在扫描技能目录…
+skills.no_match: 没有匹配的技能
+skills.section_user: 用户
+skills.source_shared: 共享
+skills.scope_user_detail: 在所有项目中可用
+skills.scope_in_project: "位于 %{project}"
+skills.filter_all: 全部技能
+skills.select_placeholder: 选择一个技能
+skills.detail_invoke: 调用
+skills.detail_location: 位置
+skills.detail_contents: 内容
+skills.detail_updated: 更新
+skills.no_description: 暂无描述
+skills.disabled_badge: 已禁用
+skills.file_count_one: 1 个附属文件
+skills.file_count_many: "%{count} 个附属文件"
+skills.updated_just_now: 刚刚
+skills.updated_minutes: "%{count} 分钟前"
+skills.updated_hours: "%{count} 小时前"
+skills.updated_days: "%{count} 天前"
+skills.allowed_tools: 工具
+skills.duplicate_one: 另有 1 处同名技能 — 更具体的一份生效
+skills.duplicate_many: "另有 %{count} 处同名技能 — 更具体的一份生效"
+skills.open_file: 打开 SKILL.md
+skills.reveal: 在访达中显示
+skills.copy_path: 复制路径
+skills.path_copied: 已复制路径
+skills.delete: 删除
+skills.confirm_delete: 确认删除
+skills.deleted_toast: "已将“%{name}”移到废纸篓"
+skills.delete_failed: "无法删除技能：%{error}"
+skills.toggle_failed: "无法更新技能：%{error}"
+skills.empty_title: 还没有技能
+skills.empty_description: 技能是一个包含 SKILL.md 的文件夹 — 任何智能体都能加载的可复用指令，例如部署手册或评审清单。为 Claude Code、Codex 等所有智能体安装的技能都会显示在这里，以 /名称 调用。
+commands.init_description: 为此项目创建或更新 %{instructions_file}
+commands.review_description: 审查当前分支中尚未合并的更改
+commands.commit_description: 暂存并提交当前更改
+commands.claude_compact: 总结对话以释放上下文空间
+commands.claude_context: 查看上下文窗口的占用情况
+commands.claude_cost: 查看当前任务的令牌用量与费用
+commands.claude_init: 分析项目并编写 CLAUDE.md
+commands.claude_pr_comments: 获取当前拉取请求的审查意见
+commands.claude_review: 审查拉取请求
+commands.claude_security_review: 对尚未合并的更改进行安全审查
+commands.claude_todos: 列出当前待办事项
+composer.edit_in_composer: 在输入框中编辑
+composer.queued_followups: 已排队的后续消息
+composer.queued_followups_description: 已排队的后续消息 · 当前回复结束后发送
+composer.preparing_task: 正在准备任务…
+composer.steer_turn: 向本轮补充指示（⌘↩）
+composer.queue_followup: 排队为后续消息（⏎）
+branches.detached_head: 游离 HEAD
+branches.search_project: 搜索 %{project} 的分支
+branches.switching: 正在切换…
+branches.create_and_checkout: 创建并切换到新分支
+branches.create_hint: 按 Return 创建 · 按 Esc 取消
+branches.none_found: 未找到分支
+branches.create_and_checkout_ellipsis: 创建并切换到新分支…
+branches.title: 分支
+workspace.work_in: 工作位置
+workspace.local: 本地
+workspace.new_worktree: 新建工作树
+workspace.workspace: 工作区
+workspace.worktree: 工作树
+terminal.starting: 正在启动终端…
+project.add_project: 添加项目
+session.stopped: 已停止
+session.turn_completed: 本轮已完成
+session.stopped_before_response: 智能体在返回回复前停止了
+session.codex_exited_before_response: Codex app-server 在返回回复前退出了
+session.steer_rejected: 无法向智能体补充指示（%{error}）；消息已排队，将作为后续消息发送
+session.agent_ran_out_of_context: 智能体在本轮任务中耗尽了上下文空间
+session.agent_declined_turn: 智能体拒绝执行本轮任务
+session.agent_stopped_reason: "智能体已停止：%{reason}"
+errors.open_session: "无法打开该任务：%{error}"
+errors.create_projectless_task: "无法在 ~/.waku 下创建任务：%{error}"
+errors.save_projectless_migration: "无法保存无项目任务的迁移结果：%{error}"
+errors.move_projectless_task: "无法将旧的根目录无项目任务移至 ~/.waku：%{error}"
+errors.change_branch: "无法切换分支：%{error}"
+errors.capture_pre_turn_checkpoint: "无法创建任务开始前的检查点：%{error}"
+errors.capture_turn_checkpoint: "无法创建本轮任务的检查点：%{error}"
+errors.save_local_state: "无法保存本地状态：%{error}"
+errors.task_project_not_found: 找不到该任务所属的项目
+errors.provider_native_session_unavailable: "%{provider} 的原生会话不可用"
+errors.provider_native_thread_unavailable: "%{provider} 的原生线程不可用"
+errors.provider_native_cursor_unavailable: "%{provider} 的原生会话位置不可用"
+errors.provider_native_thread_cursor_unavailable: "%{provider} 的原生线程位置不可用"
+errors.provider_waku_task_unavailable: "%{provider} 对应的 Waku 任务不可用"
+errors.provider_not_installed: "尚未安装 %{provider}"
+errors.provider_not_found: "尚未安装 %{provider}，或无法找到该程序"
+errors.claude_fork_checkpoint_missing: Claude 未返回派生任务所需的检查点
+errors.claude_turn_checkpoint_unavailable: "Claude 中该轮任务的原生检查点不可用：%{error}"
+errors.pi_session_file_unavailable: Pi 的原生会话文件不可用
+errors.fork_task: "无法派生任务：%{error}"
+errors.create_rewind_snapshot: "无法创建回退前的安全快照：%{error}"
+errors.restore_checkpoint: "无法恢复检查点：%{error}"
+errors.restore_checkpoint_and_safety: "检查点恢复失败（%{error}），安全快照也未能恢复（%{restore_error}）。恢复引用已保留在 %{safety_ref}"
+errors.rollback_rejected_workspace_restored: "服务商拒绝回退，工作区已恢复：%{error}"
+errors.rollback_and_safety_failed: "服务商回退失败（%{error}），安全快照也未能恢复（%{restore_error}）。恢复引用已保留在 %{safety_ref}"
+errors.no_session_selected: 尚未选择任务
+errors.session_not_found: 找不到任务
+errors.project_not_found: 找不到项目
+errors.prepare_task_project_not_found: 无法准备任务：找不到项目
+errors.store_pasted_image: "无法添加粘贴的图片：%{error}"
+errors.create_worktree: "无法创建工作树：%{error}"
+errors.prepared_runtime_unavailable: 已准备的智能体运行环境不可用
+errors.start_agent: "无法启动智能体：%{error}"
+errors.provider_no_active_turn: "%{provider} 当前没有可补充指示的任务"
+errors.provider_transport_write: "%{provider} 通信写入失败：%{error}"
+errors.provider_transport_write_short: "%{provider} 通信写入失败"
+errors.provider_transport_read: "%{provider} 通信读取失败：%{error}"
+errors.provider_invalid_json: "%{provider} 发来了无效的 JSON：%{error}"
+errors.provider_exited: "%{provider} 已退出（%{status}）"
+errors.provider_rpc_exited: "%{provider} RPC 已退出（%{status}）"
+errors.read_provider_exit_status: "无法读取 %{provider} 的退出状态：%{error}"
+errors.initialize_provider: "无法初始化 %{provider}：%{error}"
+errors.provider_no_session_id: "%{provider} 未返回会话 ID"
+errors.provider_rejected_prompt_detail: "%{provider} 拒绝了消息：%{error}"
+errors.stop_provider: "无法停止 %{provider}：%{error}"
+errors.switch_provider_model: "无法切换 %{provider} 模型：%{error}"
+errors.change_provider_thinking: "无法更改 %{provider} 的思考强度：%{error}"
+errors.open_provider_session: "无法打开 %{provider} 会话：%{error}"
+errors.select_model: "无法选择模型：%{error}"
+errors.read_provider_event_stream: "无法读取 %{provider} 事件流：%{error}"
+errors.answer_provider_permission: "无法响应 %{provider} 的权限请求：%{error}"
+errors.initialize_codex_app_server: 无法初始化 Codex app-server
+errors.register_computer_use_skill: 无法向 Codex 注册 Waku 电脑操作技能
+errors.codex_thread_open_incomplete: Codex 未能完成线程打开操作
+errors.provider_receive_prompt: "%{provider} 未能接收消息"
+errors.provider_start_turn: "%{provider} 未能开始本轮"
+errors.provider_rejected_steer: "%{provider} 拒绝了补充指示：%{error}"
+errors.provider_stopped_receiving: "%{provider} 已停止接收消息"
+errors.provider_initialize_session: "%{provider} 未能初始化此任务"
+errors.provider_rejected_prompt: "%{provider} 在开始处理前拒绝了消息"
+errors.provider_complete_turn: "%{provider} 未能完成本轮任务"
+errors.pi_reported_error: Pi 报告了错误
+session.response_unavailable: 该回复已不可用
+session.response_cannot_fork: 目前无法从该回复派生任务
+session.response_fork_in_progress: 请等待任务派生完成后再移除原任务
+session.response_cannot_copy: 无法将该回复复制到新任务中
+session.forked_with_checkpoint_warning: "任务已派生，但部分 Git 检查点未能复制：%{error}"
+session.forked_from_response: 已从该回复派生新任务
+session.message_not_editable: 目前无法编辑该消息
+session.edited_message_empty: 编辑后的消息不能为空
+session.message_unavailable: 该消息已不可用
+session.select_before_rewind: 请先选择该任务，再回退对话
+session.stop_before_rewind: 请先停止当前这一轮，再回退对话
+session.provider_cannot_rewind: "%{provider} 目前还无法安全回退原生会话"
+session.pre_turn_checkpoint_missing: 缺少该消息发送前的 Git 检查点
+session.rewind_title: "%{title}（回退）"
+session.rewound: 已回退到第 %{turn} 轮任务之前
+session.rewound_with_stale_refs: "已回退到第 %{turn} 轮任务之前，但仍有过期引用：%{error}"
+right_panel.browser: 浏览器
+right_panel.terminal: 终端
+right_panel.files: 文件
+right_panel.diff: 审阅
+right_panel.toggle: 显示或隐藏右侧面板
+right_panel.open_surface: 打开一个面板
+right_panel.choose_surface: 选择要在右侧面板中显示的内容
+right_panel.browser_description: 打开本地应用或网址
+right_panel.terminal_description: 在此工作区中启动 Shell
+right_panel.files_description: 浏览并阅读工作区文件
+right_panel.diff_description: 审阅文件更改
+right_panel.terminal_unavailable: 终端不可用
+right_panel.terminal_unavailable_description: 请重新打开终端面板以启动 Shell
+environment.title: 环境
+environment.summary: 环境和后台工作
+environment.changes: 更改
+environment.commit_or_push: 提交或推送
+environment.compare_branch: 比较分支
+commit.message_placeholder: 提交信息（留空以自动生成）…
+commit.include_unstaged: 包含未暂存的更改
+commit.commit: 提交
+commit.commit_and_push: 提交并推送
+commit.push: 推送
+commit.generating_message: 正在生成提交信息…
+commit.committing: 正在提交…
+commit.committing_and_pushing: 正在提交并推送…
+commit.pushing: 正在推送…
+commit.no_task: 没有可提交的任务
+commit.no_workspace: 当前任务没有工作区
+commit.no_changes: 没有可提交的更改
+commit.agent_unavailable: 当前智能体命令行不可用，无法生成提交信息
+commit.committed: 已提交更改
+commit.committed_and_pushed: 已提交并推送更改
+commit.pushed: 已推送更改
+background.title: 后台工作
+background.description: 查看智能体启动的进程和子智能体
+background.processes: 后台进程
+background.agents: 子智能体
+background.process: 进程
+background.monitor: 监控
+background.subagent: 子智能体
+background.no_work: 暂无后台工作
+background.no_work_description: 长时间运行的命令和子智能体显示在这里。
+background.view: 查看
+background.stop: 停止
+background.stop_all: 全部停止
+background.stop_not_running: 该进程已不再运行。
+background.output: 输出
+background.no_output: 暂无输出
+background.command: 命令
+background.prompt: 提示词
+background.cwd: 工作目录
+background.role: 角色
+background.model: 模型
+background.latest_update: 最新进展
+background.exit_code: 退出码
+background.output_truncated: 较早的输出已截断
+background.process_count: "%{count} 个后台进程"
+background.process_count_one: 1 个后台进程
+background.agent_count: "%{count} 个子智能体"
+background.agent_count_one: 1 个子智能体
+background.status.starting: 正在启动
+background.status.running: 正在运行
+background.status.monitoring: 正在监控
+background.status.stopping: 正在停止
+background.status.completed: 已完成
+background.status.failed: 失败
+background.status.stopped: 已停止
+background.status.lost: 已断开
+files.unsaved_changes: 有未保存的更改 — 按 ⌘S 保存
+files.no_project_open: 尚未打开项目
+files.no_project_open_description: 打开一个项目即可浏览其中的文件
+files.no_project_is_open: 尚未打开项目
+files.unable_to_edit: "无法编辑此文件：%{error}"
+files.could_not_save_opening: "无法保存 %{path}：文件仍在打开"
+files.could_not_save_read_only: "无法保存 %{path}：文件不可编辑"
+files.could_not_save: "无法保存 %{path}：%{error}"
+diff.no_changes: 没有更改
+diff.no_changes_description: 此来源没有可审阅的文件更改
+diff.filter_files: 筛选文件…
+diff.source_last_turn: 上一轮
+diff.source_turn: 第 %{turn} 轮
+diff.source_uncommitted: 未提交
+diff.source_unstaged: 未暂存
+diff.source_staged: 已暂存
+diff.source_committed: 已提交
+diff.source_branch: 分支
+diff.loading: 正在加载更改…
+diff.loading_description: 正在捕获一致的 Git 快照以供审阅
+diff.unavailable: 无法查看更改
+diff.refresh: 刷新更改
+diff.refresh_failed: "无法刷新更改：%{error}"
+diff.truncated: 大型差异 · 仅显示前 50,000 行
+diff.unmodified_lines: "%{count} 行未更改"
+diff.expand_all_context: 展开所有未更改的行
+diff.expand_context: 展开未更改的行 · 按住 Shift 点击可全部展开
+diff.expand_context_above: 显示上方 100 行 · 按住 Shift 点击可全部展开
+diff.expand_context_below: 显示下方 100 行 · 按住 Shift 点击可全部展开
+browser.back: 后退（⌘[）
+browser.forward: 前进（⌘]）
+browser.stop_loading: 停止加载（Esc）
+browser.reload: 重新加载（⌘R）
+browser.open_external: 在默认浏览器中打开
+browser.browse_web: 浏览网页
+browser.start_hint: 在上方输入网址或搜索内容 — 按 ⌘L 聚焦地址栏
+browser.unavailable: 浏览器不可用
+browser.requires_macos: 浏览器面板仅支持 macOS
+find.bad_pattern: 表达式无效
+find.no_results: 无结果
+find.result_count: "%{current} / %{total}"
+find.match_case: 区分大小写（⌥⌘C）
+find.match_whole_word: 全字匹配（⌥⌘W）
+find.use_regex: 使用正则表达式（⌥⌘R）
+find.previous_match: 上一个匹配项（⇧Enter）
+find.next_match: 下一个匹配项（Enter）
+find.close: 关闭（Esc）
+find.replace: 替换（Enter）
+find.replace_all: 全部替换（⌥⌘Enter）
+find.toggle_replace: 展开或收起替换栏
+common.dismiss_notification: 关闭通知
+common.reveal_in_finder: 在访达中显示
+attachments.close_preview: 关闭图片预览
+attachments.preview_unavailable: 无法显示图片
+common.copy_named: 复制%{name}
+transcript.worked: 已完成
+transcript.worked_for: 用时 %{duration}
+transcript.you_stopped_after: 你在工作 %{duration} 后停止了
+transcript.working_for: 工作中 · %{duration}
+transcript.thinking: 正在思考
+transcript.thought_for: 思考用时 %{duration}
+transcript.changed_file: 更改了 %{count} 个文件
+transcript.changed_files: 更改了 %{count} 个文件
+transcript.review_changes: 审阅
+transcript.show_more_files: 再显示 %{count} 个文件
+transcript.show_fewer_files: 收起文件列表
+transcript.showing_first_files: 仅显示前 %{count}/%{total} 个
+duration.second: "%{count} 秒"
+duration.seconds: "%{count} 秒"
+duration.minute: "%{count} 分钟"
+duration.minutes: "%{count} 分钟"
+duration.hour: "%{count} 小时"
+duration.hours: "%{count} 小时"
+duration.seconds_short: "%{count} 秒"
+duration.minutes_short: "%{count} 分"
+duration.hours_short: "%{count} 小时"
+duration.two_units: "%{first} %{second}"
+usage.scan_summary: 已扫描 %{scanned} 份对话记录（%{skipped} 份不在所选时段内）· %{records} 条用量记录 · %{seconds} 秒
+usage.daily: 每日
+usage.monthly: 每月
+usage.projects: 项目
+usage.scanning: 正在扫描服务商的对话记录…
+usage.rescan: 重新扫描服务商的对话记录
+usage.range: "%{start} 至 %{end}"
+usage.full_api_rate_note: "* 按完整 API 费率估算"
+usage.sessions_summary: 汇总 %{count} 个任务的输入、缓存读取和输出
+usage.raw_token_cost: 原始令牌费用
+usage.processed_tokens_upper: 已处理令牌
+usage.cost_share: 占费用的 %{share} · %{tokens} 个令牌
+usage.token_share: 占令牌的 %{share} · %{cost}
+usage.no_activity_window: 所选时段内没有活动
+usage.cost_upper: 费用
+usage.tokens_upper: 令牌
+usage.daily_cost: 每日费用
+usage.daily_processed_tokens: 每日已处理令牌
+usage.model_upper: 模型
+usage.day_upper: 日期
+usage.breakdown: 明细
+usage.no_projects_match: 没有符合筛选条件的项目
+usage.by_project: 按项目
+usage.projects_caption: "%{projects} · %{tokens} 个令牌 · %{sessions}"
+usage.projects_shown: "共 %{projects}，当前显示 %{shown} 个"
+usage.percent_of_cost: 占费用的 %{share}
+usage.token_count: "%{count} 个令牌"
+usage.last_active: 最后活跃于 %{date}
+usage.show_models: 查看 %{models}的费用明细
+usage.other_sessions: 其他任务
+usage.rates_unavailable: 模型费率暂不可用；费率表加载完成前，相关费用会显示为未定价
+usage.total: 总计
+usage.processed_tokens: 已处理令牌
+usage.per_active_day: 每个活跃日 %{count}
+usage.cached_input: 缓存输入
+usage.observed_input_share: 占已统计输入的 %{share}
+usage.uncached_input: 未缓存输入
+usage.cache_writes: "%{count} 个缓存写入令牌"
+usage.output: 输出
+usage.includes_reasoning: 其中推理令牌 %{count}
+usage.cache_savings: 缓存节省
+usage.raw_cost_multiple: 相当于原始令牌费用的 %{multiple} 倍
+usage.vs_full_input_rates: 与完整输入费率相比
+usage.model: 模型
+usage.cost: 费用
+usage.share: 占比
+usage.tokens: 令牌
+usage.day: 日期
+usage.cost_quality: 费用可信度
+usage.provider_reported: 服务商报告
+usage.model_priced: 按模型定价
+usage.unpriced: 未定价
+usage.no_activity_12_months: 过去 12 个月内没有活动
+usage.last_12_months: 过去 12 个月
+usage.so_far: 截至目前
+usage.no_activity: 没有活动
+usage.models_by_spend: "%{models} · 按费用排序"
+usage.tokens_and_sessions: "%{tokens} 个令牌 · %{sessions}"
+usage.month_caption: "%{tokens} 个令牌 · %{sessions} · %{days}"
+usage.last_7_days: 过去 7 天
+usage.last_30_days: 过去 30 天
+usage.last_90_days: 过去 90 天
+usage.this_month: 本月
+usage.last_month: 上月
+usage.custom: 自定义
+usage.project_one: "%{count} 个项目"
+usage.project_many: "%{count} 个项目"
+usage.session_one: "%{count} 个任务"
+usage.session_many: "%{count} 个任务"
+usage.model_one: "%{count} 个模型"
+usage.model_many: "%{count} 个模型"
+usage.active_day_one: "%{count} 个活跃日"
+usage.active_day_many: "%{count} 个活跃日"
+usage.refresh_failed: "用量刷新失败：%{error}"
+usage.context_used: 上下文窗口已使用 %{percent}%（⌘U）
+usage.shortcut: 用量（⌘U）
+usage.context_window: 上下文窗口
+usage.plan_limits: 套餐用量限额
+usage.plan_limits_named: 套餐用量限额 · %{plan}
+usage.open_account_settings: 打开账户用量设置
+usage.unavailable: 不可用 — %{error}
+usage.usage_limit: 用量限额
+usage.hour_limit: "%{count} 小时限额"
+usage.day_limit: "%{count} 天限额"
+usage.weekly_limit: 每周限额
+usage.daily_limit: 每日限额
+usage.monthly_limit: 每月限额
+usage.limit_suffix: 限额
+usage.scoped_limit: "%{period} · %{name}"
+usage.weekly_all_models: 每周 · 所有模型
+usage.weekly_model: 每周 · %{model}
+usage.resets_soon: 即将重置
+usage.resets_in_minutes: "%{count} 分钟后重置"
+usage.resets_in_hours: "%{count} 小时后重置"
+usage.resets_in_hours_minutes: "%{hours} 小时 %{minutes} 分钟后重置"
+usage.resets_date: 将于 %{date} 重置
+usage_error.signin_cannot_read: "%{provider} 登录状态无法读取用量（HTTP %{status}）。运行一次 %{provider} 任务后即可刷新"
+usage_error.rate_limited: 用量接口当前受到速率限制，请稍后再试
+usage_error.http_status: 用量接口返回了 HTTP %{status}
+usage_error.invalid_json: 用量接口返回了无效的 JSON
+usage_error.no_home_directory: 找不到用户主目录
+usage_error.read_file: 无法读取 %{path}
+usage_error.codex_auth_invalid: Codex auth.json 不是有效的 JSON
+usage_error.codex_access_token_missing: Codex auth.json 中没有访问令牌；请运行 `codex login`
+usage_error.no_rate_limit_windows: 用量接口未返回任何速率限制周期
+usage_error.start_grok_probe: 无法启动 `grok agent stdio`
+usage_error.grok_stdin_unavailable: Grok 的标准输入不可用
+usage_error.grok_stdout_unavailable: Grok 的标准输出不可用
+usage_error.start_grok_reader: 无法启动 Grok 探测读取器
+usage_error.grok_billing_timeout: Grok 未在规定时间内响应账单请求
+usage_error.grok_answered: "Grok 返回：%{error}"
+usage_error.grok_no_billing_data: Grok 未返回账单数据；请运行 `grok` 登录
+usage_error.claude_credentials_missing: 钥匙串和 ~/.claude 中均未找到 Claude Code 凭据
+usage_error.run_security: 无法运行 /usr/bin/security
+usage_error.keychain_item_missing: 钥匙串中没有 %{service} 项
+usage_error.claude_credentials_invalid: Claude Code 凭据不是有效的 JSON
+usage_error.claude_oauth_missing: Claude Code 凭据中没有 claudeAiOauth 项
+usage_error.claude_access_token_missing: Claude Code 凭据中没有访问令牌
+usage_error.run_curl: 无法运行 /usr/bin/curl
+usage_error.curl_stdin_unavailable: curl 的标准输入不可用
+usage_error.configure_curl: 无法向 curl 传递配置
+usage_error.curl_did_not_finish: curl 未能完成请求
+usage_error.curl_failed: "curl 失败：%{error}"
+usage_error.unknown_error: 未知错误
+usage_error.curl_no_status: curl 未返回 HTTP 状态行

--- a/src/app/components.rs
+++ b/src/app/components.rs
@@ -64,7 +64,7 @@ fn format_message_time_at(created_at: u64, now: DateTime<Local>) -> String {
             let timestamp = timestamp.with_timezone(&Local);
             let message_date = timestamp.date_naive();
             let today = now.date_naive();
-            if crate::i18n::is_simplified_chinese() {
+            if crate::i18n::uses_east_asian_date_format() {
                 let time = timestamp.format("%H:%M").to_string();
                 if message_date >= today {
                     return time;

--- a/src/app/usage_page.rs
+++ b/src/app/usage_page.rs
@@ -2838,7 +2838,7 @@ fn usage_project_path(path: &Path, home: Option<&Path>) -> String {
 
 /// `2026-08-07` → `Aug 7`.
 fn format_day_short(day: NaiveDate) -> String {
-    if crate::i18n::is_simplified_chinese() {
+    if crate::i18n::uses_east_asian_date_format() {
         format!("{}月{}日", day.month(), day.day())
     } else {
         day.format("%b %-d").to_string()
@@ -2847,7 +2847,7 @@ fn format_day_short(day: NaiveDate) -> String {
 
 /// `2026-08-01` → `August 2026`.
 fn format_month(first_day: NaiveDate) -> String {
-    if crate::i18n::is_simplified_chinese() {
+    if crate::i18n::uses_east_asian_date_format() {
         format!("{}年{}月", first_day.year(), first_day.month())
     } else {
         first_day.format("%B %Y").to_string()
@@ -2856,7 +2856,7 @@ fn format_month(first_day: NaiveDate) -> String {
 
 /// `2025-09-01` → `Sep 2025`.
 fn format_month_short(day: NaiveDate) -> String {
-    if crate::i18n::is_simplified_chinese() {
+    if crate::i18n::uses_east_asian_date_format() {
         format!("{}年{}月", day.year(), day.month())
     } else {
         day.format("%b %Y").to_string()

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-/// The language preference Waku persists. `System` resolves to one of the two
+/// The language preference Waku persists. `System` resolves to one of the
 /// locales Waku deliberately ships today.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -8,16 +8,23 @@ pub enum AppLanguage {
     System,
     English,
     SimplifiedChinese,
+    Japanese,
 }
 
 impl AppLanguage {
-    pub const ALL: [Self; 3] = [Self::System, Self::English, Self::SimplifiedChinese];
+    pub const ALL: [Self; 4] = [
+        Self::System,
+        Self::English,
+        Self::SimplifiedChinese,
+        Self::Japanese,
+    ];
 
     pub fn locale(self) -> &'static str {
         match self.resolved() {
             Self::System => unreachable!("system language always resolves to a shipped locale"),
             Self::English => "en",
             Self::SimplifiedChinese => "zh-CN",
+            Self::Japanese => "ja",
         }
     }
 
@@ -28,6 +35,7 @@ impl AppLanguage {
             Self::System => translate("language.system"),
             Self::English => "English".to_owned(),
             Self::SimplifiedChinese => "简体中文".to_owned(),
+            Self::Japanese => "日本語".to_owned(),
         }
     }
 
@@ -46,6 +54,8 @@ impl AppLanguage {
         let locale = locale.replace('_', "-").to_ascii_lowercase();
         if locale == "zh-cn" || locale == "zh-sg" || locale.starts_with("zh-hans") {
             Self::SimplifiedChinese
+        } else if locale == "ja" || locale.starts_with("ja-") {
+            Self::Japanese
         } else {
             Self::English
         }
@@ -66,8 +76,12 @@ pub fn translate(key: &str) -> String {
     rust_i18n::t!(key).into_owned()
 }
 
-pub fn is_simplified_chinese() -> bool {
-    &*rust_i18n::locale() == "zh-CN"
+pub fn uses_east_asian_date_format() -> bool {
+    locale_uses_east_asian_date_format(&rust_i18n::locale())
+}
+
+fn locale_uses_east_asian_date_format(locale: &str) -> bool {
+    matches!(locale, "zh-CN" | "ja")
 }
 
 #[cfg(target_os = "macos")]
@@ -100,16 +114,19 @@ mod tests {
     fn language_locale_ids_are_supported() {
         assert_eq!(AppLanguage::English.locale(), "en");
         assert_eq!(AppLanguage::SimplifiedChinese.locale(), "zh-CN");
+        assert_eq!(AppLanguage::Japanese.locale(), "ja");
         let locales = rust_i18n::available_locales!();
-        assert_eq!(locales.len(), 2);
+        assert_eq!(locales.len(), 3);
         assert!(locales.iter().any(|locale| locale.as_ref() == "en"));
         assert!(locales.iter().any(|locale| locale.as_ref() == "zh-CN"));
+        assert!(locales.iter().any(|locale| locale.as_ref() == "ja"));
     }
 
     #[test]
     fn language_names_are_autonyms() {
         assert_eq!(AppLanguage::English.label(), "English");
         assert_eq!(AppLanguage::SimplifiedChinese.label(), "简体中文");
+        assert_eq!(AppLanguage::Japanese.label(), "日本語");
     }
 
     #[test]
@@ -119,7 +136,23 @@ mod tests {
             serde_json::to_string(&AppLanguage::System).unwrap(),
             r#""system""#
         );
-        assert!(matches!(AppLanguage::System.locale(), "en" | "zh-CN"));
+        assert!(matches!(
+            AppLanguage::System.locale(),
+            "en" | "zh-CN" | "ja"
+        ));
+    }
+
+    #[test]
+    fn japanese_system_locales_are_detected() {
+        assert_eq!(AppLanguage::from_locale_id("ja"), AppLanguage::Japanese);
+        assert_eq!(AppLanguage::from_locale_id("ja_JP"), AppLanguage::Japanese);
+    }
+
+    #[test]
+    fn japanese_and_simplified_chinese_use_east_asian_dates() {
+        assert!(locale_uses_east_asian_date_format("ja"));
+        assert!(locale_uses_east_asian_date_format("zh-CN"));
+        assert!(!locale_uses_east_asian_date_format("en"));
     }
 
     #[test]
@@ -155,6 +188,15 @@ mod tests {
         assert_eq!(
             &*rust_i18n::t!("session.rewound", locale = "zh-CN", turn = 3),
             "已回退到第 3 轮任务之前"
+        );
+        assert_eq!(&*rust_i18n::t!("settings.general", locale = "ja"), "一般");
+        assert_eq!(
+            &*rust_i18n::t!("computer_use.allow_control", locale = "ja", app = "Finder"),
+            "Waku に「Finder」の操作を許可しますか？"
+        );
+        assert_eq!(
+            &*rust_i18n::t!("session.rewound", locale = "ja", turn = 3),
+            "タスクをターン 3 の前まで巻き戻しました"
         );
     }
 

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -702,7 +702,7 @@ pub fn reset_label(resets_at: i64, now: i64) -> String {
     }
     use chrono::TimeZone as _;
     match chrono::Local.timestamp_opt(resets_at, 0) {
-        chrono::LocalResult::Single(date) if crate::i18n::is_simplified_chinese() => tr!(
+        chrono::LocalResult::Single(date) if crate::i18n::uses_east_asian_date_format() => tr!(
             "usage.resets_date",
             date = format!(
                 "{}月{}日 {}",


### PR DESCRIPTION
## Summary

- add Japanese language selection, system-locale detection, and a complete 750-key Japanese catalog
- use the existing East Asian date and time formatting path for Japanese
- split Simplified Chinese into its own locale file and apply wording fixes from a Grok CLI review

## Validation

- verified all three catalogs contain the same 750 keys and matching interpolation placeholders
- reviewed Japanese and Simplified Chinese with the `grok` CLI
- ran `cargo fmt --package waku` and `git diff --check`
- Rust tests were stopped during cold dependency compilation at user request; no visual test was performed