### PR TITLE
Parse the hyphen-separated model list printed by current cursor-agent

### DIFF
--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -182,7 +182,11 @@ fn parse_cursor_models(output: &str) -> Vec<ProviderModel> {
                 .map(str::trim)
                 .unwrap_or(line);
             let is_default = line.to_ascii_lowercase().contains("(default)");
-            let line = line.replace("(default)", "").replace("(Default)", "");
+            let line = line
+                .replace("(default)", "")
+                .replace("(Default)", "")
+                .replace("(current)", "")
+                .replace("(Current)", "");
             let line = line.trim();
             if line.is_empty() || line.contains("Usage:") || line.contains("error:") {
                 return None;
@@ -190,6 +194,7 @@ fn parse_cursor_models(output: &str) -> Vec<ProviderModel> {
             let (id, label) = line
                 .split_once('\t')
                 .or_else(|| line.split_once("  "))
+                .or_else(|| line.split_once(" - "))
                 .map(|(id, label)| (id.trim(), label.trim()))
                 .filter(|(id, _)| !id.is_empty())
                 .unwrap_or((line, line));
@@ -789,6 +794,32 @@ mod tests {
         assert!(models[0].is_default);
         assert_eq!(models[1].id, "composer-2.5");
         assert_eq!(models[1].name, "Composer 2.5");
+    }
+
+    #[test]
+    fn parses_cursor_cli_hyphen_separated_models() {
+        // The format printed by cursor-agent since at least 2026.08.04:
+        // `id - Label`, with `(default)` and `(current)` suffixes.
+        let models = parse_cursor_models(
+            "Available models\n\nauto - Auto (default)\ngpt-5.3-codex-low - Codex 5.3 Low\ncomposer-2.5 - Composer 2.5 (current)\nclaude-opus-5-thinking-high - Opus 5 1M Thinking\n",
+        );
+        assert_eq!(
+            models
+                .iter()
+                .map(|model| model.id.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "auto",
+                "gpt-5.3-codex-low",
+                "composer-2.5",
+                "claude-opus-5-thinking-high"
+            ]
+        );
+        assert!(models[0].is_default);
+        assert_eq!(models[0].name, "Auto");
+        assert_eq!(models[1].name, "Codex 5.3 Low");
+        assert_eq!(models[2].name, "Composer 2.5");
+        assert!(!models[2].is_default);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The Cursor model picker shows only one model, **Auto**, even though `cursor-agent models` lists ~190.

Current cursor-agent (observed on 2026.08.04-aaa8809) prints its inventory as:

```
Available models

auto - Auto (default)
gpt-5.3-codex-low - Codex 5.3 Low
composer-2.5 - Composer 2.5 (current)
```

`parse_cursor_models` only splits id from label on a tab or two consecutive spaces. With the ` - ` separator neither matches, the whole line becomes the candidate id, the `id.split_whitespace().count() != 1` guard rejects it, and discovery returns empty. The catalog then falls back to the provider-owned `auto`-only list — which is exactly the single model users see. On an affected machine, `~/Library/Caches/Waku/models/` has catalogs for every provider except `cursor.json`, since Cursor discovery has never succeeded.

## Solution

- Accept ` - ` as an id/label separator, after the existing tab and double-space splits so the older formats keep their precedence.
- Strip the `(current)` marker the same way `(default)` is stripped, so it can't leak into a display label.

Added a regression test with the current CLI output shape; the existing legacy-format and fallback tests still pass.

## Checks

- `cargo fmt --package waku -- --check`
- `cargo check`
- `cargo test` — 547 passed, 0 failed
- Parser verified against the verbatim output of a live `cursor-agent models` run: 0 models parsed before, 193 after, with clean ids and `auto` as the only default.
- Validated in the rebuilt `Waku Debug.app` (`bun run dev`): the debug model cache (`temp/model-cache/cursor.json`) fills with all 193 discovered models.

## Limitations

Cursor's plain-text output remains an unversioned contract; if the CLI changes format again the parser may need another variant. A JSON source (e.g. the ACP `session/new` `models` field) would be sturdier, but that felt larger than a bug fix — happy to follow up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)