### PR TITLE
Fix composer crash when an IME composes after multi-byte text

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1485,6 +1485,15 @@ impl ComposerInput {
         self.offset_from_utf16(range.start)..self.offset_from_utf16(range.end)
     }
 
+    /// Resolves a range whose endpoints count UTF-16 units from `base`, the
+    /// form macOS uses for everything relative to the marked text. The offsets
+    /// have to be added in UTF-16 before the conversion; converting first and
+    /// adding to `base` overshoots once anything multi-byte precedes it.
+    fn range_from_relative_utf16(&self, base: usize, range: &Range<usize>) -> Range<usize> {
+        let base_utf16 = self.offset_to_utf16(base);
+        self.range_from_utf16(&(base_utf16 + range.start..base_utf16 + range.end))
+    }
+
     fn previous_boundary(&self, offset: usize) -> usize {
         self.content
             .grapheme_indices(true)
@@ -1623,9 +1632,7 @@ impl EntityInputHandler for ComposerInput {
         // text is it absolute.
         let range = match (range_utf16.as_ref(), self.marked_range.as_ref()) {
             (Some(range_utf16), Some(marked)) => {
-                let base = self.offset_to_utf16(marked.start);
-                let absolute =
-                    self.range_from_utf16(&(base + range_utf16.start..base + range_utf16.end));
+                let absolute = self.range_from_relative_utf16(marked.start, range_utf16);
                 absolute.start.clamp(marked.start, marked.end)
                     ..absolute.end.clamp(marked.start, marked.end)
             }
@@ -1644,10 +1651,11 @@ impl EntityInputHandler for ComposerInput {
         if self.marked_range.is_none() {
             self.history.finalize_composition();
         }
+        // The composition's selection is also relative to the marked text,
+        // which now starts at `range.start`.
         self.selected_range = new_selected_range_utf16
             .as_ref()
-            .map(|range| self.range_from_utf16(range))
-            .map(|new_range| new_range.start + range.start..new_range.end + range.start)
+            .map(|new_range| self.range_from_relative_utf16(range.start, new_range))
             .unwrap_or_else(|| {
                 let offset = range.start + new_text.len();
                 offset..offset
@@ -2316,8 +2324,9 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use gpui::{
-        ClipboardEntry, ClipboardItem, Context, Entity, ExternalPaths, Image, ImageFormat, Pixels,
-        Render, TestAppContext, TextRun, Window, div, font, hsla, prelude::*, px,
+        ClipboardEntry, ClipboardItem, Context, Entity, EntityInputHandler, ExternalPaths, Image,
+        ImageFormat, Pixels, Render, TestAppContext, TextRun, Window, div, font, hsla, prelude::*,
+        px,
     };
 
     use super::TokenClass;
@@ -2756,6 +2765,47 @@ mod tests {
         assert_eq!(word_range_at(text, 9), 8..13);
         assert_eq!(word_range_at(text, 14), 14..text.len());
         assert_eq!(word_range_at(text, text.len()), text.len()..text.len());
+    }
+
+    /// ASCII keeps UTF-16 and UTF-8 offsets in step, so composing after it has
+    /// to land exactly where it always did.
+    #[gpui::test]
+    fn ime_composition_after_ascii_keeps_its_caret(cx: &mut TestAppContext) {
+        let (input, cx) = setup_input(cx, "hi", px(300.));
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(2..2, cx)));
+
+        cx.update(|window, cx| {
+            input.update(cx, |input, cx| {
+                input.replace_and_mark_text_in_range(None, "k", Some(1..1), window, cx);
+            })
+        });
+
+        cx.read_entity(&input, |input, _| {
+            assert_eq!(input.content(), "hik");
+            assert_eq!(input.marked_range, Some(2..3));
+            assert_eq!(input.selected_range, 3..3);
+        });
+    }
+
+    /// Multi-byte content ahead of the composition makes UTF-16 and UTF-8
+    /// offsets diverge, which used to place the caret past the end of the
+    /// content and abort the next slice.
+    #[gpui::test]
+    fn ime_selection_stays_inside_content_after_multibyte_text(cx: &mut TestAppContext) {
+        let (input, cx) = setup_input(cx, "あ", px(300.));
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(3..3, cx)));
+
+        cx.update(|window, cx| {
+            input.update(cx, |input, cx| {
+                input.replace_and_mark_text_in_range(None, "k", Some(1..1), window, cx);
+            })
+        });
+
+        cx.read_entity(&input, |input, _| {
+            assert_eq!(input.content(), "あk");
+            assert_eq!(input.marked_range, Some(3..4));
+            assert_eq!(input.selected_range, 4..4);
+        });
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`ComposerInput::replace_and_mark_text_in_range` placed the composition's caret with

```rust
.map(|range| self.range_from_utf16(range))
.map(|new_range| new_range.start + range.start..new_range.end + range.start)
```

macOS counts `new_selected_range_utf16` in UTF-16 units from the start of the marked text. The code resolved that relative offset against the whole content and then added the marked start as a UTF-8 offset. The two offset spaces only agree while the content is ASCII, which is why typing romaji into an empty composer never hit this.

Put one multi-byte character in front of the composition and they diverge. With `"あ"` already in the composer, typing `k` produces content `"あk"` — 4 bytes — and a selected range of `6..6`. Slicing that range panics, and because the call arrives on the input method's thread, the process aborts mid-keystroke.

## Before / After

<!-- before -->

<!-- after -->

## The fix

Add the offsets in UTF-16 before converting them.

The replacement range a few lines above already did this correctly, so both now go through one helper rather than leaving two spellings of the same operation in a single function:

```rust
fn range_from_relative_utf16(&self, base: usize, range: &Range<usize>) -> Range<usize> {
    let base_utf16 = self.offset_to_utf16(base);
    self.range_from_utf16(&(base_utf16 + range.start..base_utf16 + range.end))
}
```

The replacement-range call site is unchanged in behavior — the extracted body is the same three operations in the same order.

## Crash evidence

Seven reports in `~/Library/Logs/DiagnosticReports` from the released build share one signature: `EXC_CRASH (SIGABRT)` on the thread named `(input method 767 com.google.inputmethod.Japanese)`, entering Waku through `-[NSTextInputContext setMarkedText:selectedRange:replacementRange:completionHandler:]`. That binary is stripped, so its Waku frames are unsymbolicated.

The debug build from the dev watcher on `main` produces the same signature — that is what the "before" recording above shows. Its frames symbolicate to `gpui_macos::window::handle_key_event` reaching `std::panicking::panic_with_hook`, which places the abort in a Rust panic on the input method's thread. The `input.rs` frames are folded away by inlining in the `dev` profile (`optimized + debuginfo`), so the failing line comes from the regression test rather than from the report.

## Verification

Both offset expressions depend only on the content, so the old and new ones were evaluated over every char boundary of 16 content fixtures (ASCII, kana, emoji, embedded newlines) against every relative UTF-16 range — 2504 combinations:

|                                        | before | after |
| -------------------------------------- | ------ | ----- |
| result outside the content bounds      | 1530   | 0     |
| differs while the old range was valid  | —      | 77    |
| of those, ASCII before the composition | —      | 0     |

Every divergence has multi-byte text ahead of the composition. ASCII content resolves exactly as it did before.

Two regression tests cover both halves of that table:

- `ime_composition_after_ascii_keeps_its_caret` passes on the old code as well, and pins the path this change must not move
- `ime_selection_stays_inside_content_after_multibyte_text` fails on the old code with `6..6` over 4 bytes of content

Checks:

- `cargo fmt --package waku -- --check`
- `cargo check`
- `cargo test` — 536 passed
- Debug app from the dev watcher, composing Japanese with Google Japanese Input

One test fails on `main` as well, unrelated to this change: `every_provider_offers_slash_commands_out_of_the_box`. `discover_slash_commands` reads the real home directory, so a `~/.claude/skills/review` on the machine shadows Waku's built-in `/review` template and the assertion on `template.is_some()` fails. The product behavior looks right — a user's own command should win — and it is the test that needs to isolate the home directory. Happy to send that as a separate PR.

## Known limitation

`offset_from_utf16` rounds an offset landing inside a surrogate pair to the right, so a range splitting an emoji resolves to an empty range where Zed clips with `Bias::Left` / `Bias::Right`. It predates this change, it cannot move a range out of bounds or off a char boundary, and I could not construct a real IME sequence that reaches it — so it is left alone here rather than widening this PR.

---

Release-note line if it is useful, worded however you prefer:

- Fixed a crash when an IME composed text after existing multi-byte content.
