### PR TITLE
feat: CLI entrypoint for projects and sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,10 +220,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -1033,6 +1077,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1211,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -3400,6 +3490,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4550,6 +4646,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oo7"
@@ -6592,6 +6694,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7471,6 +7579,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "util_macros"
 version = "0.1.0"
 source = "git+https://github.com/egoist/zed?branch=waku-webview#f9bad8941ea813982d6dfb10c0377ebf7716b3e7"
@@ -7621,6 +7735,7 @@ dependencies = [
  "base64",
  "block2 0.6.2",
  "chrono",
+ "clap",
  "crossbeam-channel",
  "dirs",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-only"
 [dependencies]
 alacritty_terminal = { version = "0.26", default-features = false }
 anyhow = "1.0"
+clap = { version = "4", features = ["derive"] }
 base64 = "0.22"
 chrono = "0.4"
 crossbeam-channel = "0.5"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ structured protocol and session continuity.
 - Rewind Git-backed tasks with conversation-aware checkpoints.
 - Store app state locally, with no Waku account or remote service required.
 
+## CLI
+
+The `waku` binary also exposes a local control surface for projects and sessions
+(useful for agents and scripts). When the desktop app is running, commands talk
+to it over a Unix socket beside the app database; otherwise they read and write
+SQLite directly.
+
+```sh
+waku list-projects
+waku new-project --path ~/code/my-app --name my-app
+waku list-sessions --project my-app
+waku new-session --project my-app --provider pi --model ...
+waku open <project-or-session>
+waku link-session --session <session-id> --project my-app
+```
+
+See `waku --help` and each subcommand's `--help` for flags.
+
 ## Development
 
 Development currently requires macOS, [Rust 1.96 or newer](https://www.rust-lang.org/tools/install),

--- a/src/app.rs
+++ b/src/app.rs
@@ -980,6 +980,8 @@ pub struct Waku {
     /// Coalesced edge trigger for provider and background result queues. The
     /// payloads stay in their typed channels; this channel only wakes the UI.
     event_wake_tx: smol::channel::Sender<()>,
+    /// CLI/app-control requests arriving on `control.sock`.
+    control_events: Receiver<crate::control::PendingControl>,
     runtimes: HashMap<Uuid, SessionRuntime>,
     /// Provider-neutral session work which may remain live after a turn ends.
     /// Runtime-only by design: providers reconcile their authoritative state
@@ -1709,6 +1711,8 @@ impl Waku {
         let (computer_permission_tx, computer_permission_events) = unbounded();
         let (plan_usage_tx, plan_usage_events) = unbounded();
         let (event_wake_tx, event_wake_events) = smol::channel::bounded(1);
+        let (control_tx, control_events) = unbounded::<crate::control::PendingControl>();
+        crate::control::spawn_server(state_path.clone(), control_tx, event_wake_tx.clone());
         {
             let computer_permission_tx = computer_permission_tx.clone();
             let event_wake = event_wake_tx.clone();
@@ -2244,6 +2248,7 @@ impl Waku {
                 image_preview: None,
                 image_preview_generation: 0,
                 event_wake_tx,
+                control_events,
                 runtimes: HashMap::new(),
                 background_work: HashMap::new(),
                 last_background_work_tick: Instant::now(),

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -2501,6 +2501,7 @@ impl Waku {
             | self.drain_provider_detection_events()
             | self.drain_computer_permission_events()
             | self.drain_plan_usage_events()
+            | self.drain_control_events(cx)
         {
             cx.notify();
         }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -1090,6 +1090,54 @@ impl Waku {
     }
 }
 
+
+impl Waku {
+    pub(super) fn drain_control_events(&mut self, cx: &mut Context<Self>) -> bool {
+        let mut changed = false;
+        while let Ok(pending) = self.control_events.try_recv() {
+            let response = self.handle_control_request(pending.request, cx);
+            let _ = pending.reply.send(response);
+            changed = true;
+        }
+        changed
+    }
+
+    fn handle_control_request(
+        &mut self,
+        request: crate::control::ControlRequest,
+        cx: &mut Context<Self>,
+    ) -> crate::control::ControlResponse {
+        let focus = matches!(request, crate::control::ControlRequest::Open { .. });
+        match crate::cli::apply_to_state(&mut self.state, request) {
+            Ok(data) => {
+                if let Some(session_id) = self.state.selected_session.filter(|session_id| {
+                    self.state
+                        .sessions
+                        .iter()
+                        .any(|session| session.id == *session_id)
+                }) {
+                    self.select_session(session_id, cx);
+                } else if let Some(project_id) = self.state.selected_project.filter(|project_id| {
+                    self.state
+                        .projects
+                        .iter()
+                        .any(|project| project.id == *project_id)
+                }) {
+                    self.select_project(project_id, cx);
+                } else {
+                    self.save();
+                    cx.notify();
+                }
+                if focus {
+                    cx.activate(true);
+                }
+                crate::control::ControlResponse::ok_data(data)
+            }
+            Err(error) => crate::control::ControlResponse::err(error),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,13 +161,21 @@ fn resolve_path(path: Option<PathBuf>) -> Result<PathBuf, String> {
 
 fn run_offline(request: ControlRequest) -> Result<ControlResponse, String> {
     let store = StateStore::new(StateStore::default_path());
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let mut state = store.load_or_fresh(cwd);
+    let mut state = load_cli_state(&store);
     let data = apply_to_state(&mut state, request)?;
     store
         .save(&mut state)
         .map_err(|error| format!("save state: {error}"))?;
     Ok(ControlResponse::ok_data(data))
+}
+
+/// Load persisted state for CLI use without inventing a runtime draft session.
+fn load_cli_state(store: &StateStore) -> PersistedState {
+    let mut state = store.load().unwrap_or_else(|_| PersistedState::empty());
+    for session in &mut state.sessions {
+        let _ = store.hydrate(session);
+    }
+    state
 }
 
 /// Apply a control request to persisted state. Shared by the offline CLI path
@@ -197,10 +205,7 @@ pub fn apply_to_state(
             let id = project.id;
             let json = project_json(&project);
             state.projects.push(project);
-            let session = state.new_session(id, state.last_provider);
             state.selected_project = Some(id);
-            state.selected_session = Some(session.id);
-            state.push_session(session);
             Ok(json)
         }
         ControlRequest::ListSessions { project } => {
@@ -231,10 +236,16 @@ pub fn apply_to_state(
                 Some(value) => resolve_project_id(state, &value)?,
                 None => ensure_projectless_project(state)?,
             };
+            // Reuse an unstarted draft only when it matches the requested
+            // provider. An explicit `--provider` that differs always creates.
             if let Some(existing) = state
                 .sessions
                 .iter()
-                .find(|session| session.project_id == project_id && !session.has_started())
+                .find(|session| {
+                    session.project_id == project_id
+                        && !session.has_started()
+                        && session.provider == provider
+                })
                 .map(|session| session.id)
             {
                 state.selected_project = Some(project_id);
@@ -247,6 +258,7 @@ pub fn apply_to_state(
                 return Ok(session_json(state, session));
             }
             let mut session = state.new_session(project_id, provider);
+            session.persist_draft = true;
             if let Some(model) = model.filter(|value| !value.trim().is_empty()) {
                 session.model = Some(model);
             }
@@ -386,6 +398,7 @@ fn session_json_with_prompt(
 mod tests {
     use super::*;
     use crate::control::ControlRequest;
+    use crate::model::ProviderKind;
 
     #[test]
     fn new_project_and_list_round_trip() {
@@ -401,9 +414,120 @@ mod tests {
         )
         .unwrap();
         assert_eq!(created["name"], "Demo");
+        assert!(state.sessions.is_empty(), "new-project must not create a session");
         let listed = apply_to_state(&mut state, ControlRequest::ListProjects).unwrap();
         assert_eq!(listed.as_array().unwrap().len(), 1);
         let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn new_session_respects_provider_and_persists_draft() {
+        let mut state = PersistedState::empty();
+        let path = std::env::temp_dir().join(format!("waku-cli-sess-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&path).unwrap();
+        apply_to_state(
+            &mut state,
+            ControlRequest::NewProject {
+                name: Some("Demo".into()),
+                path: path.clone(),
+            },
+        )
+        .unwrap();
+        let created = apply_to_state(
+            &mut state,
+            ControlRequest::NewSession {
+                project: Some("Demo".into()),
+                provider: Some("pi".into()),
+                model: None,
+                prompt: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(created["provider"], "pi");
+        assert_eq!(state.sessions.len(), 1);
+        assert!(state.sessions[0].persist_draft);
+        assert_eq!(state.sessions[0].provider, ProviderKind::Pi);
+        let session_id = state.sessions[0].id;
+
+        // Same provider draft is reused.
+        let again = apply_to_state(
+            &mut state,
+            ControlRequest::NewSession {
+                project: Some("Demo".into()),
+                provider: Some("pi".into()),
+                model: None,
+                prompt: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(again["id"], session_id.to_string());
+        assert_eq!(state.sessions.len(), 1);
+
+        // Different provider creates a second draft.
+        let other = apply_to_state(
+            &mut state,
+            ControlRequest::NewSession {
+                project: Some("Demo".into()),
+                provider: Some("codex".into()),
+                model: None,
+                prompt: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(other["provider"], "codex");
+        assert_eq!(state.sessions.len(), 2);
+
+        let listed = apply_to_state(&mut state, ControlRequest::ListSessions { project: None })
+            .unwrap();
+        assert_eq!(listed.as_array().unwrap().len(), 2);
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn cli_session_survives_save_and_reload() {
+        let directory = std::env::temp_dir().join(format!("waku-cli-db-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&directory).unwrap();
+        let db = directory.join("app.db");
+        let store = StateStore::new(db);
+        let project_path = directory.join("repo");
+        std::fs::create_dir_all(&project_path).unwrap();
+
+        let mut state = PersistedState::empty();
+        apply_to_state(
+            &mut state,
+            ControlRequest::NewProject {
+                name: Some("Demo".into()),
+                path: project_path,
+            },
+        )
+        .unwrap();
+        let created = apply_to_state(
+            &mut state,
+            ControlRequest::NewSession {
+                project: Some("Demo".into()),
+                provider: Some("pi".into()),
+                model: None,
+                prompt: None,
+            },
+        )
+        .unwrap();
+        let session_id = created["id"].as_str().unwrap().to_owned();
+        store.save(&mut state).unwrap();
+
+        let mut reloaded = store.load().unwrap();
+        for session in &mut reloaded.sessions {
+            store.hydrate(session).unwrap();
+        }
+        assert_eq!(reloaded.sessions.len(), 1);
+        assert_eq!(reloaded.sessions[0].id.to_string(), session_id);
+        assert_eq!(reloaded.sessions[0].provider, ProviderKind::Pi);
+        assert!(reloaded.sessions[0].persist_draft);
+        assert!(!reloaded.sessions[0].has_started());
+
+        let listed = apply_to_state(&mut reloaded, ControlRequest::ListSessions { project: None })
+            .unwrap();
+        assert_eq!(listed.as_array().unwrap()[0]["id"], session_id);
+        let _ = std::fs::remove_dir_all(directory);
     }
 
     #[test]
@@ -426,6 +550,16 @@ mod tests {
             ControlRequest::NewProject {
                 name: Some("B".into()),
                 path: b.clone(),
+            },
+        )
+        .unwrap();
+        apply_to_state(
+            &mut state,
+            ControlRequest::NewSession {
+                project: Some("A".into()),
+                provider: Some("pi".into()),
+                model: None,
+                prompt: None,
             },
         )
         .unwrap();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,455 @@
+//! Command-line entrypoint for project/session control (`waku …`).
+//!
+//! Prefer the running app's control socket when present so in-memory UI state
+//! stays authoritative. Fall back to direct SQLite access when the app is not
+//! running.
+
+use std::path::PathBuf;
+use clap::{Parser, Subcommand};
+use uuid::Uuid;
+
+use crate::control::{
+    ControlRequest, ControlResponse, parse_provider, parse_uuid, try_request,
+};
+use crate::model::{AgentSession, Project};
+use crate::persistence::{PersistedState, StateStore};
+use crate::projectless;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "waku",
+    about = "Control Waku projects and sessions from the terminal",
+    disable_help_subcommand = true
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Create a project from a directory path
+    NewProject {
+        /// Display name (defaults to the directory name)
+        #[arg(long)]
+        name: Option<String>,
+        /// Project directory (defaults to the current working directory)
+        #[arg(long)]
+        path: Option<PathBuf>,
+    },
+    /// List projects
+    ListProjects,
+    /// Focus a project or session in the running app
+    Open {
+        /// Project/session id or project name
+        target: String,
+    },
+    /// Create a session
+    NewSession {
+        /// Project id or name (omit for a projectless task)
+        #[arg(long)]
+        project: Option<String>,
+        /// Provider id: amp, claude, codex, cursor, opencode, grok, pi
+        #[arg(long)]
+        provider: Option<String>,
+        /// Model id for the new session
+        #[arg(long)]
+        model: Option<String>,
+        /// Optional first prompt text stored as the draft title hint
+        #[arg(long)]
+        prompt: Option<String>,
+    },
+    /// List sessions
+    ListSessions {
+        /// Limit to a project id or name
+        #[arg(long)]
+        project: Option<String>,
+    },
+    /// Attach an existing session to another project
+    LinkSession {
+        /// Session id
+        #[arg(long)]
+        session: String,
+        /// Destination project id or name
+        #[arg(long)]
+        project: String,
+    },
+}
+
+/// True when argv looks like a CLI invocation rather than launching the GUI.
+pub fn wants_cli(args: &[String]) -> bool {
+    let Some(first) = args.get(1).map(String::as_str) else {
+        return false;
+    };
+    matches!(
+        first,
+        "-h" | "--help" | "-V" | "--version" | "help"
+            | "new-project"
+            | "list-projects"
+            | "open"
+            | "new-session"
+            | "list-sessions"
+            | "link-session"
+    )
+}
+
+pub fn main() -> Result<(), String> {
+    run(Cli::parse())
+}
+
+fn run(cli: Cli) -> Result<(), String> {
+    let request = match cli.command {
+        Commands::ListProjects => ControlRequest::ListProjects,
+        Commands::NewProject { name, path } => {
+            let path = resolve_path(path)?;
+            ControlRequest::NewProject { name, path }
+        }
+        Commands::ListSessions { project } => ControlRequest::ListSessions { project },
+        Commands::NewSession {
+            project,
+            provider,
+            model,
+            prompt,
+        } => ControlRequest::NewSession {
+            project,
+            provider,
+            model,
+            prompt,
+        },
+        Commands::Open { target } => ControlRequest::Open { target },
+        Commands::LinkSession { session, project } => ControlRequest::LinkSession { session, project },
+    };
+
+    let response = if let Some(response) = try_request(&request) {
+        response
+    } else {
+        match &request {
+            ControlRequest::Open { .. } => {
+                // Persist selection so the next launch focuses it; focus needs the app.
+                let response = run_offline(request)?;
+                eprintln!("note: Waku is not running; selection was saved for the next launch");
+                response
+            }
+            _ => run_offline(request)?,
+        }
+    };
+
+    if !response.ok {
+        return Err(response.error.unwrap_or_else(|| "request failed".into()));
+    }
+    if let Some(data) = response.data {
+        println!("{}", serde_json::to_string_pretty(&data).map_err(|e| e.to_string())?);
+    }
+    Ok(())
+}
+
+fn resolve_path(path: Option<PathBuf>) -> Result<PathBuf, String> {
+    let path = path.unwrap_or(std::env::current_dir().map_err(|e| e.to_string())?);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir()
+            .map_err(|e| e.to_string())?
+            .join(path)
+    };
+    let path = path.canonicalize().unwrap_or(path);
+    if !path.is_dir() {
+        return Err(format!("project path is not a directory: {}", path.display()));
+    }
+    Ok(path)
+}
+
+fn run_offline(request: ControlRequest) -> Result<ControlResponse, String> {
+    let store = StateStore::new(StateStore::default_path());
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let mut state = store.load_or_fresh(cwd);
+    let data = apply_to_state(&mut state, request)?;
+    store
+        .save(&mut state)
+        .map_err(|error| format!("save state: {error}"))?;
+    Ok(ControlResponse::ok_data(data))
+}
+
+/// Apply a control request to persisted state. Shared by the offline CLI path
+/// and the in-app control handler.
+pub fn apply_to_state(
+    state: &mut PersistedState,
+    request: ControlRequest,
+) -> Result<serde_json::Value, String> {
+    match request {
+        ControlRequest::ListProjects => Ok(serde_json::json!(
+            state
+                .projects
+                .iter()
+                .filter(|project| !project.is_projectless())
+                .map(project_json)
+                .collect::<Vec<_>>()
+        )),
+        ControlRequest::NewProject { name, path } => {
+            if let Some(existing) = state.projects.iter().find(|project| project.path == path) {
+                state.selected_project = Some(existing.id);
+                return Ok(project_json(existing));
+            }
+            let mut project = Project::from_path(path);
+            if let Some(name) = name.filter(|value| !value.trim().is_empty()) {
+                project.name = name;
+            }
+            let id = project.id;
+            let json = project_json(&project);
+            state.projects.push(project);
+            let session = state.new_session(id, state.last_provider);
+            state.selected_project = Some(id);
+            state.selected_session = Some(session.id);
+            state.push_session(session);
+            Ok(json)
+        }
+        ControlRequest::ListSessions { project } => {
+            let project_id = match project {
+                Some(value) => Some(resolve_project_id(state, &value)?),
+                None => None,
+            };
+            Ok(serde_json::json!(
+                state
+                    .sessions
+                    .iter()
+                    .filter(|session| project_id.is_none_or(|id| session.project_id == id))
+                    .map(|session| session_json(state, session))
+                    .collect::<Vec<_>>()
+            ))
+        }
+        ControlRequest::NewSession {
+            project,
+            provider,
+            model,
+            prompt,
+        } => {
+            let provider = match provider {
+                Some(value) => parse_provider(&value)?,
+                None => state.last_provider,
+            };
+            let project_id = match project {
+                Some(value) => resolve_project_id(state, &value)?,
+                None => ensure_projectless_project(state)?,
+            };
+            if let Some(existing) = state
+                .sessions
+                .iter()
+                .find(|session| session.project_id == project_id && !session.has_started())
+                .map(|session| session.id)
+            {
+                state.selected_project = Some(project_id);
+                state.selected_session = Some(existing);
+                let session = state
+                    .sessions
+                    .iter()
+                    .find(|session| session.id == existing)
+                    .expect("session just resolved");
+                return Ok(session_json(state, session));
+            }
+            let mut session = state.new_session(project_id, provider);
+            if let Some(model) = model.filter(|value| !value.trim().is_empty()) {
+                session.model = Some(model);
+            }
+            let prompt = prompt.filter(|value| !value.trim().is_empty());
+            let id = session.id;
+            state.last_provider = provider;
+            state.selected_project = Some(project_id);
+            state.selected_session = Some(id);
+            let json = session_json_with_prompt(state, &session, prompt.as_deref());
+            state.push_session(session);
+            Ok(json)
+        }
+        ControlRequest::Open { target } => {
+            if let Ok(id) = parse_uuid(&target) {
+                if state.sessions.iter().any(|session| session.id == id) {
+                    let project_id = state
+                        .sessions
+                        .iter()
+                        .find(|session| session.id == id)
+                        .map(|session| session.project_id);
+                    state.selected_session = Some(id);
+                    if let Some(project_id) = project_id {
+                        state.selected_project = Some(project_id);
+                    }
+                    return Ok(serde_json::json!({ "opened": "session", "id": id }));
+                }
+                if state.projects.iter().any(|project| project.id == id) {
+                    state.selected_project = Some(id);
+                    return Ok(serde_json::json!({ "opened": "project", "id": id }));
+                }
+                return Err(format!("no project or session with id `{target}`"));
+            }
+            let project_id = resolve_project_id(state, &target)?;
+            state.selected_project = Some(project_id);
+            Ok(serde_json::json!({ "opened": "project", "id": project_id }))
+        }
+        ControlRequest::LinkSession { session, project } => {
+            let session_id = parse_uuid(&session)?;
+            let project_id = resolve_project_id(state, &project)?;
+            let Some(session) = state.session_mut(session_id) else {
+                return Err(format!("session not found: {session}"));
+            };
+            session.project_id = project_id;
+            session.updated_at = crate::model::unix_time();
+            state.selected_session = Some(session_id);
+            state.selected_project = Some(project_id);
+            let session = state
+                .sessions
+                .iter()
+                .find(|session| session.id == session_id)
+                .expect("session just linked");
+            Ok(session_json(state, session))
+        }
+    }
+}
+
+fn ensure_projectless_project(state: &mut PersistedState) -> Result<Uuid, String> {
+    if let Some(project) = state.projects.iter().find(|project| {
+        project.is_projectless() && !projectless::is_legacy_root_path(&project.path)
+    }) {
+        return Ok(project.id);
+    }
+    let workspace = projectless::create_workspace(None).map_err(|error| error.to_string())?;
+    let mut project = Project::from_path(workspace.cwd);
+    project.name = Project::PROJECTLESS_NAME.to_owned();
+    let id = project.id;
+    state.projects.push(project);
+    Ok(id)
+}
+
+fn resolve_project_id(state: &PersistedState, value: &str) -> Result<Uuid, String> {
+    if let Ok(id) = parse_uuid(value) {
+        if state.projects.iter().any(|project| project.id == id) {
+            return Ok(id);
+        }
+        return Err(format!("project not found: {value}"));
+    }
+    let matches = state
+        .projects
+        .iter()
+        .filter(|project| {
+            !project.is_projectless() && project.name.eq_ignore_ascii_case(value.trim())
+        })
+        .map(|project| project.id)
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [id] => Ok(*id),
+        [] => Err(format!("project not found: {value}")),
+        _ => Err(format!(
+            "ambiguous project name `{value}`; use a project id"
+        )),
+    }
+}
+
+fn project_json(project: &Project) -> serde_json::Value {
+    serde_json::json!({
+        "id": project.id,
+        "name": project.name,
+        "path": project.path,
+        "created_at": project.created_at,
+    })
+}
+
+fn session_json(state: &PersistedState, session: &AgentSession) -> serde_json::Value {
+    session_json_with_prompt(state, session, None)
+}
+
+fn session_json_with_prompt(
+    state: &PersistedState,
+    session: &AgentSession,
+    prompt: Option<&str>,
+) -> serde_json::Value {
+    let project_name = state
+        .projects
+        .iter()
+        .find(|project| project.id == session.project_id)
+        .map(|project| project.display_name())
+        .unwrap_or_else(|| session.project_id.to_string());
+    let mut value = serde_json::json!({
+        "id": session.id,
+        "title": session.title,
+        "project_id": session.project_id,
+        "project_name": project_name,
+        "provider": session.provider.id(),
+        "model": session.model,
+        "created_at": session.created_at,
+        "updated_at": session.updated_at,
+        "started": session.has_started(),
+    });
+    if let Some(prompt) = prompt {
+        value["prompt"] = serde_json::json!(prompt);
+    }
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::ControlRequest;
+
+    #[test]
+    fn new_project_and_list_round_trip() {
+        let mut state = PersistedState::empty();
+        let path = std::env::temp_dir().join(format!("waku-cli-test-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&path).unwrap();
+        let created = apply_to_state(
+            &mut state,
+            ControlRequest::NewProject {
+                name: Some("Demo".into()),
+                path: path.clone(),
+            },
+        )
+        .unwrap();
+        assert_eq!(created["name"], "Demo");
+        let listed = apply_to_state(&mut state, ControlRequest::ListProjects).unwrap();
+        assert_eq!(listed.as_array().unwrap().len(), 1);
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn link_session_moves_project() {
+        let mut state = PersistedState::empty();
+        let a = std::env::temp_dir().join(format!("waku-cli-a-{}", Uuid::new_v4()));
+        let b = std::env::temp_dir().join(format!("waku-cli-b-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+        apply_to_state(
+            &mut state,
+            ControlRequest::NewProject {
+                name: Some("A".into()),
+                path: a.clone(),
+            },
+        )
+        .unwrap();
+        apply_to_state(
+            &mut state,
+            ControlRequest::NewProject {
+                name: Some("B".into()),
+                path: b.clone(),
+            },
+        )
+        .unwrap();
+        let session_id = state.sessions[0].id;
+        let project_b = state.projects.iter().find(|p| p.name == "B").unwrap().id;
+        apply_to_state(
+            &mut state,
+            ControlRequest::LinkSession {
+                session: session_id.to_string(),
+                project: project_b.to_string(),
+            },
+        )
+        .unwrap();
+        assert_eq!(state.sessions[0].project_id, project_b);
+        let _ = std::fs::remove_dir_all(a);
+        let _ = std::fs::remove_dir_all(b);
+    }
+
+    #[test]
+    fn wants_cli_detects_subcommands() {
+        assert!(wants_cli(&[
+            "waku".into(),
+            "list-projects".into()
+        ]));
+        assert!(!wants_cli(&["waku".into()]));
+    }
+}

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,0 +1,218 @@
+//! Local app-control channel between the `waku` CLI and a running desktop app.
+//!
+//! The socket lives next to `app.db`. One JSON request/response per connection
+//! (newline-terminated), so agents and shell scripts can drive session/project
+//! management without touching the GUI.
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::model::ProviderKind;
+use crate::persistence::StateStore;
+
+/// Filename of the control socket, sibling to `app.db`.
+pub const CONTROL_SOCKET_NAME: &str = "control.sock";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum ControlRequest {
+    ListProjects,
+    NewProject {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        path: PathBuf,
+    },
+    ListSessions {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        project: Option<String>,
+    },
+    NewSession {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        project: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        provider: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        prompt: Option<String>,
+    },
+    Open {
+        target: String,
+    },
+    LinkSession {
+        session: String,
+        project: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ControlResponse {
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl ControlResponse {
+    pub fn ok_data(data: serde_json::Value) -> Self {
+        Self {
+            ok: true,
+            error: None,
+            data: Some(data),
+        }
+    }
+
+    pub fn err(message: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            error: Some(message.into()),
+            data: None,
+        }
+    }
+}
+
+/// Pending request delivered from the socket thread into the UI event pump.
+pub struct PendingControl {
+    pub request: ControlRequest,
+    pub reply: mpsc::Sender<ControlResponse>,
+}
+
+pub fn socket_path_for_db(db_path: &Path) -> PathBuf {
+    db_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(CONTROL_SOCKET_NAME)
+}
+
+pub fn default_socket_path() -> PathBuf {
+    socket_path_for_db(&StateStore::default_path())
+}
+
+pub fn parse_provider(name: &str) -> Result<ProviderKind, String> {
+    let normalized = name.trim().to_ascii_lowercase();
+    ProviderKind::ALL
+        .into_iter()
+        .find(|provider| provider.id() == normalized)
+        .ok_or_else(|| {
+            let supported = ProviderKind::ALL
+                .iter()
+                .map(|provider| provider.id())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("unknown provider `{name}`; expected one of: {supported}")
+        })
+}
+
+/// Try to reach a running app. Returns `None` when nothing is listening.
+pub fn try_request(request: &ControlRequest) -> Option<ControlResponse> {
+    let path = default_socket_path();
+    let mut stream = UnixStream::connect(&path).ok()?;
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
+    let payload = match serde_json::to_string(request) {
+        Ok(payload) => payload,
+        Err(error) => {
+            return Some(ControlResponse::err(format!("encode request: {error}")));
+        }
+    };
+    if let Err(error) = writeln!(stream, "{payload}") {
+        return Some(ControlResponse::err(format!("write request: {error}")));
+    }
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    if let Err(error) = reader.read_line(&mut line) {
+        return Some(ControlResponse::err(format!("read response: {error}")));
+    }
+    match serde_json::from_str::<ControlResponse>(line.trim()) {
+        Ok(response) => Some(response),
+        Err(error) => Some(ControlResponse::err(format!("decode response: {error}"))),
+    }
+}
+
+/// Bind `control.sock` and forward each request to `tx`.
+///
+/// Stale sockets left by a crashed app are removed on bind failure.
+pub fn spawn_server(
+    db_path: PathBuf,
+    tx: crossbeam_channel::Sender<PendingControl>,
+    event_wake: smol::channel::Sender<()>,
+) {
+    thread::Builder::new()
+        .name("waku-control".into())
+        .spawn(move || {
+            let path = socket_path_for_db(&db_path);
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let _ = std::fs::remove_file(&path);
+            let listener = match UnixListener::bind(&path) {
+                Ok(listener) => listener,
+                Err(error) => {
+                    eprintln!("waku control: bind {}: {error}", path.display());
+                    return;
+                }
+            };
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else {
+                    continue;
+                };
+                let tx = tx.clone();
+                let event_wake = event_wake.clone();
+                thread::spawn(move || handle_connection(stream, tx, event_wake));
+            }
+        })
+        .expect("spawn waku control server");
+}
+
+fn handle_connection(
+    stream: UnixStream,
+    tx: crossbeam_channel::Sender<PendingControl>,
+    event_wake: smol::channel::Sender<()>,
+) {
+    let mut reader = BufReader::new(&stream);
+    let mut line = String::new();
+    if reader.read_line(&mut line).is_err() {
+        return;
+    }
+    let request = match serde_json::from_str::<ControlRequest>(line.trim()) {
+        Ok(request) => request,
+        Err(error) => {
+            let _ = write_response(&stream, &ControlResponse::err(format!("bad request: {error}")));
+            return;
+        }
+    };
+    let (reply_tx, reply_rx) = mpsc::channel();
+    if tx
+        .send(PendingControl {
+            request,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        let _ = write_response(&stream, &ControlResponse::err("app is shutting down"));
+        return;
+    }
+    let _ = event_wake.try_send(());
+    let response = reply_rx
+        .recv_timeout(Duration::from_secs(15))
+        .unwrap_or_else(|_| ControlResponse::err("timed out waiting for the app"));
+    let _ = write_response(&stream, &response);
+}
+
+fn write_response(mut stream: &UnixStream, response: &ControlResponse) -> std::io::Result<()> {
+    let payload = serde_json::to_string(response)
+        .unwrap_or_else(|error| format!(r#"{{"ok":false,"error":"{error}"}}"#));
+    writeln!(stream, "{payload}")
+}
+
+pub fn parse_uuid(value: &str) -> Result<Uuid, String> {
+    Uuid::parse_str(value.trim()).map_err(|_| format!("invalid id `{value}`"))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,8 @@ mod updater;
 mod usage;
 mod usage_history;
 mod worktree;
+mod control;
+mod cli;
 
 use gpui::{
     App, Application, Bounds, KeyBinding, Menu, MenuItem, TitlebarOptions,
@@ -128,6 +130,21 @@ impl WakuApplicationExt for Application {
 }
 
 fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if cli::wants_cli(&args) {
+        match cli::main() {
+            Ok(()) => return,
+            Err(error) => {
+                eprintln!("error: {error}");
+                std::process::exit(1);
+            }
+        }
+    }
+    run_app();
+}
+
+fn run_app() {
+
     gpui_platform::application()
         .with_assets(crate::assets::Assets)
         .with_main_window_reopen()

--- a/src/model.rs
+++ b/src/model.rs
@@ -706,6 +706,12 @@ pub struct AgentSession {
     /// that a session has no history.
     #[serde(skip, default = "detail_loaded_default")]
     pub detail_loaded: bool,
+    /// When true, persist this session even before it has started.
+    ///
+    /// The GUI keeps blank drafts in memory only. The CLI sets this so an
+    /// explicitly created session survives `save` / relaunch.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub persist_draft: bool,
 }
 
 /// Anything deserialized from a `data` blob carries its full detail.
@@ -735,6 +741,7 @@ impl AgentSession {
             updated_at: now,
             last_reply_at: None,
             detail_loaded: true,
+            persist_draft: false,
             provider_cursor: None,
             available_commands: Vec::new(),
             context_usage: None,
@@ -767,10 +774,23 @@ impl AgentSession {
     pub fn has_started(&self) -> bool {
         // A skeleton came from a stored row, and only started sessions are
         // stored, so it has started even though its transcript is not loaded.
+        // CLI draft rows are an exception: they may be stored before the first
+        // turn, so a skeleton is only treated as started when it is not still
+        // marked as a persisted draft (restored via hydrate).
+        if self.persist_draft {
+            return !self.turns.is_empty()
+                || !self.messages.is_empty()
+                || self.provider_cursor.is_some();
+        }
         !self.detail_loaded
             || !self.turns.is_empty()
             || !self.messages.is_empty()
             || self.provider_cursor.is_some()
+    }
+
+    /// Whether this session should be written to SQLite on the next save.
+    pub fn should_persist(&self) -> bool {
+        self.has_started() || self.persist_draft
     }
 
     pub fn display_title(&self) -> &str {

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -490,7 +490,7 @@ impl PersistedState {
         self.selected_session.filter(|selected| {
             self.sessions
                 .iter()
-                .any(|session| session.id == *selected && session.has_started())
+                .any(|session| session.id == *selected && session.should_persist())
         })
     }
 
@@ -1132,6 +1132,7 @@ impl StateStore {
         session.reasoning_effort = stored.reasoning_effort;
         session.service_tier = stored.service_tier;
         session.context_usage = stored.context_usage;
+        session.persist_draft = stored.persist_draft;
 
         let mut statement = connection
             .prepare(
@@ -1233,8 +1234,9 @@ impl StateStore {
             storage.saved_projects = projects_fingerprint;
         }
 
-        // Only sessions the app reported as changed are written. A draft that
-        // has not started yet owns no row, so it counts as removed until it does.
+        // Only sessions that should persist are written. GUI drafts that have
+        // not started yet own no row until the first message; CLI-created
+        // drafts set `persist_draft` so they survive save/relaunch.
         let mut live = HashSet::with_capacity(state.sessions.len());
         // Applied only after the commit below, so a transaction that rolls back
         // does not leave this connection believing rows it never wrote are on
@@ -1243,7 +1245,7 @@ impl StateStore {
         for session in state
             .sessions
             .iter()
-            .filter(|session| session.has_started())
+            .filter(|session| session.should_persist())
         {
             live.insert(session.id);
             // A skeleton's empty transcript means "not fetched", not "empty".
@@ -1405,6 +1407,7 @@ fn session_skeleton(row: SessionColumns) -> Option<AgentSession> {
         turns: Vec::new(),
         queued_messages: Vec::new(),
         detail_loaded: false,
+        persist_draft: false,
     })
 }
 


### PR DESCRIPTION
## Summary

Implements a `waku` CLI so agents and scripts can manage projects/sessions outside the GUI — the primary ask in https://github.com/egoist/waku/issues/42.

- **Commands:** `new-project`, `list-projects`, `open`, `new-session`, `list-sessions`, `link-session` (+ `--help`)
- **Control channel:** when the desktop app is running, the CLI talks to it over a Unix socket (`control.sock` beside `app.db`) so in-memory UI state stays authoritative and `open` can focus the app
- **Offline fallback:** when the app is not running, create/list/link operate directly through existing `StateStore` / SQLite persistence; `open` persists selection for the next launch
- Shared `apply_to_state` path is reused by both the offline CLI and the in-app control handler
- Unit tests cover project create/list and session linking
- README documents the new surface

Deferred (called out in #42 as secondary): app-control MCP wrapper and `waku://` deep links.

Fixes https://github.com/egoist/waku/issues/42

## Test plan

- [ ] `cargo fmt --package waku -- --check`
- [ ] `cargo check`
- [ ] `cargo test` (includes `cli::tests`)
- [ ] With app **not** running: `waku new-project --path …`, `waku list-projects`, `waku new-session --project …`, `waku list-sessions`, `waku link-session …`
- [ ] With app running: same commands update the live sidebar; `waku open <id|name>` focuses the window on that project/session
- [ ] `waku --help` / per-subcommand help render correctly