### PR TITLE
Include ~/.grok/bin in provider executable search path

### DIFF
--- a/src/command_env.rs
+++ b/src/command_env.rs
@@ -61,6 +61,7 @@ fn search_paths_from(path: Option<&OsStr>, home: Option<&Path>) -> Vec<PathBuf> 
             home.join(".local/bin"),
             home.join(".bun/bin"),
             home.join(".cargo/bin"),
+            home.join(".grok/bin"),
             home.join(".local/share/mise/shims"),
             home.join(".volta/bin"),
         ]);
@@ -91,6 +92,7 @@ mod tests {
         assert_eq!(paths[0], PathBuf::from("/usr/bin"));
         assert_eq!(paths[1], PathBuf::from("/bin"));
         assert!(paths.contains(&home.join(".bun/bin")));
+        assert!(paths.contains(&home.join(".grok/bin")));
         assert!(paths.contains(&home.join(".local/share/mise/shims")));
         assert!(paths.contains(&PathBuf::from("/opt/homebrew/bin")));
         assert_eq!(


### PR DESCRIPTION
## Problem

Waku marks Grok as uninstalled even when Grok Build is present. The official installer puts the `grok` binary under `~/.grok/bin` by default (`BIN_DIR="${GROK_BIN_DIR:-$HOME/.grok/bin}"` in https://x.ai/cli/install.sh), and apps opened through LaunchServices do not inherit the user's shell PATH.

Fixes #47

## Solution

Add `~/.grok/bin` to the same home-directory search path extensions already used for other agent CLIs (`.local/bin`, `.bun/bin`, `.cargo/bin`, mise, volta). Update the unit test that locks that list.

## Checks

- [x] Focused change only in `src/command_env.rs`
- [x] Existing `launch_services_path_is_extended_for_script_based_clis` assertion extended for `.grok/bin`
- [ ] `cargo test` / full baseline not re-run in this environment after the last toolchain fix (change is two path entries + one assert)

## Notes

Does not change binary overrides or provider probing logic beyond discovery path.