### PR TITLE
fix(spawn): normalize SIGCHLD for provider children spawned from GCD

### DIFF
--- a/src/amp_session.rs
+++ b/src/amp_session.rs
@@ -45,7 +45,8 @@ pub fn prompt_with_fork_context(context: &str, prompt: &str) -> String {
 /// Amp does not put its generated thread title on the streaming channel. The
 /// native thread index is its authoritative metadata surface instead.
 pub fn thread_title(binary: &Path, cwd: &Path, thread_id: &str) -> anyhow::Result<Option<String>> {
-    let output = crate::command_env::command(binary)
+    let mut command = crate::command_env::command(binary);
+    let command = command
         .args([
             "threads",
             "list",
@@ -55,9 +56,9 @@ pub fn thread_title(binary: &Path, cwd: &Path, thread_id: &str) -> anyhow::Resul
             "100",
         ])
         .current_dir(cwd)
-        .stdin(Stdio::null())
-        .output()
-        .context("failed to read Amp thread metadata")?;
+        .stdin(Stdio::null());
+    let output =
+        crate::command_env::output(command).context("failed to read Amp thread metadata")?;
     if !output.status.success() {
         let detail = String::from_utf8_lossy(&output.stderr);
         bail!("Amp could not list its threads: {}", detail.trim());
@@ -83,12 +84,12 @@ fn title_from_thread_list(threads: &Value, thread_id: &str) -> Option<String> {
 }
 
 fn export_thread(binary: &Path, cwd: &Path, thread_id: &str) -> anyhow::Result<Value> {
-    let output = crate::command_env::command(binary)
+    let mut command = crate::command_env::command(binary);
+    let command = command
         .args(["threads", "export", thread_id])
         .current_dir(cwd)
-        .stdin(Stdio::null())
-        .output()
-        .context("failed to export the Amp thread")?;
+        .stdin(Stdio::null());
+    let output = crate::command_env::output(command).context("failed to export the Amp thread")?;
     if !output.status.success() {
         let detail = String::from_utf8_lossy(&output.stderr);
         bail!("Amp could not export thread {thread_id}: {}", detail.trim());
@@ -97,12 +98,13 @@ fn export_thread(binary: &Path, cwd: &Path, thread_id: &str) -> anyhow::Result<V
 }
 
 fn create_thread(binary: &Path, cwd: &Path) -> anyhow::Result<String> {
-    let output = crate::command_env::command(binary)
+    let mut command = crate::command_env::command(binary);
+    let command = command
         .args(["threads", "new"])
         .current_dir(cwd)
-        .stdin(Stdio::null())
-        .output()
-        .context("failed to create the Amp branch thread")?;
+        .stdin(Stdio::null());
+    let output =
+        crate::command_env::output(command).context("failed to create the Amp branch thread")?;
     if !output.status.success() {
         let detail = String::from_utf8_lossy(&output.stderr);
         bail!("Amp could not create the branch thread: {}", detail.trim());

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -2688,11 +2688,9 @@ mod response_fork_title_tests {
 /// Run `<cli> --version` and pull a version number out of whatever it prints.
 /// Blocking; runs on a version-probe thread, never on the UI thread.
 fn probe_provider_version(binary: &std::path::Path) -> Option<String> {
-    let output = crate::command_env::command(binary)
-        .arg("--version")
-        .stdin(std::process::Stdio::null())
-        .output()
-        .ok()?;
+    let mut command = crate::command_env::command(binary);
+    let command = command.arg("--version").stdin(std::process::Stdio::null());
+    let output = crate::command_env::output(command).ok()?;
     let combined = format!(
         "{}\n{}",
         String::from_utf8_lossy(&output.stdout),

--- a/src/command_env.rs
+++ b/src/command_env.rs
@@ -1,8 +1,9 @@
 use std::collections::HashSet;
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, OpenOptions};
+use std::io;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, Output, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{OnceLock, RwLock};
 use std::time::{Duration, Instant};
@@ -37,6 +38,97 @@ pub fn command(program: impl AsRef<OsStr>) -> Command {
         command.env("PATH", path);
     }
     command
+}
+
+/// Spawn `command` with `SIGCHLD` unblocked in the child. On macOS, libdispatch
+/// worker threads (which back GPUI's background executor) block `SIGCHLD`, and
+/// a process spawned from such a thread inherits the blocked mask. That breaks
+/// provider-side async process reapers. The caller's mask is restored as soon
+/// as the child has been created.
+pub(crate) fn spawn(command: &mut Command) -> io::Result<Child> {
+    with_sigchld_unblocked(|| command.spawn())
+}
+
+/// Spawn `command` through [`spawn`] and collect its output.
+///
+/// `Command::spawn` inherits standard streams by default, unlike
+/// `Command::output`. Own all three streams here so callers keep the latter's
+/// behavior while the signal mask is changed only for the spawn itself.
+pub(crate) fn output(command: &mut Command) -> io::Result<Output> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    spawn(command)?.wait_with_output()
+}
+
+/// Normalize a Waku-owned provider thread before a dependency spawns the child
+/// internally. The ACP SDK owns its `async_process::Command`, so its dedicated
+/// connection thread uses this once at startup instead of [`spawn`].
+pub(crate) fn unblock_sigchld_for_current_thread() -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        let sigchld = sigchld_set()?;
+        pthread_result(unsafe {
+            libc::pthread_sigmask(libc::SIG_UNBLOCK, &sigchld, std::ptr::null_mut())
+        })
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok(())
+    }
+}
+
+fn with_sigchld_unblocked<T>(operation: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
+    #[cfg(target_os = "macos")]
+    let _restore = SignalMaskRestore::unblock_sigchld()?;
+    operation()
+}
+
+#[cfg(target_os = "macos")]
+fn sigchld_set() -> io::Result<libc::sigset_t> {
+    let mut set = MaybeUninit::<libc::sigset_t>::uninit();
+    if unsafe { libc::sigemptyset(set.as_mut_ptr()) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut set = unsafe { set.assume_init() };
+    if unsafe { libc::sigaddset(&mut set, libc::SIGCHLD) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(set)
+}
+
+#[cfg(target_os = "macos")]
+fn pthread_result(status: libc::c_int) -> io::Result<()> {
+    if status == 0 {
+        Ok(())
+    } else {
+        // pthread APIs return the error number directly instead of setting
+        // errno, so `last_os_error` would report unrelated thread state.
+        Err(io::Error::from_raw_os_error(status))
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct SignalMaskRestore(libc::sigset_t);
+
+#[cfg(target_os = "macos")]
+impl SignalMaskRestore {
+    fn unblock_sigchld() -> io::Result<Self> {
+        let sigchld = sigchld_set()?;
+        let mut previous = MaybeUninit::<libc::sigset_t>::uninit();
+        pthread_result(unsafe {
+            libc::pthread_sigmask(libc::SIG_UNBLOCK, &sigchld, previous.as_mut_ptr())
+        })?;
+        Ok(Self(unsafe { previous.assume_init() }))
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for SignalMaskRestore {
+    fn drop(&mut self) {
+        let _ = unsafe { libc::pthread_sigmask(libc::SIG_SETMASK, &self.0, std::ptr::null_mut()) };
+    }
 }
 
 pub fn find_executable(name: &str) -> Option<PathBuf> {
@@ -227,7 +319,7 @@ fn capture_shell_path(shell: &Path, shell_args: &[&str], timeout: Duration) -> O
     #[cfg(target_os = "macos")]
     command.process_group(0);
 
-    let mut child = command.spawn().ok()?;
+    let mut child = spawn(&mut command).ok()?;
     if !wait_for_child(&mut child, timeout) {
         return None;
     }
@@ -307,6 +399,76 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn output_captures_stdout_and_stderr() {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", "printf stdout; printf stderr >&2"]);
+
+        let output = output(&mut command).expect("command should run");
+
+        assert_eq!(output.stdout, b"stdout");
+        assert_eq!(output.stderr, b"stderr");
+    }
+
+    #[cfg(target_os = "macos")]
+    fn sigchld_is_blocked() -> io::Result<bool> {
+        let mut current = MaybeUninit::<libc::sigset_t>::uninit();
+        pthread_result(unsafe {
+            libc::pthread_sigmask(libc::SIG_SETMASK, std::ptr::null(), current.as_mut_ptr())
+        })?;
+        Ok(unsafe { libc::sigismember(current.as_ptr(), libc::SIGCHLD) } == 1)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn block_sigchld() -> io::Result<SignalMaskRestore> {
+        let sigchld = sigchld_set()?;
+        let mut previous = MaybeUninit::<libc::sigset_t>::uninit();
+        pthread_result(unsafe {
+            libc::pthread_sigmask(libc::SIG_BLOCK, &sigchld, previous.as_mut_ptr())
+        })?;
+        Ok(SignalMaskRestore(unsafe { previous.assume_init() }))
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn spawn_unblocks_sigchld_in_the_child_and_restores_the_caller() {
+        if std::env::var_os("WAKU_SIGCHLD_CHILD_PROBE").is_some() {
+            assert!(!sigchld_is_blocked().expect("read child signal mask"));
+            return;
+        }
+
+        let _restore_original = block_sigchld().expect("block SIGCHLD for the fixture");
+        assert!(sigchld_is_blocked().expect("read blocked parent mask"));
+
+        let mut command = Command::new(std::env::current_exe().expect("resolve test executable"));
+        command
+            .args([
+                "--exact",
+                "command_env::tests::spawn_unblocks_sigchld_in_the_child_and_restores_the_caller",
+                "--nocapture",
+            ])
+            .env("WAKU_SIGCHLD_CHILD_PROBE", "1");
+        let output = output(&mut command).expect("spawn child signal probe");
+
+        assert!(
+            output.status.success(),
+            "child signal probe failed:\n{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(sigchld_is_blocked().expect("read restored parent mask"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn dedicated_provider_thread_can_normalize_sigchld() {
+        let _restore_original = block_sigchld().expect("block SIGCHLD for the fixture");
+
+        unblock_sigchld_for_current_thread().expect("unblock provider thread");
+
+        assert!(!sigchld_is_blocked().expect("read normalized signal mask"));
+    }
 
     #[test]
     fn launch_services_path_is_extended_for_script_based_clis() {

--- a/src/computer_use.rs
+++ b/src/computer_use.rs
@@ -210,11 +210,11 @@ fn invoke_helper_direct(
     if let Some(mode) = mode {
         command.arg(mode);
     }
-    let mut child = command
+    let command = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
+        .stderr(Stdio::piped());
+    let mut child = crate::command_env::spawn(command)
         .with_context(|| format!("failed to start {}", helper.display()))?;
     let pid = child.id();
     active_helper_pid.store(pid, Ordering::SeqCst);

--- a/src/driver/acp.rs
+++ b/src/driver/acp.rs
@@ -141,6 +141,13 @@ impl AcpDriver {
         thread::Builder::new()
             .name(format!("waku-{}-acp", provider.id()))
             .spawn(move || {
+                if let Err(error) = crate::command_env::unblock_sigchld_for_current_thread() {
+                    let _ = thread_events.send(DriverEvent::Error(format!(
+                        "{provider_name}: failed to normalize the provider signal mask: {error}"
+                    )));
+                    let _ = thread_events.send(DriverEvent::ProcessExited);
+                    return;
+                }
                 let result = smol::block_on(run_sdk_connection(
                     agent,
                     provider,

--- a/src/driver/amp.rs
+++ b/src/driver/amp.rs
@@ -124,11 +124,11 @@ impl AmpDriver {
             service_tier.as_deref(),
             thread_id.as_deref(),
         ));
-        let mut child = command
+        let command = command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
+            .stderr(Stdio::piped());
+        let mut child = crate::command_env::spawn(command)
             .context("failed to start `amp` in streaming-input mode")?;
         let stdin = child
             .stdin

--- a/src/driver/claude.rs
+++ b/src/driver/claude.rs
@@ -171,11 +171,11 @@ impl ClaudeDriver {
             command.args(["--session-id", &session_id]);
         }
 
-        let mut child = command
+        let command = command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
+            .stderr(Stdio::piped());
+        let mut child = crate::command_env::spawn(command)
             .context("failed to start `claude` in streaming-input mode")?;
         let stdin = child
             .stdin

--- a/src/driver/codex.rs
+++ b/src/driver/codex.rs
@@ -210,13 +210,13 @@ impl CodexDriver {
         let mut command = crate::command_env::command(&binary);
         command.args(["app-server", "--stdio"]);
         configure_computer_use_command(&mut command, computer_use.as_ref());
-        let mut child = command
+        let command = command
             .current_dir(&cwd)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .context("failed to start `codex app-server`")?;
+            .stderr(Stdio::piped());
+        let mut child =
+            crate::command_env::spawn(command).context("failed to start `codex app-server`")?;
 
         let stdin = child
             .stdin
@@ -973,14 +973,15 @@ fn codex_title_turn_params(thread_id: &str, user_message: &str) -> Value {
 /// Codex Desktop's client-owned behavior with an isolated ephemeral turn, then
 /// hand the result back to the main writer for `thread/name/set`.
 fn generate_codex_title(binary: &Path, cwd: &Path, prompt: &str) -> anyhow::Result<String> {
-    let mut child = crate::command_env::command(binary)
+    let mut command = crate::command_env::command(binary);
+    let command = command
         .args(["app-server", "--stdio"])
         .current_dir(cwd)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .context("failed to start Codex title generation")?;
+        .stderr(Stdio::null());
+    let mut child =
+        crate::command_env::spawn(command).context("failed to start Codex title generation")?;
     let mut stdin = child
         .stdin
         .take()

--- a/src/driver/pi.rs
+++ b/src/driver/pi.rs
@@ -118,13 +118,13 @@ impl PiDriver {
                 .zip(pi_extension.as_deref())
                 .map(|(runtime, extension)| (&runtime.config, extension)),
         );
-        let mut child = command
+        let command = command
             .current_dir(cwd)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .context("failed to start `pi --mode rpc`")?;
+            .stderr(Stdio::piped());
+        let mut child =
+            crate::command_env::spawn(command).context("failed to start `pi --mode rpc`")?;
         let stdin = child
             .stdin
             .take()

--- a/src/git_commit.rs
+++ b/src/git_commit.rs
@@ -532,12 +532,11 @@ fn run_capture(command: &mut Command, timeout: Duration) -> anyhow::Result<Captu
         // a timeout does not leave those descendants running in the workspace.
         command.process_group(0);
     }
-    let mut child = command
+    let command = command
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("could not start process")?;
+        .stderr(Stdio::piped());
+    let mut child = crate::command_env::spawn(command).context("could not start process")?;
     let stdout = child.stdout.take().context("process stdout unavailable")?;
     let stderr = child.stderr.take().context("process stderr unavailable")?;
     let stdout_reader = thread::spawn(move || read_bounded(stdout, MAX_STDOUT_BYTES));

--- a/src/grok_session.rs
+++ b/src/grok_session.rs
@@ -249,13 +249,14 @@ struct GrokRpc {
 
 impl GrokRpc {
     fn start(binary: &Path) -> anyhow::Result<Self> {
-        let mut child = crate::command_env::command(binary)
+        let mut command = crate::command_env::command(binary);
+        let command = command
             .args(["agent", "--always-approve", "--no-leader", "stdio"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-            .context("failed to start Grok's ACP server")?;
+            .stderr(Stdio::null());
+        let mut child =
+            crate::command_env::spawn(command).context("failed to start Grok's ACP server")?;
         let stdin = child
             .stdin
             .take()

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -150,7 +150,9 @@ fn write_models_file(path: &Path, models: &[ProviderModel]) -> std::io::Result<(
 }
 
 fn discover_cursor_models(binary: &Path) -> Vec<ProviderModel> {
-    let Ok(output) = crate::command_env::command(binary).arg("models").output() else {
+    let mut command = crate::command_env::command(binary);
+    let command = command.arg("models");
+    let Ok(output) = crate::command_env::output(command) else {
         return Vec::new();
     };
     let combined = format!(
@@ -213,7 +215,9 @@ fn parse_cursor_models(output: &str) -> Vec<ProviderModel> {
 }
 
 fn discover_opencode_models(binary: &Path) -> Vec<ProviderModel> {
-    let Ok(output) = crate::command_env::command(binary).arg("models").output() else {
+    let mut command = crate::command_env::command(binary);
+    let command = command.arg("models");
+    let Ok(output) = crate::command_env::output(command) else {
         return Vec::new();
     };
     parse_opencode_models(&String::from_utf8_lossy(&output.stdout))
@@ -240,7 +244,9 @@ fn parse_opencode_models(output: &str) -> Vec<ProviderModel> {
 }
 
 fn discover_grok_models(binary: &Path) -> Vec<ProviderModel> {
-    let Ok(output) = crate::command_env::command(binary).arg("models").output() else {
+    let mut command = crate::command_env::command(binary);
+    let command = command.arg("models");
+    let Ok(output) = crate::command_env::output(command) else {
         return Vec::new();
     };
     let combined = format!(
@@ -291,7 +297,8 @@ fn parse_grok_models(output: &str) -> Vec<ProviderModel> {
 }
 
 fn discover_pi_models(binary: &Path) -> Vec<ProviderModel> {
-    let Ok(mut child) = crate::command_env::command(binary)
+    let mut command = crate::command_env::command(binary);
+    let command = command
         .args([
             "--mode",
             "rpc",
@@ -303,9 +310,8 @@ fn discover_pi_models(binary: &Path) -> Vec<ProviderModel> {
         .env("PI_SKIP_VERSION_CHECK", "1")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-    else {
+        .stderr(Stdio::null());
+    let Ok(mut child) = crate::command_env::spawn(command) else {
         return Vec::new();
     };
     let Some(mut stdin) = child.stdin.take() else {
@@ -430,13 +436,13 @@ fn pi_reasoning_options(model: &Value) -> Vec<ProviderModelOption> {
 }
 
 fn discover_codex_models(binary: &Path) -> Vec<ProviderModel> {
-    let Ok(mut child) = crate::command_env::command(binary)
+    let mut command = crate::command_env::command(binary);
+    let command = command
         .args(["app-server", "--stdio"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-    else {
+        .stderr(Stdio::null());
+    let Ok(mut child) = crate::command_env::spawn(command) else {
         return Vec::new();
     };
     let Some(mut stdin) = child.stdin.take() else {

--- a/src/opencode_session.rs
+++ b/src/opencode_session.rs
@@ -142,7 +142,7 @@ impl OpenCodeServer {
         for (name, value) in environment {
             command.env(name, value);
         }
-        let child = command
+        let command = command
             .args([
                 "serve",
                 "--hostname",
@@ -155,9 +155,9 @@ impl OpenCodeServer {
             .current_dir(cwd)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .context("failed to start `opencode serve`")?;
+            .stderr(Stdio::null());
+        let child =
+            crate::command_env::spawn(command).context("failed to start `opencode serve`")?;
         let pid = child.id();
         let mut server = Self { child, port, pid };
         let started_at = Instant::now();

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -276,14 +276,15 @@ fn parse_opencode_go_plan_usage(body: &Value) -> Option<PlanUsage> {
 /// with the account's monthly quota. Blocking, bounded by timeouts, and the
 /// probe process is always torn down.
 pub fn fetch_grok_plan_usage(binary: &std::path::Path) -> anyhow::Result<PlanUsage> {
-    let mut child = crate::command_env::command(binary)
+    let mut command = crate::command_env::command(binary);
+    let command = command
         .args(["agent", "stdio"])
         .env("GROK_OAUTH2_REFERRER", "waku")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .context(tr!("usage_error.start_grok_probe"))?;
+        .stderr(Stdio::null());
+    let mut child =
+        crate::command_env::spawn(command).context(tr!("usage_error.start_grok_probe"))?;
     let result = grok_billing_over_stdio(&mut child);
     // The probe has no shutdown request; ending it is the protocol.
     let _ = child.kill();


### PR DESCRIPTION
## Summary

Normalize `SIGCHLD` at Waku's process-spawn boundary so provider CLIs can reap their own children.

On macOS, GPUI's background executor runs on libdispatch worker threads, which block `SIGCHLD`. Every provider process Waku spawns from that executor inherits the blocked mask. Async process reapers driven by `SIGCHLD` then never observe exits: `codex app-server`'s unified exec leaves every command as a `Z` (defunct) zombie and reports the session as "Process running" forever (see #53). Legacy `shell_command` uses blocking `waitpid` and is unaffected, which is why toggling `unified_exec` changed the symptom.

## Change

- Add `command_env::spawn` / `command_env::output`, which unblock `SIGCHLD` on the calling thread only for the duration of `Command::spawn()`, then restore the previous mask. The child gets the normal Unix signal mask; the parent thread state is untouched and spawning still uses `posix_spawn` (no `fork`).
- Route every provider process and its supporting probes through these helpers: Codex app-server (runtime, title generation, model discovery), Claude, Cursor/Grok ACP, OpenCode serve, Pi, Amp (driver + session helpers), the computer-use helper, and provider version probes.

Closes #53.

---

## 摘要

在 Waku 的进程 spawn 边界统一恢复 `SIGCHLD`, 让 provider CLI 能正常回收自己的子进程.

在 macOS 上, GPUI 的 background executor 运行在 libdispatch 工作线程上, 而 libdispatch 工作线程默认屏蔽 `SIGCHLD`. Waku 从该 executor spawn 出来的每个 provider 进程都会继承被屏蔽的信号掩码. 依赖 `SIGCHLD` 的异步进程回收机制因此永远等不到退出通知: `codex app-server` 的 unified exec 会把每条命令变成 `Z` (defunct) 僵尸进程, 并一直显示 "Process running" (见 #53). legacy `shell_command` 使用阻塞式 `waitpid`, 不受影响, 所以开关 `unified_exec` 会改变症状.

## 改动

- 新增 `command_env::spawn` / `command_env::output`: 只在 `Command::spawn()` 期间在当前线程临时解除 `SIGCHLD` 屏蔽, 之后恢复原掩码. 子进程获得正常的 Unix 信号掩码; 父线程状态不受影响, 且仍使用 `posix_spawn` (不引入 `fork`).
- 所有 provider 进程及其辅助探测都改为走这两个入口: Codex app-server (运行时, 标题生成, 模型发现), Claude, Cursor/Grok ACP, OpenCode serve, Pi, Amp (driver + session 辅助命令), computer-use helper, provider 版本探测.
