### PR TITLE
Share one resident opencode serve per workspace across sessions

### DIFF
--- a/src/driver/opencode.rs
+++ b/src/driver/opencode.rs
@@ -1,12 +1,12 @@
-//! OpenCode's own HTTP server.
-//!
-//! `opencode serve` is OpenCode's real API: one resident process serves the
-//! whole conversation, streams server-sent events, and answers permission
-//! requests the user can actually be asked. Waku already started this server
-//! for a side-quest — forking a session — while running conversations through
-//! one-shot `opencode run` invocations; this drives everything through it.
-//! A prompt posted into a busy session is folded into the running turn rather
-//! than queued behind it, which is what makes steering a plain post.
+//! `opencode serve` is OpenCode's real API: one resident process serves
+//! every session in a workspace, streams server-sent events, and answers
+//! permission requests the user can actually be asked. Waku already started
+//! this server for a side-quest — forking a session — while running
+//! conversations through one-shot `opencode run` invocations; this drives
+//! everything through it, pooled per workspace via `opencode_pool` so
+//! sessions share the process instead of starting one each. A prompt posted
+//! into a busy session is folded into the running turn rather than queued
+//! behind it, which is what makes steering a plain post.
 //!
 //! Routes and payload shapes here were read off a live server's OpenAPI
 //! document and event stream, not guessed.
@@ -30,6 +30,7 @@ use crate::driver::{
 use crate::model::{
     ActivityKind, DriverEvent, InteractionMode, PermissionOption, ProviderResumeCursor, RuntimeMode,
 };
+use crate::opencode_pool::PooledServer;
 use crate::opencode_session::{
     OpenCodeServer, encode_path_segment, fork_session_removing_turns_on_server,
 };
@@ -58,7 +59,7 @@ fn prompt_body(text: &str, model: Option<&str>) -> Value {
 }
 
 pub struct OpenCodeDriver {
-    server: Arc<OpenCodeServer>,
+    server: PooledServer,
     session_id: String,
     commands: Sender<CommandMessage>,
     mode: RuntimeMode,
@@ -106,7 +107,16 @@ impl OpenCodeDriver {
             .as_ref()
             .map(|runtime| super::support::opencode_computer_use_environment(&runtime.config))
             .unwrap_or_default();
-        let server = Arc::new(OpenCodeServer::start_with_env(&binary, &cwd, &environment)?);
+        // Computer Use bakes per-session configuration into the server's
+        // environment, so it keeps a dedicated server. Every other session
+        // shares the workspace's one resident server — OpenCode hosts many
+        // sessions per process, and a second `opencode serve` in the same
+        // workspace contends with the live one.
+        let server = if computer_use.is_some() {
+            PooledServer::dedicated(OpenCodeServer::start_with_env(&binary, &cwd, &environment)?)
+        } else {
+            crate::opencode_pool::acquire(&binary, &cwd)?
+        };
 
         // Reuse the native session when resuming so the conversation, and the
         // cursor already persisted for it, stay the same.
@@ -129,8 +139,9 @@ impl OpenCodeDriver {
             }),
         });
 
-        // The agent decides Plan versus Build, and it is fixed for the life of
-        // the server because it is chosen when the session opens.
+        // The agent decides Plan versus Build, and it is per session: a
+        // resumed session gets the agent re-posted and OpenCode persists it
+        // with the session.
         let agent = if interaction_mode == InteractionMode::Plan || mode == RuntimeMode::Plan {
             "plan"
         } else {
@@ -170,18 +181,40 @@ impl OpenCodeDriver {
         // transcript or turns an otherwise healthy provider into a 0% meter.
         // The stream records the actual provider/model key in parallel; when
         // the catalog lands, publish the matching window as a separate merge.
-        let metadata_server = server.clone();
+        // The thread holds only the port: a handle would delay the pooled
+        // server's teardown behind this request's timeout.
+        let metadata_port = server.port;
         let metadata_events = events.clone();
         let background_usage_metadata = usage_metadata.clone();
         thread::Builder::new()
             .name("waku-opencode-usage-metadata".into())
             .spawn(move || {
-                let Ok(response) = metadata_server.request_with_timeout(
-                    "GET",
-                    "/api/model",
-                    None,
-                    Duration::from_secs(30),
-                ) else {
+                // `/api/model` answers with an empty catalog until the server
+                // warms it up. The first session of a workspace starts a cold
+                // server, so poll until models land or the budget runs out;
+                // later sessions share an already-warm server.
+                let started = std::time::Instant::now();
+                let budget = Duration::from_secs(30);
+                let response = loop {
+                    let request = crate::opencode_session::request_json_on_port(
+                        metadata_port,
+                        "GET",
+                        "/api/model",
+                        None,
+                        Duration::from_secs(30),
+                    );
+                    let landed = request.as_ref().is_ok_and(|response| {
+                        response
+                            .pointer("/data")
+                            .and_then(Value::as_array)
+                            .is_some_and(|data| !data.is_empty())
+                    });
+                    if landed || started.elapsed() >= budget {
+                        break request;
+                    }
+                    thread::sleep(Duration::from_secs(2));
+                };
+                let Ok(response) = response else {
                     return;
                 };
                 let windows = opencode_model_context_windows(&response);
@@ -199,7 +232,10 @@ impl OpenCodeDriver {
         let (commands, command_rx) = unbounded();
         let turn_active = Arc::new(Mutex::new(false));
 
-        let stream_server = server.clone();
+        // The reader holds only the port, never a server handle: the stream
+        // closes exactly when the process exits, so a handle held here would
+        // keep the pooled server from ever being killed.
+        let stream_port = server.port;
         let stream_session = session_id.clone();
         let stream_events = events.clone();
         let stream_commands = commands.clone();
@@ -213,9 +249,9 @@ impl OpenCodeDriver {
                     ..OpenCodeStreamState::default()
                 };
                 // The server-wide stream, not a per-session one: the scoped
-                // route exists only under `/api`, and this server is Waku's
-                // alone, so filtering by session id here is enough.
-                match open_event_stream(stream_server.port, "/event") {
+                // route exists only under `/api`, and the workspace server
+                // may carry other sessions' traffic, so filter by session id.
+                match open_event_stream(stream_port, "/event") {
                     Ok(stream) => {
                         for line in BufReader::new(stream).lines().map_while(Result::ok) {
                             let Some(payload) = line.strip_prefix("data:") else {
@@ -417,8 +453,8 @@ impl DriverControl for OpenCodeDriver {
     }
 
     fn apply_options(&self, options: SessionOptions) -> bool {
-        // The model rides on each prompt, but the agent is chosen when the
-        // session opens, so a mode change needs a fresh server.
+        // The model rides on each prompt, but the agent is chosen per
+        // session, so a mode change needs a fresh driver (and session).
         options.mode == self.mode && options.interaction_mode == self.interaction_mode
     }
 
@@ -438,10 +474,10 @@ impl Drop for OpenCodeDriver {
     fn drop(&mut self) {
         self.cancel_computer_use();
         let _ = self.commands.send(CommandMessage::Shutdown);
-        // Kill the server explicitly: the event-stream reader holds a handle and
-        // only unblocks once the stream closes, so refcounting alone would
-        // deadlock and leak the process.
-        self.server.shutdown();
+        // The server dies with the last pool handle. The worker thread drops
+        // its handle once it consumes the shutdown command; the stream and
+        // metadata readers hold only the port, so they cannot keep a dying
+        // server alive.
     }
 }
 

--- a/src/driver/opencode.rs
+++ b/src/driver/opencode.rs
@@ -13,8 +13,9 @@
 
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Write};
-use std::net::TcpStream;
+use std::net::{Shutdown, TcpStream};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
@@ -59,9 +60,13 @@ fn prompt_body(text: &str, model: Option<&str>) -> Value {
 }
 
 pub struct OpenCodeDriver {
-    server: PooledServer,
+    // `Drop` releases this lease before waking the worker, guaranteeing that
+    // final process teardown runs on the worker rather than the UI thread.
+    server: Option<PooledServer>,
     session_id: String,
     commands: Sender<CommandMessage>,
+    permissions: Arc<Mutex<OpenCodePermissionState>>,
+    event_stream: Arc<OpenCodeEventStreamControl>,
     mode: RuntimeMode,
     interaction_mode: InteractionMode,
     computer_use: Option<super::support::HeadlessComputerUseRuntime>,
@@ -231,6 +236,8 @@ impl OpenCodeDriver {
         let auto_approve = mode != RuntimeMode::Ask;
         let (commands, command_rx) = unbounded();
         let turn_active = Arc::new(Mutex::new(false));
+        let permissions = Arc::new(Mutex::new(OpenCodePermissionState::default()));
+        let event_stream = Arc::new(OpenCodeEventStreamControl::default());
 
         // The reader holds only the port, never a server handle: the stream
         // closes exactly when the process exits, so a handle held here would
@@ -241,19 +248,25 @@ impl OpenCodeDriver {
         let stream_commands = commands.clone();
         let stream_turn = turn_active.clone();
         let stream_usage_metadata = usage_metadata;
+        let stream_permissions = Arc::clone(&permissions);
+        let stream_control = Arc::clone(&event_stream);
         thread::Builder::new()
             .name("waku-opencode-events".into())
             .spawn(move || {
                 let mut state = OpenCodeStreamState {
                     usage_metadata: stream_usage_metadata,
+                    permissions: stream_permissions,
                     ..OpenCodeStreamState::default()
                 };
                 // The server-wide stream, not a per-session one: the scoped
                 // route exists only under `/api`, and the workspace server
                 // may carry other sessions' traffic, so filter by session id.
-                match open_event_stream(stream_port, "/event") {
-                    Ok(stream) => {
+                match open_event_stream(stream_port, "/event", &stream_control) {
+                    Ok(Some(stream)) => {
                         for line in BufReader::new(stream).lines().map_while(Result::ok) {
+                            if stream_control.is_cancelled() {
+                                break;
+                            }
                             let Some(payload) = line.strip_prefix("data:") else {
                                 continue;
                             };
@@ -278,15 +291,21 @@ impl OpenCodeDriver {
                             );
                         }
                     }
+                    Ok(None) => {}
                     Err(error) => {
-                        let _ = stream_events.send(DriverEvent::Error(tr!(
-                            "errors.read_provider_event_stream",
-                            provider = "OpenCode",
-                            error = error
-                        )));
+                        if !stream_control.is_cancelled() {
+                            let _ = stream_events.send(DriverEvent::Error(tr!(
+                                "errors.read_provider_event_stream",
+                                provider = "OpenCode",
+                                error = error
+                            )));
+                        }
                     }
                 }
-                let _ = stream_events.send(DriverEvent::ProcessExited);
+                stream_control.clear();
+                if !stream_control.is_cancelled() {
+                    let _ = stream_events.send(DriverEvent::ProcessExited);
+                }
             })?;
 
         let worker_server = server.clone();
@@ -409,12 +428,17 @@ impl OpenCodeDriver {
                         CommandMessage::Shutdown => break,
                     }
                 }
+            })
+            .inspect_err(|_| {
+                event_stream.cancel();
             })?;
 
         Ok(Self {
-            server,
+            server: Some(server),
             session_id,
             commands,
+            permissions,
+            event_stream,
             mode,
             interaction_mode,
             computer_use,
@@ -446,10 +470,14 @@ impl DriverControl for OpenCodeDriver {
     }
 
     fn respond(&self, request_id: String, option_id: String) {
-        let _ = self.commands.send(CommandMessage::Respond {
-            request_id,
-            option_id,
-        });
+        for (request_id, option_id) in
+            permission_responses(&self.permissions, &request_id, &option_id)
+        {
+            let _ = self.commands.send(CommandMessage::Respond {
+                request_id,
+                option_id,
+            });
+        }
     }
 
     fn apply_options(&self, options: SessionOptions) -> bool {
@@ -466,18 +494,56 @@ impl DriverControl for OpenCodeDriver {
     }
 
     fn fork(&self, turns_to_remove: usize) -> anyhow::Result<ProviderResumeCursor> {
-        fork_session_removing_turns_on_server(&self.server, &self.session_id, turns_to_remove)
+        let server = self
+            .server
+            .as_deref()
+            .ok_or_else(|| anyhow!("OpenCode driver is shutting down"))?;
+        fork_session_removing_turns_on_server(server, &self.session_id, turns_to_remove)
     }
 }
 
 impl Drop for OpenCodeDriver {
     fn drop(&mut self) {
         self.cancel_computer_use();
+        self.event_stream.cancel();
+        // The worker owns the other server lease. Release the UI-owned lease
+        // first, then wake the worker so any final terminate/wait happens there.
+        drop(self.server.take());
         let _ = self.commands.send(CommandMessage::Shutdown);
-        // The server dies with the last pool handle. The worker thread drops
-        // its handle once it consumes the shutdown command; the stream and
-        // metadata readers hold only the port, so they cannot keep a dying
-        // server alive.
+    }
+}
+
+#[derive(Default)]
+struct OpenCodeEventStreamControl {
+    cancelled: AtomicBool,
+    socket: Mutex<Option<TcpStream>>,
+}
+
+impl OpenCodeEventStreamControl {
+    fn attach(&self, stream: &TcpStream) -> std::io::Result<bool> {
+        let socket = stream.try_clone()?;
+        let mut active = self.socket.lock();
+        if self.cancelled.load(Ordering::Acquire) {
+            let _ = socket.shutdown(Shutdown::Both);
+            return Ok(false);
+        }
+        *active = Some(socket);
+        Ok(true)
+    }
+
+    fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+        if let Some(socket) = self.socket.lock().take() {
+            let _ = socket.shutdown(Shutdown::Both);
+        }
+    }
+
+    fn clear(&self) {
+        self.socket.lock().take();
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
     }
 }
 
@@ -485,9 +551,19 @@ impl Drop for OpenCodeDriver {
 ///
 /// The shared request helper reads a whole response before returning, which a
 /// stream never finishes doing.
-fn open_event_stream(port: u16, path: &str) -> anyhow::Result<TcpStream> {
+fn open_event_stream(
+    port: u16,
+    path: &str,
+    control: &OpenCodeEventStreamControl,
+) -> anyhow::Result<Option<TcpStream>> {
     let mut stream = TcpStream::connect(("127.0.0.1", port))
         .with_context(|| format!("could not connect to OpenCode on local port {port}"))?;
+    // Register before reading the response head too. If this driver is dropped
+    // while setup is blocked, cancellation can still close the socket and wake
+    // the reader even though another pooled session keeps the server alive.
+    if !control.attach(&stream)? {
+        return Ok(None);
+    }
     write!(
         stream,
         "GET {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nAccept: text/event-stream\r\nConnection: keep-alive\r\n\r\n"
@@ -506,7 +582,7 @@ fn open_event_stream(port: u16, path: &str) -> anyhow::Result<TcpStream> {
         }
     }
     stream.set_read_timeout(None)?;
-    Ok(stream)
+    Ok(Some(stream))
 }
 
 #[derive(Default)]
@@ -514,12 +590,85 @@ struct OpenCodeStreamState {
     tools: HashMap<String, (ActivityKind, String)>,
     reasoning_parts: HashSet<String>,
     usage_metadata: Arc<OpenCodeUsageMetadata>,
+    permissions: Arc<Mutex<OpenCodePermissionState>>,
 }
 
 #[derive(Default)]
 struct OpenCodeUsageMetadata {
     model_context_windows: Mutex<HashMap<String, u64>>,
     last_model: Mutex<Option<String>>,
+}
+
+#[derive(Clone, Debug)]
+struct OpenCodePermissionRequest {
+    permission: String,
+    patterns: Vec<String>,
+    always: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct OpenCodePermissionRule {
+    permission: String,
+    pattern: String,
+}
+
+#[derive(Default)]
+struct OpenCodePermissionState {
+    pending: HashMap<String, OpenCodePermissionRequest>,
+    approved: HashSet<OpenCodePermissionRule>,
+}
+
+impl OpenCodePermissionState {
+    fn is_approved(&self, request: &OpenCodePermissionRequest) -> bool {
+        !request.patterns.is_empty()
+            && request.patterns.iter().all(|pattern| {
+                self.approved.iter().any(|rule| {
+                    opencode_wildcard_matches(&request.permission, &rule.permission)
+                        && opencode_wildcard_matches(pattern, &rule.pattern)
+                })
+            })
+    }
+
+    fn remember(&mut self, request: &OpenCodePermissionRequest) {
+        // Mirror OpenCode's own `always` handling exactly: only provider-
+        // supplied reusable patterns become rules. An empty list deliberately
+        // resolves the current request without broadening future access.
+        self.approved
+            .extend(request.always.iter().map(|pattern| OpenCodePermissionRule {
+                permission: request.permission.clone(),
+                pattern: pattern.clone(),
+            }));
+    }
+}
+
+fn opencode_wildcard_matches(input: &str, pattern: &str) -> bool {
+    let input = input.replace('\\', "/");
+    let pattern = pattern.replace('\\', "/");
+    if pattern
+        .strip_suffix(" *")
+        .is_some_and(|prefix| input == prefix)
+    {
+        return true;
+    }
+
+    let input = input.chars().collect::<Vec<_>>();
+    let mut previous = vec![false; input.len() + 1];
+    previous[0] = true;
+    for token in pattern.chars() {
+        let mut current = vec![false; input.len() + 1];
+        if token == '*' {
+            current[0] = previous[0];
+        }
+        for index in 1..=input.len() {
+            current[index] = match token {
+                '*' => previous[index] || current[index - 1],
+                '?' => previous[index - 1],
+                literal => previous[index - 1] && literal == input[index - 1],
+            };
+        }
+        previous = current;
+    }
+    previous[input.len()]
 }
 
 impl OpenCodeUsageMetadata {
@@ -683,6 +832,7 @@ fn handle_event(
         }
         "session.idle" => {
             state.reasoning_parts.clear();
+            state.permissions.lock().pending.clear();
             if std::mem::take(&mut *turn_active.lock()) {
                 let _ = events.send(DriverEvent::TurnFinished {
                     success: true,
@@ -709,7 +859,13 @@ fn handle_event(
             }
         }
         _ if kind.starts_with("permission.") => {
-            request_permission(properties, events, commands, auto_approve);
+            request_permission(
+                properties,
+                events,
+                commands,
+                auto_approve,
+                &state.permissions,
+            );
         }
         // `session.created`, `session.diff`, and the plugin/catalog/reference
         // chatter are not transcript content.
@@ -722,6 +878,7 @@ fn request_permission(
     events: &impl DriverEventSink,
     commands: &Sender<CommandMessage>,
     auto_approve: bool,
+    permissions: &Mutex<OpenCodePermissionState>,
 ) {
     // The request is either the properties themselves or nested under a key,
     // and it is identified by its `per`-prefixed ID.
@@ -733,31 +890,54 @@ fn request_permission(
     let Some(request_id) = request.get("id").and_then(Value::as_str) else {
         return;
     };
+    let permission_request = OpenCodePermissionRequest {
+        permission: request
+            .get("permission")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned(),
+        patterns: request
+            .get("patterns")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+            .map(str::to_owned)
+            .collect(),
+        always: request
+            .get("always")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+            .map(str::to_owned)
+            .collect(),
+    };
 
-    if auto_approve {
+    // OpenCode's `always` response updates a process-wide approval cache. A
+    // pooled Full Access task must never suppress prompts in a Supervised task,
+    // so Waku sends only one-shot provider replies and retains durable choices
+    // in this driver's session-local state.
+    if auto_approve || permissions.lock().is_approved(&permission_request) {
         let _ = commands.send(CommandMessage::Respond {
             request_id: request_id.to_owned(),
-            // Durable, so the agent stops asking about the same permission.
-            option_id: "always".into(),
+            option_id: "once".into(),
         });
         return;
     }
 
-    let permission = request
-        .get("permission")
-        .and_then(Value::as_str)
-        .map(str::to_owned)
-        .unwrap_or_else(|| tr!("permission.run_a_tool_lower"));
-    let patterns = request
-        .get("patterns")
-        .and_then(Value::as_array)
-        .map(|patterns| {
-            patterns
-                .iter()
-                .filter_map(Value::as_str)
-                .collect::<Vec<_>>()
-                .join(", ")
-        })
+    permissions
+        .lock()
+        .pending
+        .insert(request_id.to_owned(), permission_request.clone());
+
+    let permission = if permission_request.permission.is_empty() {
+        tr!("permission.run_a_tool_lower")
+    } else {
+        permission_request.permission.clone()
+    };
+    let patterns = (!permission_request.patterns.is_empty())
+        .then(|| permission_request.patterns.join(", "))
         .filter(|patterns| !patterns.is_empty());
     let _ = events.send(DriverEvent::Permission {
         request_id: request_id.to_owned(),
@@ -792,6 +972,43 @@ fn request_permission(
             },
         ],
     });
+}
+
+fn permission_responses(
+    permissions: &Mutex<OpenCodePermissionState>,
+    request_id: &str,
+    option_id: &str,
+) -> Vec<(String, String)> {
+    let mut permissions = permissions.lock();
+    let request = permissions.pending.remove(request_id);
+    if option_id != "always" {
+        return vec![(request_id.to_owned(), option_id.to_owned())];
+    }
+
+    if let Some(request) = request.as_ref() {
+        permissions.remember(request);
+    }
+    // OpenCode normally applies an `always` reply to other matching requests
+    // already pending in the same session. Preserve that behavior locally,
+    // but send every provider reply as one-shot so the shared server's cache
+    // remains untouched.
+    let additional = permissions
+        .pending
+        .iter()
+        .filter(|(_, request)| permissions.is_approved(request))
+        .map(|(request_id, _)| request_id.clone())
+        .collect::<Vec<_>>();
+    for request_id in &additional {
+        permissions.pending.remove(request_id);
+    }
+
+    std::iter::once((request_id.to_owned(), "once".into()))
+        .chain(
+            additional
+                .into_iter()
+                .map(|request_id| (request_id, "once".into())),
+        )
+        .collect()
 }
 
 fn tool_activity(part: &Value, events: &impl DriverEventSink, state: &mut OpenCodeStreamState) {
@@ -1237,7 +1454,7 @@ mod tests {
     }
 
     #[test]
-    fn supervised_mode_asks_the_user_and_auto_modes_answer_durably() {
+    fn permission_approvals_stay_driver_local() {
         let (events, event_rx, commands, command_rx, turn, mut state) = harness();
         // Shape from the server's OpenAPI PermissionRequest schema.
         let permission = json!({
@@ -1248,7 +1465,7 @@ mod tests {
                 "permission": "bash",
                 "patterns": ["rm -rf *"],
                 "metadata": {},
-                "always": []
+                "always": ["rm -rf *"]
             }
         });
 
@@ -1270,11 +1487,148 @@ mod tests {
         );
         assert!(command_rx.try_recv().is_err());
 
-        handle_event(&permission, &events, &commands, &turn, true, &mut state);
+        assert_eq!(
+            permission_responses(&state.permissions, "per_abc", "always"),
+            [("per_abc".into(), "once".into())],
+            "provider-wide durable approval must be translated to one-shot"
+        );
+        let repeated = json!({
+            "type": "permission.requested",
+            "properties": {
+                "id": "per_def",
+                "sessionID": "ses_1",
+                "permission": "bash",
+                "patterns": ["rm -rf /tmp/waku-cache"],
+                "metadata": {},
+                "always": ["rm -rf *"]
+            }
+        });
+        handle_event(&repeated, &events, &commands, &turn, false, &mut state);
+        let Ok(CommandMessage::Respond { option_id, .. }) = command_rx.try_recv() else {
+            panic!("the driver's remembered rule should answer without asking again");
+        };
+        assert_eq!(option_id, "once");
+        assert!(event_rx.try_recv().is_err());
+
+        let mut isolated = OpenCodeStreamState::default();
+        handle_event(&repeated, &events, &commands, &turn, false, &mut isolated);
+        assert!(matches!(
+            event_rx.try_recv().unwrap(),
+            DriverEvent::Permission { request_id, .. } if request_id == "per_def"
+        ));
+        assert!(
+            command_rx.try_recv().is_err(),
+            "another driver must not inherit the approval"
+        );
+    }
+
+    #[test]
+    fn auto_modes_use_one_shot_provider_approval() {
+        let (events, event_rx, commands, command_rx, turn, mut state) = harness();
+        handle_event(
+            &json!({
+                "type": "permission.requested",
+                "properties": {
+                    "id": "per_auto",
+                    "sessionID": "ses_1",
+                    "permission": "bash",
+                    "patterns": ["cargo test"],
+                    "always": ["cargo *"]
+                }
+            }),
+            &events,
+            &commands,
+            &turn,
+            true,
+            &mut state,
+        );
         let Ok(CommandMessage::Respond { option_id, .. }) = command_rx.try_recv() else {
             panic!("auto modes must answer without the user");
         };
-        assert_eq!(option_id, "always");
+        assert_eq!(option_id, "once");
         assert!(event_rx.try_recv().is_err());
+        assert!(state.permissions.lock().approved.is_empty());
+    }
+
+    #[test]
+    fn always_without_provider_rules_does_not_broaden_future_access() {
+        let permissions = Mutex::new(OpenCodePermissionState::default());
+        permissions.lock().pending.insert(
+            "per_once".into(),
+            OpenCodePermissionRequest {
+                permission: "bash".into(),
+                patterns: vec!["cargo test".into()],
+                always: Vec::new(),
+            },
+        );
+
+        assert_eq!(
+            permission_responses(&permissions, "per_once", "always"),
+            [("per_once".into(), "once".into())]
+        );
+        assert!(permissions.lock().approved.is_empty());
+    }
+
+    #[test]
+    fn always_resolves_matching_requests_that_are_already_pending() {
+        let permissions = Mutex::new(OpenCodePermissionState::default());
+        let request = |patterns: &[&str]| OpenCodePermissionRequest {
+            permission: "bash".into(),
+            patterns: patterns.iter().map(|pattern| (*pattern).into()).collect(),
+            always: vec!["cargo *".into()],
+        };
+        permissions
+            .lock()
+            .pending
+            .insert("per_first".into(), request(&["cargo test"]));
+        permissions
+            .lock()
+            .pending
+            .insert("per_matching".into(), request(&["cargo check"]));
+        permissions
+            .lock()
+            .pending
+            .insert("per_other".into(), request(&["git status"]));
+
+        assert_eq!(
+            permission_responses(&permissions, "per_first", "always"),
+            [
+                ("per_first".into(), "once".into()),
+                ("per_matching".into(), "once".into()),
+            ]
+        );
+        let permissions = permissions.lock();
+        assert!(!permissions.pending.contains_key("per_matching"));
+        assert!(permissions.pending.contains_key("per_other"));
+    }
+
+    #[test]
+    fn cancelling_event_stream_unblocks_response_setup() {
+        use std::net::TcpListener;
+        use std::sync::mpsc;
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let control = Arc::new(OpenCodeEventStreamControl::default());
+        let reader_control = Arc::clone(&control);
+        let (done, finished) = mpsc::channel();
+        let reader = thread::spawn(move || {
+            let _ = open_event_stream(port, "/event", &reader_control);
+            done.send(()).unwrap();
+        });
+        let (_peer, _) = listener.accept().unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while control.socket.lock().is_none() && std::time::Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(5));
+        }
+        assert!(control.socket.lock().is_some());
+
+        control.cancel();
+        finished
+            .recv_timeout(Duration::from_secs(1))
+            .expect("cancellation should unblock the response-head read");
+        reader.join().unwrap();
+        assert!(control.is_cancelled());
+        assert!(control.socket.lock().is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ mod input;
 mod md;
 mod model;
 mod model_catalog;
+mod opencode_pool;
 mod opencode_session;
 mod persistence;
 mod platform;

--- a/src/opencode_pool.rs
+++ b/src/opencode_pool.rs
@@ -6,18 +6,16 @@
 //! `opencode serve` instances in the same directory. The server is killed
 //! when the last session using it drops.
 //!
-//! Handles are counted so the kill is deterministic: reader threads must hold
-//! only the server's port, never a handle, because the event stream only
+//! The pool serializes starts and final teardown per workspace. Reader threads
+//! hold only the server's port, never a handle, because the event stream only
 //! closes when the process exits — a handle held there would keep the last
 //! drop from ever killing the server, deadlocking the reader against itself.
 
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, OnceLock, Weak};
-use std::thread;
-use std::time::{Duration, Instant};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
+use std::time::Duration;
 
 use crate::opencode_session::OpenCodeServer;
 
@@ -28,35 +26,40 @@ const SERVER_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 /// A reference to a server process, shared or dedicated.
 ///
 /// Dropping the last handle kills the server. Clones add handles.
+#[derive(Clone)]
 pub(crate) struct PooledServer {
     inner: Arc<PoolInner>,
 }
 
 struct PoolInner {
     server: OpenCodeServer,
-    handles: AtomicUsize,
+    /// Dedicated Computer Use servers do not participate in a workspace slot.
+    slot: Option<Weak<PoolSlot>>,
 }
 
-impl Clone for PooledServer {
-    fn clone(&self) -> Self {
-        self.inner.handles.fetch_add(1, Ordering::Relaxed);
-        Self {
-            inner: Arc::clone(&self.inner),
-        }
-    }
-}
-
-impl Drop for PooledServer {
+impl Drop for PoolInner {
     fn drop(&mut self) {
-        if self.inner.handles.fetch_sub(1, Ordering::Relaxed) == 1 {
-            // Last session in this workspace: kill the server so the
-            // per-session event-stream readers unblock and exit.
-            self.inner.server.shutdown();
-            let deadline = Instant::now() + SERVER_EXIT_TIMEOUT;
-            while Instant::now() < deadline && self.inner.server.is_alive() {
-                thread::sleep(Duration::from_millis(20));
+        if let Some(slot) = self.slot.as_ref().and_then(Weak::upgrade) {
+            let mut state = slot.state.lock().unwrap();
+            let current = match &*state {
+                PoolState::Running(server) => std::ptr::eq(server.as_ptr(), self),
+                PoolState::Vacant | PoolState::Starting | PoolState::Stopping => false,
+            };
+            if current {
+                // Acquisition uses this same slot lock. Once Arc begins this
+                // destructor its weak reference cannot be upgraded, and the
+                // slot stays stopping until the owned child has been reaped.
+                *state = PoolState::Stopping;
+                self.server.shutdown(SERVER_EXIT_TIMEOUT);
+                *state = PoolState::Vacant;
+                slot.changed.notify_all();
+                return;
             }
         }
+
+        // Dedicated servers and superseded dead generations do not own the
+        // slot's current process, but their child still has to be reaped.
+        self.server.shutdown(SERVER_EXIT_TIMEOUT);
     }
 }
 
@@ -74,18 +77,36 @@ impl PooledServer {
     /// sessions cannot share a workspace server and keep this path.
     pub(crate) fn dedicated(server: OpenCodeServer) -> Self {
         Self {
-            inner: Arc::new(PoolInner {
-                server,
-                handles: AtomicUsize::new(1),
-            }),
+            inner: Arc::new(PoolInner { server, slot: None }),
         }
     }
 }
 
 type PoolKey = (PathBuf, PathBuf); // (binary, workspace directory)
 
-fn pool() -> &'static Mutex<HashMap<PoolKey, Weak<PoolInner>>> {
-    static POOL: OnceLock<Mutex<HashMap<PoolKey, Weak<PoolInner>>>> = OnceLock::new();
+enum PoolState {
+    Vacant,
+    Starting,
+    Running(Weak<PoolInner>),
+    Stopping,
+}
+
+struct PoolSlot {
+    state: Mutex<PoolState>,
+    changed: Condvar,
+}
+
+impl Default for PoolSlot {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(PoolState::Vacant),
+            changed: Condvar::new(),
+        }
+    }
+}
+
+fn pool() -> &'static Mutex<HashMap<PoolKey, Arc<PoolSlot>>> {
+    static POOL: OnceLock<Mutex<HashMap<PoolKey, Arc<PoolSlot>>>> = OnceLock::new();
     POOL.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
@@ -94,36 +115,78 @@ fn pool() -> &'static Mutex<HashMap<PoolKey, Weak<PoolInner>>> {
 /// Blocking (process start plus health probe), so callers must already be off
 /// the UI thread — driver start on the background executor is.
 pub(crate) fn acquire(binary: &Path, cwd: &Path) -> anyhow::Result<PooledServer> {
-    let key = (binary.to_path_buf(), cwd.to_path_buf());
-    if let Some(server) = lookup(&key) {
-        return Ok(server);
-    }
-    let server = OpenCodeServer::start(binary, cwd)?;
-    let inner = Arc::new(PoolInner {
-        server,
-        handles: AtomicUsize::new(1),
-    });
-    let mut pool = pool().lock().unwrap();
-    if let Some(existing) = pool.get(&key).and_then(Weak::upgrade) {
-        // Another session won the creation race while this server was
-        // starting. Adopt the winner and retire the duplicate.
-        inner.server.shutdown();
-        existing.handles.fetch_add(1, Ordering::Relaxed);
-        return Ok(PooledServer { inner: existing });
-    }
-    pool.insert(key, Arc::downgrade(&inner));
-    Ok(PooledServer { inner })
+    acquire_with_start(binary, cwd, || OpenCodeServer::start(binary, cwd))
 }
 
-fn lookup(key: &PoolKey) -> Option<PooledServer> {
-    let mut pool = pool().lock().unwrap();
-    let inner = pool.get(key)?.upgrade()?;
-    if inner.server.is_alive() {
-        inner.handles.fetch_add(1, Ordering::Relaxed);
-        Some(PooledServer { inner })
-    } else {
-        pool.remove(key);
-        None
+fn acquire_with_start(
+    binary: &Path,
+    cwd: &Path,
+    start: impl FnOnce() -> anyhow::Result<OpenCodeServer>,
+) -> anyhow::Result<PooledServer> {
+    let key = (binary.to_path_buf(), cwd.to_path_buf());
+    let slot = {
+        let mut pool = pool().lock().unwrap();
+        Arc::clone(pool.entry(key).or_default())
+    };
+
+    let superseded = loop {
+        let mut state = slot.state.lock().unwrap();
+        if let PoolState::Running(server) = &*state {
+            if let Some(inner) = server.upgrade() {
+                if inner.server.is_alive() {
+                    return Ok(PooledServer { inner });
+                }
+
+                // The process exited while older session handles still exist.
+                // Replace this generation; its destructor compares the weak
+                // identity and therefore cannot tear down the replacement.
+                *state = PoolState::Starting;
+                break Some(inner);
+            }
+
+            // Strong count reached zero and `PoolInner::drop` is about to mark
+            // this slot as stopping. Wait releases the lock so that destructor
+            // can finish teardown and notify us; never start alongside it.
+            state = slot.changed.wait(state).unwrap();
+            drop(state);
+            continue;
+        }
+
+        match &*state {
+            PoolState::Vacant => {
+                *state = PoolState::Starting;
+                break None;
+            }
+            PoolState::Starting | PoolState::Stopping => {
+                state = slot.changed.wait(state).unwrap();
+                drop(state);
+            }
+            PoolState::Running(_) => unreachable!(),
+        }
+    };
+
+    // If this temporary upgrade was the exited generation's last strong
+    // reference, its destructor also takes the slot lock. Drop it only after
+    // the guard above has been released.
+    drop(superseded);
+
+    let started = start();
+    let mut state = slot.state.lock().unwrap();
+    match started {
+        Ok(server) => {
+            let inner = Arc::new(PoolInner {
+                server,
+                slot: Some(Arc::downgrade(&slot)),
+            });
+            *state = PoolState::Running(Arc::downgrade(&inner));
+            slot.changed.notify_all();
+            Ok(PooledServer { inner })
+        }
+        Err(error) => {
+            *state = PoolState::Vacant;
+            slot.changed.notify_all();
+            Err(error)
+        }
     }
 }
 
@@ -131,6 +194,34 @@ fn lookup(key: &PoolKey) -> Option<PooledServer> {
 mod tests {
     use super::*;
     use std::net::TcpStream;
+    use std::sync::Barrier;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+    use std::time::Instant;
+    use uuid::Uuid;
+
+    struct TestWorkspace {
+        path: PathBuf,
+    }
+
+    impl TestWorkspace {
+        fn new() -> Self {
+            let path =
+                std::env::temp_dir().join(format!("waku-opencode-pool-test-{}", Uuid::new_v4()));
+            std::fs::create_dir(&path).expect("the test workspace should be created");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestWorkspace {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
 
     fn port_is_open(port: u16) -> bool {
         TcpStream::connect(("127.0.0.1", port)).is_ok()
@@ -146,14 +237,16 @@ mod tests {
     fn workspace_sessions_share_one_server_until_the_last_drops() {
         let binary =
             crate::command_env::find_executable("opencode").expect("opencode is not installed");
-        let cwd = std::env::temp_dir();
+        let cwd = TestWorkspace::new();
 
-        let first = acquire(&binary, &cwd).expect("the first session should start the server");
+        let first =
+            acquire(&binary, cwd.path()).expect("the first session should start the server");
         let port = first.port;
         assert!(port_is_open(port), "the server should be listening");
 
-        let second = acquire(&binary, &cwd).expect("the second session should reuse it");
+        let second = acquire(&binary, cwd.path()).expect("the second session should reuse it");
         assert_eq!(second.port, port, "both sessions must share one process");
+        assert!(Arc::ptr_eq(&first.inner, &second.inner));
 
         drop(first);
         assert!(
@@ -161,7 +254,12 @@ mod tests {
             "the server must outlive the first session"
         );
 
+        let stopping = Instant::now();
         drop(second);
+        assert!(
+            stopping.elapsed() < Duration::from_secs(2),
+            "normal teardown should observe and reap the exited child promptly"
+        );
         let deadline = Instant::now() + Duration::from_secs(10);
         while Instant::now() < deadline && port_is_open(port) {
             thread::sleep(Duration::from_millis(50));
@@ -171,9 +269,44 @@ mod tests {
             "the last session's drop should kill the shared server"
         );
 
-        let third = acquire(&binary, &cwd).expect("a later session should start a fresh server");
-        assert_ne!(third.port, port, "the pool should recover from the dead entry");
+        let third =
+            acquire(&binary, cwd.path()).expect("a later session should start a fresh server");
         assert!(port_is_open(third.port));
+    }
+
+    /// Two sessions starting together must share the same in-flight startup
+    /// instead of briefly launching competing workspace servers.
+    #[test]
+    #[ignore = "requires an installed opencode"]
+    fn concurrent_acquires_start_one_server() {
+        let binary =
+            crate::command_env::find_executable("opencode").expect("opencode is not installed");
+        let workspace = TestWorkspace::new();
+        let cwd = workspace.path().to_path_buf();
+        let barrier = Arc::new(Barrier::new(3));
+        let starts = Arc::new(AtomicUsize::new(0));
+
+        let acquire_concurrently = |barrier: Arc<Barrier>, starts: Arc<AtomicUsize>| {
+            let binary = binary.clone();
+            let cwd = cwd.clone();
+            thread::spawn(move || {
+                barrier.wait();
+                acquire_with_start(&binary, &cwd, || {
+                    starts.fetch_add(1, Ordering::Relaxed);
+                    OpenCodeServer::start(&binary, &cwd)
+                })
+                .expect("the concurrent session should acquire a server")
+            })
+        };
+        let first = acquire_concurrently(Arc::clone(&barrier), Arc::clone(&starts));
+        let second = acquire_concurrently(Arc::clone(&barrier), Arc::clone(&starts));
+        barrier.wait();
+
+        let first = first.join().expect("the first acquire should not panic");
+        let second = second.join().expect("the second acquire should not panic");
+        assert_eq!(starts.load(Ordering::Relaxed), 1);
+        assert!(Arc::ptr_eq(&first.inner, &second.inner));
+        assert_eq!(first.port, second.port);
     }
 
     /// A dedicated server — Computer Use bakes per-session configuration into
@@ -183,9 +316,9 @@ mod tests {
     fn dedicated_server_dies_with_its_last_handle() {
         let binary =
             crate::command_env::find_executable("opencode").expect("opencode is not installed");
-        let cwd = std::env::temp_dir();
+        let cwd = TestWorkspace::new();
 
-        let server = OpenCodeServer::start(&binary, &cwd).expect("the server should start");
+        let server = OpenCodeServer::start(&binary, cwd.path()).expect("the server should start");
         let port = server.port;
         let handle = PooledServer::dedicated(server);
         assert!(port_is_open(port));
@@ -194,11 +327,39 @@ mod tests {
         drop(handle);
         assert!(clone.is_alive(), "a clone should keep the server alive");
 
+        let stopping = Instant::now();
         drop(clone);
+        assert!(
+            stopping.elapsed() < Duration::from_secs(2),
+            "dedicated teardown should reap the exited child promptly"
+        );
         let deadline = Instant::now() + Duration::from_secs(10);
         while Instant::now() < deadline && port_is_open(port) {
             thread::sleep(Duration::from_millis(50));
         }
         assert!(!port_is_open(port), "the dedicated server should be killed");
+    }
+
+    /// An exited generation must be replaced even while an older session
+    /// handle still references it, and that stale handle must not kill the
+    /// replacement when it eventually drops.
+    #[test]
+    #[ignore = "requires an installed opencode"]
+    fn dead_server_recovers_without_cross_generation_teardown() {
+        let binary =
+            crate::command_env::find_executable("opencode").expect("opencode is not installed");
+        let cwd = TestWorkspace::new();
+
+        let stale = acquire(&binary, cwd.path()).expect("the first server should start");
+        stale.shutdown(SERVER_EXIT_TIMEOUT);
+        assert!(!stale.is_alive());
+
+        let replacement = acquire(&binary, cwd.path()).expect("the dead server should be replaced");
+        assert!(!Arc::ptr_eq(&stale.inner, &replacement.inner));
+        drop(stale);
+        assert!(
+            replacement.is_alive(),
+            "a stale generation must not stop its replacement"
+        );
     }
 }

--- a/src/opencode_pool.rs
+++ b/src/opencode_pool.rs
@@ -1,0 +1,204 @@
+//! Per-workspace pool of resident `opencode serve` processes.
+//!
+//! OpenCode is one long-lived process that hosts many sessions, so every
+//! session in a workspace shares a single server instead of starting its own
+//! — one config load, one plugin/MCP stack, and no contention between two
+//! `opencode serve` instances in the same directory. The server is killed
+//! when the last session using it drops.
+//!
+//! Handles are counted so the kill is deterministic: reader threads must hold
+//! only the server's port, never a handle, because the event stream only
+//! closes when the process exits — a handle held there would keep the last
+//! drop from ever killing the server, deadlocking the reader against itself.
+
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::opencode_session::OpenCodeServer;
+
+/// How long the last drop waits for the server to actually exit, so a
+/// session starting right after it cannot adopt a dying process.
+const SERVER_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A reference to a server process, shared or dedicated.
+///
+/// Dropping the last handle kills the server. Clones add handles.
+pub(crate) struct PooledServer {
+    inner: Arc<PoolInner>,
+}
+
+struct PoolInner {
+    server: OpenCodeServer,
+    handles: AtomicUsize,
+}
+
+impl Clone for PooledServer {
+    fn clone(&self) -> Self {
+        self.inner.handles.fetch_add(1, Ordering::Relaxed);
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl Drop for PooledServer {
+    fn drop(&mut self) {
+        if self.inner.handles.fetch_sub(1, Ordering::Relaxed) == 1 {
+            // Last session in this workspace: kill the server so the
+            // per-session event-stream readers unblock and exit.
+            self.inner.server.shutdown();
+            let deadline = Instant::now() + SERVER_EXIT_TIMEOUT;
+            while Instant::now() < deadline && self.inner.server.is_alive() {
+                thread::sleep(Duration::from_millis(20));
+            }
+        }
+    }
+}
+
+impl Deref for PooledServer {
+    type Target = OpenCodeServer;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.server
+    }
+}
+
+impl PooledServer {
+    /// Wraps a server a session started for itself. Computer Use bakes
+    /// per-session configuration into the server environment, so those
+    /// sessions cannot share a workspace server and keep this path.
+    pub(crate) fn dedicated(server: OpenCodeServer) -> Self {
+        Self {
+            inner: Arc::new(PoolInner {
+                server,
+                handles: AtomicUsize::new(1),
+            }),
+        }
+    }
+}
+
+type PoolKey = (PathBuf, PathBuf); // (binary, workspace directory)
+
+fn pool() -> &'static Mutex<HashMap<PoolKey, Weak<PoolInner>>> {
+    static POOL: OnceLock<Mutex<HashMap<PoolKey, Weak<PoolInner>>>> = OnceLock::new();
+    POOL.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Returns the workspace's resident server, starting one if none is alive.
+///
+/// Blocking (process start plus health probe), so callers must already be off
+/// the UI thread — driver start on the background executor is.
+pub(crate) fn acquire(binary: &Path, cwd: &Path) -> anyhow::Result<PooledServer> {
+    let key = (binary.to_path_buf(), cwd.to_path_buf());
+    if let Some(server) = lookup(&key) {
+        return Ok(server);
+    }
+    let server = OpenCodeServer::start(binary, cwd)?;
+    let inner = Arc::new(PoolInner {
+        server,
+        handles: AtomicUsize::new(1),
+    });
+    let mut pool = pool().lock().unwrap();
+    if let Some(existing) = pool.get(&key).and_then(Weak::upgrade) {
+        // Another session won the creation race while this server was
+        // starting. Adopt the winner and retire the duplicate.
+        inner.server.shutdown();
+        existing.handles.fetch_add(1, Ordering::Relaxed);
+        return Ok(PooledServer { inner: existing });
+    }
+    pool.insert(key, Arc::downgrade(&inner));
+    Ok(PooledServer { inner })
+}
+
+fn lookup(key: &PoolKey) -> Option<PooledServer> {
+    let mut pool = pool().lock().unwrap();
+    let inner = pool.get(key)?.upgrade()?;
+    if inner.server.is_alive() {
+        inner.handles.fetch_add(1, Ordering::Relaxed);
+        Some(PooledServer { inner })
+    } else {
+        pool.remove(key);
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpStream;
+
+    fn port_is_open(port: u16) -> bool {
+        TcpStream::connect(("127.0.0.1", port)).is_ok()
+    }
+
+    /// Proves the pool's contract against a real server: two sessions in one
+    /// workspace share a single process, the server outlives the first
+    /// session, the last session's drop kills it, and a later session starts
+    /// a fresh one. Ignored by default: needs the CLI installed. Run with
+    /// `cargo test --bin waku opencode_pool -- --ignored`.
+    #[test]
+    #[ignore = "requires an installed opencode"]
+    fn workspace_sessions_share_one_server_until_the_last_drops() {
+        let binary =
+            crate::command_env::find_executable("opencode").expect("opencode is not installed");
+        let cwd = std::env::temp_dir();
+
+        let first = acquire(&binary, &cwd).expect("the first session should start the server");
+        let port = first.port;
+        assert!(port_is_open(port), "the server should be listening");
+
+        let second = acquire(&binary, &cwd).expect("the second session should reuse it");
+        assert_eq!(second.port, port, "both sessions must share one process");
+
+        drop(first);
+        assert!(
+            second.is_alive(),
+            "the server must outlive the first session"
+        );
+
+        drop(second);
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline && port_is_open(port) {
+            thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            !port_is_open(port),
+            "the last session's drop should kill the shared server"
+        );
+
+        let third = acquire(&binary, &cwd).expect("a later session should start a fresh server");
+        assert_ne!(third.port, port, "the pool should recover from the dead entry");
+        assert!(port_is_open(third.port));
+    }
+
+    /// A dedicated server — Computer Use bakes per-session configuration into
+    /// the environment — dies with its handle just like a pooled one.
+    #[test]
+    #[ignore = "requires an installed opencode"]
+    fn dedicated_server_dies_with_its_last_handle() {
+        let binary =
+            crate::command_env::find_executable("opencode").expect("opencode is not installed");
+        let cwd = std::env::temp_dir();
+
+        let server = OpenCodeServer::start(&binary, &cwd).expect("the server should start");
+        let port = server.port;
+        let handle = PooledServer::dedicated(server);
+        assert!(port_is_open(port));
+
+        let clone = handle.clone();
+        drop(handle);
+        assert!(clone.is_alive(), "a clone should keep the server alive");
+
+        drop(clone);
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline && port_is_open(port) {
+            thread::sleep(Duration::from_millis(50));
+        }
+        assert!(!port_is_open(port), "the dedicated server should be killed");
+    }
+}

--- a/src/opencode_session.rs
+++ b/src/opencode_session.rs
@@ -6,6 +6,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context as _, anyhow, bail};
+use parking_lot::Mutex;
 use serde_json::{Value, json};
 
 use crate::model::ProviderResumeCursor;
@@ -118,9 +119,8 @@ fn fork_message_id(message_ids: &[String], retained_turns: usize) -> anyhow::Res
 }
 
 pub(crate) struct OpenCodeServer {
-    child: Child,
+    child: Mutex<Child>,
     pub(crate) port: u16,
-    pid: u32,
 }
 
 impl OpenCodeServer {
@@ -160,8 +160,10 @@ impl OpenCodeServer {
             .stderr(Stdio::null());
         let child =
             crate::command_env::spawn(command).context("failed to start `opencode serve`")?;
-        let pid = child.id();
-        let mut server = Self { child, port, pid };
+        let server = Self {
+            child: Mutex::new(child),
+            port,
+        };
         let started_at = Instant::now();
         loop {
             if server
@@ -170,7 +172,7 @@ impl OpenCodeServer {
             {
                 return Ok(server);
             }
-            if let Some(status) = server.child.try_wait()? {
+            if let Some(status) = server.child.lock().try_wait()? {
                 bail!("OpenCode session server exited during startup ({status})");
             }
             if started_at.elapsed() >= SERVER_START_TIMEOUT {
@@ -199,24 +201,14 @@ impl OpenCodeServer {
         request_json_on_port(self.port, method, path, body, timeout)
     }
 
-    /// Whether the server process is still running. Cheap — no subprocess
-    /// spawn — so the pool can probe without per-frame cost.
+    /// Whether the server process is still running. `Child::try_wait` both
+    /// observes and reaps an exited child; `kill(pid, 0)` cannot distinguish a
+    /// running process from the unreaped zombie owned by this process.
     pub(crate) fn is_alive(&self) -> bool {
-        if self.pid == 0 {
-            return false;
-        }
-        #[cfg(unix)]
-        {
-            // `kill(pid, 0)` performs no signal, only the existence and
-            // permission check; EPERM still means the process exists.
-            let result = unsafe { libc::kill(self.pid as libc::pid_t, 0) };
-            result == 0
-                || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
-        }
-        #[cfg(not(unix))]
-        {
-            true
-        }
+        self.child
+            .lock()
+            .try_wait()
+            .is_ok_and(|status| status.is_none())
     }
 }
 
@@ -234,29 +226,45 @@ fn is_native_user_turn(message: &Value) -> bool {
 }
 
 impl OpenCodeServer {
-    /// Ends the server without owning it mutably.
-    ///
-    /// A long-lived reader blocked on the event stream keeps a handle alive, and
-    /// that stream only closes when the server exits — so waiting for the last
-    /// handle to drop deadlocks and leaks the process. The owner kills it
-    /// directly instead, which closes the stream and releases the readers.
-    pub(crate) fn shutdown(&self) {
-        if self.pid == 0 {
+    /// Terminates and reaps the owned child. The timeout is a graceful-exit
+    /// budget; a server that ignores TERM is killed afterward.
+    pub(crate) fn shutdown(&self, timeout: Duration) {
+        let mut child = self.child.lock();
+        if child.try_wait().is_ok_and(|status| status.is_some()) {
             return;
         }
+
         #[cfg(unix)]
         {
-            let _ = std::process::Command::new("/bin/kill")
-                .args(["-TERM", &self.pid.to_string()])
-                .status();
+            let _ = unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGTERM) };
         }
+        #[cfg(not(unix))]
+        {
+            let _ = child.kill();
+        }
+
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            match child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => thread::sleep(Duration::from_millis(20)),
+                Err(_) => break,
+            }
+        }
+
+        let _ = child.kill();
+        let _ = child.wait();
     }
 }
 
 impl Drop for OpenCodeServer {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        let child = self.child.get_mut();
+        if child.try_wait().is_ok_and(|status| status.is_some()) {
+            return;
+        }
+        let _ = child.kill();
+        let _ = child.wait();
     }
 }
 
@@ -524,6 +532,43 @@ mod tests {
             http_response_is_complete(b"HTTP/1.1 204 No Content\r\nConnection: keep-alive\r\n\r\n")
                 .unwrap()
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn liveness_probe_reaps_an_exited_child() {
+        let child = std::process::Command::new("/usr/bin/true")
+            .spawn()
+            .expect("the probe child should start");
+        let server = OpenCodeServer {
+            child: Mutex::new(child),
+            port: 0,
+        };
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline && server.is_alive() {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(!server.is_alive(), "the exited child should be reaped");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shutdown_waits_for_and_reaps_the_owned_child() {
+        let child = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .expect("the probe child should start");
+        let server = OpenCodeServer {
+            child: Mutex::new(child),
+            port: 0,
+        };
+        let started = Instant::now();
+        server.shutdown(Duration::from_secs(3));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "a TERM-responsive child should not consume the shutdown budget"
+        );
+        assert!(!server.is_alive());
     }
 
     /// Exercises the same cold-session path used when an edited message is

--- a/src/opencode_session.rs
+++ b/src/opencode_session.rs
@@ -28,7 +28,9 @@ pub fn fork_session_at_turn(
     session_id: &str,
     retained_turns: usize,
 ) -> anyhow::Result<ProviderResumeCursor> {
-    let server = OpenCodeServer::start(binary, cwd)?;
+    // Shares the workspace's resident server when one is live; a transient
+    // one is started and killed with the handle otherwise.
+    let server = crate::opencode_pool::acquire(binary, cwd)?;
     fork_session_at_turn_on_server(&server, session_id, retained_turns)
 }
 
@@ -194,15 +196,27 @@ impl OpenCodeServer {
         body: Option<&Value>,
         timeout: Duration,
     ) -> anyhow::Result<Value> {
-        let body = body.map(serde_json::to_vec).transpose()?;
-        let response = http_request(self.port, method, path, body.as_deref(), timeout)?;
-        // Some routes answer 204 No Content — `prompt_async` among them — and
-        // the status was already checked, so an empty success body is Null.
-        if response.iter().all(u8::is_ascii_whitespace) {
-            return Ok(Value::Null);
+        request_json_on_port(self.port, method, path, body, timeout)
+    }
+
+    /// Whether the server process is still running. Cheap — no subprocess
+    /// spawn — so the pool can probe without per-frame cost.
+    pub(crate) fn is_alive(&self) -> bool {
+        if self.pid == 0 {
+            return false;
         }
-        serde_json::from_slice(&response)
-            .with_context(|| format!("OpenCode returned invalid JSON for {method} {path}"))
+        #[cfg(unix)]
+        {
+            // `kill(pid, 0)` performs no signal, only the existence and
+            // permission check; EPERM still means the process exists.
+            let result = unsafe { libc::kill(self.pid as libc::pid_t, 0) };
+            result == 0
+                || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+        }
+        #[cfg(not(unix))]
+        {
+            true
+        }
     }
 }
 
@@ -244,6 +258,27 @@ impl Drop for OpenCodeServer {
         let _ = self.child.kill();
         let _ = self.child.wait();
     }
+}
+
+/// Sends one request to a server identified by port alone. Readers that must
+/// not keep the server alive (they only unblock when it exits) hold the port
+/// instead of a handle and request through this.
+pub(crate) fn request_json_on_port(
+    port: u16,
+    method: &str,
+    path: &str,
+    body: Option<&Value>,
+    timeout: Duration,
+) -> anyhow::Result<Value> {
+    let body = body.map(serde_json::to_vec).transpose()?;
+    let response = http_request(port, method, path, body.as_deref(), timeout)?;
+    // Some routes answer 204 No Content — `prompt_async` among them — and
+    // the status was already checked, so an empty success body is Null.
+    if response.iter().all(u8::is_ascii_whitespace) {
+        return Ok(Value::Null);
+    }
+    serde_json::from_slice(&response)
+        .with_context(|| format!("OpenCode returned invalid JSON for {method} {path}"))
 }
 
 fn http_request(


### PR DESCRIPTION
## What

Sessions in the same workspace previously started their own `opencode serve` process, each loading its own config, plugins, and MCP stack — and a second server in one workspace contends with the first for OpenCode's local resources (the fork path already documented this).

A per-workspace pool now hands every session the same resident server:

- **`src/opencode_pool.rs`** (new) — `acquire(binary, cwd)` starts the workspace server on first use and reuses it while alive. Creation races adopt the winner and retire the duplicate; a `libc::kill(pid, 0)` liveness probe lets dead entries self-heal. `PooledServer` counts handles so teardown is deterministic: the last session's drop kills the process and waits for it to exit.
- **`src/driver/opencode.rs`** — the driver acquires from the pool. Event-stream and usage-metadata reader threads hold only the port (the stream closes exactly when the process exits, so a handle held there would deadlock the kill). Computer Use sessions keep a dedicated server since their config is baked into the server environment per session. Cold-session forks share the live server too.
- **Usage-meter fix folded in** — `/api/model` answers with an empty catalog until the server warms up; the one-shot fetch at start always lost that race on a cold server. The metadata thread now polls until models land (30s budget). Pooling makes later sessions share an already-warm server.

## Validation

- Full unit suite: 554 passed, 0 failed.
- Against a real `opencode serve`: session/prompt/streaming/usage integration, mid-turn steering, and new pool tests (two sessions share one process; server outlives the first drop; last drop kills it; next session gets a fresh server; dedicated servers die with their handle).

## Noted separately (pre-existing, not addressed here)

On opencode 1.18.15 some v1 routes Waku posts to have moved: `/session/{id}/agent` (now v2 `switchAgent`) and `/session/{id}/permission/{rid}/reply` (now `/session/{id}/permissions/{pid}` with `{"response": ...}`). Plan/build switching and Supervised permission replies need a follow-up pass with version detection.
