### PR TITLE
Support Claude 1M model selection through gateways

### DIFF
--- a/src/app/commit_dialog.rs
+++ b/src/app/commit_dialog.rs
@@ -112,7 +112,7 @@ impl Waku {
                 Some((
                     self.workspace_path_for_session(session)?.to_path_buf(),
                     session.provider,
-                    self.model_for_session(session).map(str::to_owned),
+                    self.model_id_for_request(session),
                     session.reasoning_effort.clone(),
                 ))
             })

--- a/src/app/composer.rs
+++ b/src/app/composer.rs
@@ -789,12 +789,19 @@ impl Waku {
 
                 for (row_index, (kind, model)) in available_models.iter().enumerate() {
                     let kind = *kind;
-                    let is_selected =
-                        kind == provider && selected_model.as_deref() == Some(model.id.as_str());
+                    let is_selected = kind == provider
+                        && selected_model.as_ref().is_some_and(|selected| {
+                            crate::model_catalog::model_ids_match(kind, &selected, &model.id)
+                        });
                     let is_highlighted = highlight == Some(row_index);
-                    let is_favorite = favorites
-                        .iter()
-                        .any(|favorite| favorite.provider == kind && favorite.model == model.id);
+                    let is_favorite = favorites.iter().any(|favorite| {
+                        favorite.provider == kind
+                            && crate::model_catalog::model_ids_match(
+                                kind,
+                                &favorite.model,
+                                &model.id,
+                            )
+                    });
                     let model_id = model.id.clone();
                     let select_weak = weak.clone();
                     let select_popover = popover.clone();
@@ -1051,7 +1058,12 @@ impl Waku {
             "",
         )
         .iter()
-        .position(|(kind, model)| *kind == provider && selected_model == Some(model.id.as_str()))
+        .position(|(kind, model)| {
+            *kind == provider
+                && selected_model.is_some_and(|selected| {
+                    crate::model_catalog::model_ids_match(*kind, selected, &model.id)
+                })
+        })
         .unwrap_or(0);
         self.model_picker_scroll.scroll_to_item(index);
     }
@@ -2813,9 +2825,10 @@ pub(super) fn visible_picker_models(
                     .all(|token| searchable.contains(token));
             }
             match selected_tab {
-                ModelPickerTab::Favorites => favorites
-                    .iter()
-                    .any(|favorite| favorite.provider == *kind && favorite.model == model.id),
+                ModelPickerTab::Favorites => favorites.iter().any(|favorite| {
+                    favorite.provider == *kind
+                        && crate::model_catalog::model_ids_match(*kind, &favorite.model, &model.id)
+                }),
                 ModelPickerTab::Provider(provider) => provider == *kind,
             }
         })
@@ -2824,7 +2837,10 @@ pub(super) fn visible_picker_models(
         models.sort_by_key(|(kind, model)| {
             favorites
                 .iter()
-                .position(|favorite| favorite.provider == *kind && favorite.model == model.id)
+                .position(|favorite| {
+                    favorite.provider == *kind
+                        && crate::model_catalog::model_ids_match(*kind, &favorite.model, &model.id)
+                })
                 .unwrap_or(usize::MAX)
         });
     }

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -926,12 +926,21 @@ impl Waku {
         })
     }
 
+    pub(super) fn model_id_for_request(&self, session: &AgentSession) -> Option<String> {
+        self.model_for_session(session)
+            .map(|model| crate::model_catalog::canonical_model_id(session.provider, model))
+    }
+
     pub(super) fn model_display_name(&self, provider: ProviderKind, model: Option<&str>) -> String {
         let Some(model) = model else {
             return provider.short_name().to_owned();
         };
         self.provider_probe(provider)
-            .and_then(|probe| probe.models.iter().find(|candidate| candidate.id == model))
+            .and_then(|probe| {
+                probe.models.iter().find(|candidate| {
+                    crate::model_catalog::model_ids_match(provider, &candidate.id, model)
+                })
+            })
             .map(|candidate| candidate.name.clone())
             .unwrap_or_else(|| model.to_owned())
     }
@@ -944,7 +953,9 @@ impl Waku {
         self.provider_probe(session.provider)?
             .models
             .iter()
-            .find(|candidate| candidate.id == model)
+            .find(|candidate| {
+                crate::model_catalog::model_ids_match(session.provider, &candidate.id, model)
+            })
     }
 
     pub(super) fn selected_transcript_blocks(&self) -> &[TranscriptBlock] {
@@ -1873,11 +1884,7 @@ impl Waku {
     /// and in-session option changes both go through this so they cannot
     /// disagree about what the session is currently set to.
     pub(super) fn session_options(&self, session: &AgentSession) -> SessionOptions {
-        let model = session.model.clone().or_else(|| {
-            self.provider_probe(session.provider)
-                .and_then(ProviderProbe::preferred_model)
-                .map(|model| model.id.clone())
-        });
+        let model = self.model_id_for_request(session);
         let model_metadata = self.model_metadata_for_session(session);
         let reasoning_effort = session.reasoning_effort.clone().filter(|effort| {
             model_metadata.is_some_and(|model| {

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -743,12 +743,10 @@ impl Waku {
         model: String,
         cx: &mut Context<Self>,
     ) {
-        if let Some(index) = self
-            .state
-            .favorite_models
-            .iter()
-            .position(|favorite| favorite.provider == provider && favorite.model == model)
-        {
+        if let Some(index) = self.state.favorite_models.iter().position(|favorite| {
+            favorite.provider == provider
+                && crate::model_catalog::model_ids_match(provider, &favorite.model, &model)
+        }) {
             self.state.favorite_models.remove(index);
         } else {
             self.state

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1787,6 +1787,38 @@ fn model_picker_subtitle_deduplicates_the_provider_name() {
 }
 
 #[test]
+fn legacy_claude_fable_favorite_matches_the_single_1m_picker_entry() {
+    use super::ModelPickerTab;
+    use super::composer::visible_picker_models;
+    use crate::model::{FavoriteModel, ProviderModel, ProviderProbe};
+
+    let probes = [ProviderProbe {
+        provider: ProviderKind::Claude,
+        installed: true,
+        path: Some(std::path::PathBuf::from("/bin/claude")),
+        models: vec![ProviderModel::new(
+            "claude-fable-5[1m]",
+            "Claude Fable 5 · 1M",
+        )],
+    }];
+    let favorites = [FavoriteModel {
+        provider: ProviderKind::Claude,
+        model: "claude-fable-5".into(),
+    }];
+
+    let models = visible_picker_models(
+        &probes,
+        &favorites,
+        &[],
+        None,
+        ModelPickerTab::Favorites,
+        "",
+    );
+    assert_eq!(models.len(), 1);
+    assert_eq!(models[0].1.id, "claude-fable-5[1m]");
+}
+
+#[test]
 fn tab_cycle_walks_favorites_then_usable_providers_in_rail_order() {
     use super::ModelPickerTab;
     use super::composer::visible_picker_tabs;

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -49,17 +49,7 @@ pub fn fallback_models(provider: ProviderKind) -> Vec<ProviderModel> {
                 )
         })
         .collect(),
-        ProviderKind::Claude => vec![
-            claude_reasoning_model("claude-fable-5", "Claude Fable 5"),
-            claude_reasoning_model("claude-opus-5", "Claude Opus 5"),
-            claude_reasoning_model("claude-opus-4-8", "Claude Opus 4.8"),
-            claude_reasoning_model("claude-opus-4-7", "Claude Opus 4.7"),
-            claude_reasoning_model("claude-opus-4-6", "Claude Opus 4.6"),
-            claude_reasoning_model("claude-opus-4-5", "Claude Opus 4.5"),
-            claude_reasoning_model("claude-sonnet-5", "Claude Sonnet 5").default(),
-            claude_reasoning_model("claude-sonnet-4-6", "Claude Sonnet 4.6"),
-            ProviderModel::new("claude-haiku-4-5", "Claude Haiku 4.5"),
-        ],
+        ProviderKind::Claude => claude_fallback_models(),
         // Cursor's full catalog is account-specific and exposed by the
         // installed CLI. Auto remains the provider-owned default and keeps
         // older CLIs selectable if model discovery is unavailable.
@@ -715,6 +705,47 @@ fn claude_reasoning_model(id: &str, name: &str) -> ProviderModel {
     )
 }
 
+fn claude_reasoning_model_1m(id: &str, name: &str) -> ProviderModel {
+    claude_reasoning_model(&format!("{id}[1m]"), &format!("{name} · 1M"))
+}
+
+fn claude_fallback_models() -> Vec<ProviderModel> {
+    vec![
+        claude_reasoning_model_1m("claude-fable-5", "Claude Fable 5"),
+        claude_reasoning_model_1m("claude-opus-5", "Claude Opus 5"),
+        claude_reasoning_model("claude-opus-5", "Claude Opus 5"),
+        claude_reasoning_model_1m("claude-opus-4-8", "Claude Opus 4.8"),
+        claude_reasoning_model("claude-opus-4-8", "Claude Opus 4.8"),
+        claude_reasoning_model_1m("claude-opus-4-7", "Claude Opus 4.7"),
+        claude_reasoning_model("claude-opus-4-7", "Claude Opus 4.7"),
+        claude_reasoning_model_1m("claude-opus-4-6", "Claude Opus 4.6"),
+        claude_reasoning_model("claude-opus-4-6", "Claude Opus 4.6"),
+        claude_reasoning_model("claude-opus-4-5", "Claude Opus 4.5"),
+        claude_reasoning_model_1m("claude-sonnet-5", "Claude Sonnet 5").default(),
+        claude_reasoning_model("claude-sonnet-5", "Claude Sonnet 5"),
+        claude_reasoning_model_1m("claude-sonnet-4-6", "Claude Sonnet 4.6"),
+        claude_reasoning_model("claude-sonnet-4-6", "Claude Sonnet 4.6"),
+        ProviderModel::new("claude-haiku-4-5", "Claude Haiku 4.5"),
+    ]
+}
+
+/// Returns the request ID used for Claude's always-extended Fable 5 model.
+///
+/// Older Waku sessions persisted the bare Fable 5 ID. Keep those sessions and
+/// favorites pointing at the single picker entry while sending the explicit
+/// Claude Code selector required by gateways that do not infer 1M support.
+pub fn canonical_model_id(provider: ProviderKind, model: &str) -> String {
+    if provider == ProviderKind::Claude && model == "claude-fable-5" {
+        "claude-fable-5[1m]".to_owned()
+    } else {
+        model.to_owned()
+    }
+}
+
+pub fn model_ids_match(provider: ProviderKind, left: &str, right: &str) -> bool {
+    canonical_model_id(provider, left) == canonical_model_id(provider, right)
+}
+
 fn recv_rpc_response(rx: &Receiver<Value>, id: u64, timeout: Duration) -> Option<Value> {
     let deadline = Instant::now() + timeout;
     loop {
@@ -883,6 +914,72 @@ mod tests {
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "auto");
         assert!(models[0].is_default);
+    }
+
+    #[test]
+    fn claude_catalog_exposes_supported_1m_variants() {
+        let models = fallback_models(ProviderKind::Claude);
+        let ids = models
+            .iter()
+            .map(|model| model.id.as_str())
+            .collect::<Vec<_>>();
+
+        for model in [
+            "claude-fable-5",
+            "claude-opus-5",
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-sonnet-5",
+            "claude-sonnet-4-6",
+        ] {
+            let extended_id = format!("{model}[1m]");
+            assert!(ids.iter().any(|id| *id == extended_id.as_str()));
+        }
+
+        assert!(!ids.contains(&"claude-fable-5"));
+        for model in [
+            "claude-opus-5",
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-sonnet-5",
+            "claude-sonnet-4-6",
+        ] {
+            assert!(ids.contains(&model));
+        }
+
+        assert!(!ids.contains(&"claude-opus-4-5[1m]"));
+        assert!(!ids.contains(&"claude-haiku-4-5[1m]"));
+        assert_eq!(
+            models
+                .iter()
+                .find(|model| model.is_default)
+                .map(|model| model.id.as_str()),
+            Some("claude-sonnet-5[1m]")
+        );
+    }
+
+    #[test]
+    fn canonicalizes_legacy_fable_model_without_merging_other_variants() {
+        assert_eq!(
+            canonical_model_id(ProviderKind::Claude, "claude-fable-5"),
+            "claude-fable-5[1m]"
+        );
+        assert!(model_ids_match(
+            ProviderKind::Claude,
+            "claude-fable-5",
+            "claude-fable-5[1m]"
+        ));
+        assert!(!model_ids_match(
+            ProviderKind::Claude,
+            "claude-opus-5",
+            "claude-opus-5[1m]"
+        ));
+        assert_eq!(
+            canonical_model_id(ProviderKind::Codex, "gpt-5.5"),
+            "gpt-5.5"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- expose Claude Code's `[1m]` selector for Claude models that support extended context
- keep Claude Fable 5 as a single 1M picker entry, while preserving separate Standard and 1M entries for Opus and Sonnet variants where both are meaningful
- preserve compatibility with legacy Fable 5 sessions and favorites that stored the bare model ID

## Why

When Waku runs Claude Code behind a gateway, the gateway may not infer 1M support from the provider model ID alone. Selecting the bare `claude-fable-5` ID can therefore result in a gateway error even though Claude Fable 5 uses a 1M context window.

Claude Code supports the `[1m]` model selector. Waku now keeps that selector in the model choice and request path, while keeping the picker model identity separate from legacy persisted IDs.

## Compatibility

- Fable 5 is shown only as `Claude Fable 5 · 1M`; its legacy bare ID is canonicalized to `claude-fable-5[1m]` for requests, display lookup, and favorites.
- Opus and Sonnet models that support both modes retain separate bare and `[1m]` choices.
- Models without 1M support remain unchanged.

## Validation

- `cargo fmt --package waku -- --check`
- `cargo check --locked`
- `cargo test --locked` (549 passed, 0 failed, 10 ignored)
- `waku_js_repl` tests (10 passed)

The branch is based on the latest `upstream/main`.
