### PR TITLE
Add horizontal scrolling to code, diff, and editor surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7933,6 +7933,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "unicode-segmentation",
+ "unicode-width",
  "url",
  "uuid",
  "wry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"
 unicode-segmentation = "1.12"
+unicode-width = "0.2"
 url = "2"
 uuid = { version = "1.18", features = ["v4", "serde"] }
 pulldown-cmark = "0.13"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1053,13 +1053,20 @@ pub struct Waku {
     /// screen rather than the size of the repository change.
     right_panel_diff_list_state: ListState,
     right_panel_diff_scrollbar: Rc<ScrollbarState>,
+    right_panel_diff_horizontal_scroll_handle: ScrollHandle,
+    right_panel_diff_horizontal_scrollbar: Rc<ScrollbarState>,
     /// Selection spans and visible glyph geometry for the Review surface.
     /// Kept separate from the transcript because both surfaces paint at once.
     right_panel_diff_selection: TranscriptSelection,
     right_panel_diff_tree_list_state: ListState,
     right_panel_diff_tree_scrollbar: Rc<ScrollbarState>,
     right_panel_editor_scroll_handle: ScrollHandle,
-    right_panel_editor_scrollbar: Rc<ScrollbarState>,
+    right_panel_editor_vertical_scrollbar: Rc<ScrollbarState>,
+    right_panel_editor_horizontal_scrollbar: Rc<ScrollbarState>,
+    /// Caret offset the editor viewport was last brought to. Any other one
+    /// means the caret has moved and has to be revealed again; a scroll the
+    /// user made themselves does not change it, and so is left alone.
+    right_panel_editor_caret: Option<usize>,
     right_panel_pending_tab_reveal: Option<usize>,
     right_panel_pending_terminal_focus: Option<Uuid>,
     right_panel_expanded_paths: HashSet<PathBuf>,
@@ -2283,12 +2290,16 @@ impl Waku {
                 right_panel_diff_filter,
                 right_panel_diff_list_state: ListState::new(0, ListAlignment::Top, px(512.0)),
                 right_panel_diff_scrollbar: ScrollbarState::new(),
+                right_panel_diff_horizontal_scroll_handle: ScrollHandle::new(),
+                right_panel_diff_horizontal_scrollbar: ScrollbarState::new(),
                 right_panel_diff_selection: TranscriptSelection::default(),
                 right_panel_diff_tree_list_state: ListState::new(0, ListAlignment::Top, px(180.0))
                     .with_uniform_item_height(px(30.0)),
                 right_panel_diff_tree_scrollbar: ScrollbarState::new(),
                 right_panel_editor_scroll_handle: ScrollHandle::new(),
-                right_panel_editor_scrollbar: ScrollbarState::new(),
+                right_panel_editor_caret: None,
+                right_panel_editor_vertical_scrollbar: ScrollbarState::new(),
+                right_panel_editor_horizontal_scrollbar: ScrollbarState::new(),
                 right_panel_pending_tab_reveal: None,
                 right_panel_pending_terminal_focus: None,
                 right_panel_expanded_paths: HashSet::new(),

--- a/src/app/file_search.rs
+++ b/src/app/file_search.rs
@@ -212,6 +212,40 @@ fn revealed_scroll_offset(
     (next != current_offset).then_some(next)
 }
 
+/// Horizontal counterpart of [`revealed_scroll_offset`].
+///
+/// A match far along a long line is as unreachable as one below the fold, so it
+/// gets the same treatment on the other axis. `viewport_left` is where readable
+/// text begins rather than where the viewport does: the line-number gutter is
+/// pinned over the scrolled content, so anything under it is hidden.
+///
+/// Unlike the vertical case there is no natural resting fraction to aim for —
+/// re-centering every line would make navigation feel like it wanders — so a
+/// match outside the comfortable band is brought just inside the edge it left.
+fn revealed_scroll_offset_x(
+    current_offset: Pixels,
+    max_offset: Pixels,
+    match_left: Pixels,
+    margin: Pixels,
+    viewport_left: Pixels,
+    viewport_right: Pixels,
+) -> Option<Pixels> {
+    if viewport_right <= viewport_left + margin * 2.0 {
+        return None;
+    }
+    let (left_limit, right_limit) = (viewport_left + margin, viewport_right - margin);
+    if match_left >= left_limit && match_left <= right_limit {
+        return None;
+    }
+    let target = if match_left < left_limit {
+        left_limit
+    } else {
+        right_limit
+    };
+    let next = (current_offset + (target - match_left)).clamp(-max_offset, Pixels::ZERO);
+    (next != current_offset).then_some(next)
+}
+
 impl Waku {
     pub(super) fn refresh_file_search_localized_text(&mut self, cx: &mut Context<Self>) {
         let Some(search) = &self.file_search else {
@@ -490,36 +524,79 @@ impl Waku {
             }
         });
         if reveal && let Some(range) = active_range {
-            self.reveal_file_search_match(&editor, range.start, cx);
+            self.reveal_editor_offset(&editor, range.start, cx);
         }
         cx.notify();
     }
 
-    /// Scrolls the shared editor viewport so the match at `offset` is
-    /// visible. Uses the last painted layout, so right after an edit it can
-    /// land a line off; the next navigation corrects it.
-    fn reveal_file_search_match(
+    /// Keeps the editor viewport on the caret.
+    ///
+    /// The editor's text is not clipped to the pane, it scrolls inside it, so a
+    /// caret past the right edge is simply gone. Only a caret that has moved is
+    /// chased, which is what leaves a deliberate scroll alone.
+    pub fn follow_file_editor_caret(
+        &mut self,
+        editor: &Entity<ComposerInput>,
+        cx: &mut Context<Self>,
+    ) {
+        let caret = editor.read(cx).cursor_offset();
+        if self.right_panel_editor_caret != Some(caret)
+            && self.reveal_editor_offset(editor, caret, cx)
+        {
+            self.right_panel_editor_caret = Some(caret);
+        }
+    }
+
+    /// Scrolls the shared editor viewport so `offset` is comfortably visible on
+    /// both axes, reporting whether the offset could be placed at all.
+    ///
+    /// The position comes from the last painted layout, which cannot place an
+    /// offset a just-typed character opened up. Reporting that lets
+    /// [`Self::follow_file_editor_caret`] ask again on the next frame instead of
+    /// recording a reveal that never happened.
+    fn reveal_editor_offset(
         &self,
         editor: &Entity<ComposerInput>,
         offset: usize,
-        cx: &Context<Self>,
-    ) {
-        let Some((position, line_height)) = editor.read(cx).position_for_offset(offset) else {
-            return;
+        cx: &App,
+    ) -> bool {
+        let editor = editor.read(cx);
+        let Some((position, line_height)) = editor.position_for_offset(offset) else {
+            return false;
         };
+        // Readable text starts past the pinned line-number gutter, not at the
+        // viewport's own left edge.
+        let gutter = px(super::right_panel::file_editor_gutter_width(
+            editor.content().split('\n').count().max(1),
+        ));
         let scroll = &self.right_panel_editor_scroll_handle;
         let viewport = scroll.bounds();
-        let current = scroll.offset();
-        if let Some(next) = revealed_scroll_offset(
-            current.y,
-            scroll.max_offset().y,
+        let max = scroll.max_offset();
+        let mut next = scroll.offset();
+        if let Some(y) = revealed_scroll_offset(
+            next.y,
+            max.y,
             position.y,
             line_height,
             viewport.top(),
             viewport.bottom(),
         ) {
-            scroll.set_offset(point(current.x, next));
+            next.y = y;
         }
+        if let Some(x) = revealed_scroll_offset_x(
+            next.x,
+            max.x,
+            position.x,
+            line_height,
+            viewport.left() + gutter,
+            viewport.right(),
+        ) {
+            next.x = x;
+        }
+        if next != scroll.offset() {
+            scroll.set_offset(next);
+        }
+        true
     }
 
     fn file_search_navigate(&mut self, backwards: bool, cx: &mut Context<Self>) {
@@ -1306,6 +1383,73 @@ mod tests {
                 px(400.0)
             ),
             Some(px(0.0))
+        );
+    }
+
+    #[test]
+    fn reveal_scrolls_horizontally_only_past_the_gutter_and_the_far_edge() {
+        // `viewport_left` is already past the pinned gutter, so a caret inside
+        // the band is left where it is.
+        assert_eq!(
+            revealed_scroll_offset_x(
+                px(-100.0),
+                px(500.0),
+                px(200.0),
+                px(16.0),
+                px(60.0),
+                px(400.0)
+            ),
+            None
+        );
+        // Past the right edge: brought back to a margin inside it.
+        assert_eq!(
+            revealed_scroll_offset_x(
+                px(-100.0),
+                px(500.0),
+                px(600.0),
+                px(16.0),
+                px(60.0),
+                px(400.0)
+            ),
+            Some(px(-100.0) + (px(384.0) - px(600.0)))
+        );
+        // Under the gutter counts as hidden, even though it is inside the
+        // viewport: the gutter is painted over the text.
+        assert_eq!(
+            revealed_scroll_offset_x(
+                px(-100.0),
+                px(500.0),
+                px(40.0),
+                px(16.0),
+                px(60.0),
+                px(400.0)
+            ),
+            Some(px(-64.0))
+        );
+        // Clamped to the scrollable range.
+        assert_eq!(
+            revealed_scroll_offset_x(
+                px(-100.0),
+                px(120.0),
+                px(600.0),
+                px(16.0),
+                px(60.0),
+                px(400.0)
+            ),
+            Some(px(-120.0))
+        );
+        // A viewport with no room left after the margins reveals nothing rather
+        // than thrashing between two impossible limits.
+        assert_eq!(
+            revealed_scroll_offset_x(
+                px(-100.0),
+                px(500.0),
+                px(600.0),
+                px(16.0),
+                px(60.0),
+                px(80.0)
+            ),
+            None
         );
     }
 }

--- a/src/app/right_panel.rs
+++ b/src/app/right_panel.rs
@@ -4,6 +4,14 @@ use std::path::{Path, PathBuf};
 use super::*;
 
 const TAB_SCROLL_FADE_WIDTH: f32 = 24.0;
+/// Size the unified diff's code rows shape at. Shared with the advance
+/// measurement behind [`review_diff_content_width`] so the reserved scroll
+/// extent is computed at the size the rows actually use.
+const REVIEW_DIFF_TEXT_SIZE: Pixels = px(10.5);
+/// Distance every unified-diff row reserves for its line-number gutter. The
+/// gutter is pinned rather than laid out beside the body, so the body reserves
+/// this with padding.
+const REVIEW_DIFF_GUTTER_WIDTH: f32 = 52.0;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct WorkingTreeEntry {
@@ -211,6 +219,45 @@ fn review_diff_gap_tooltip(direction: crate::review_diff::ExpansionDirection) ->
         crate::review_diff::ExpansionDirection::Both => tr!("diff.expand_context"),
         crate::review_diff::ExpansionDirection::All => tr!("diff.expand_all_context"),
     }
+}
+
+/// Horizontal extent the unified diff needs for its widest line to be fully
+/// reachable: the fixed gutter and paddings, plus one `advance` per column.
+fn review_diff_content_width(columns: usize, advance: Pixels) -> Pixels {
+    /// Gutter, the body's inset past it, the trailing pad, and the 2px edge
+    /// marker an added or deleted row carries. The marker is a border, so it is
+    /// inside the row's width: a row that is both the widest and marked would
+    /// clip its last glyph without it.
+    const GUTTER_AND_PADDING: f32 = REVIEW_DIFF_GUTTER_WIDTH + 12.0 + 10.0 + 2.0;
+    px(GUTTER_AND_PADDING + columns as f32 * f32::from(advance))
+}
+
+/// Pins a diff row's gutter against the horizontal scroll.
+///
+/// Rows live inside the scrolled content, so the gutter cancels the offset and,
+/// painted after the body, occludes it: a long line slides under the line
+/// numbers instead of dragging them off screen. `surface` is the pane's own
+/// opaque background and is what makes that occlusion work — every wash a row
+/// puts in its gutter is translucent, and layering one over itself would both
+/// fail to hide the text and come out the wrong shade.
+fn review_diff_pinned_gutter(offset: Pixels, surface: Hsla) -> Div {
+    div()
+        .absolute()
+        .left(offset)
+        .top_0()
+        .bottom_0()
+        .w(px(REVIEW_DIFF_GUTTER_WIDTH))
+        .bg(surface)
+}
+
+/// Width the file editor reserves for its line-number gutter: wide enough for
+/// the highest number in the file.
+///
+/// The gutter is pinned over the scrolled text, so this is also how much of the
+/// viewport's left edge is covered — a caret reveal has to start there, not at
+/// the viewport's own left.
+pub fn file_editor_gutter_width(line_count: usize) -> f32 {
+    20.0 + 6.0 * (line_count.to_string().len() as f32)
 }
 
 fn review_diff_gap_directions(
@@ -896,6 +943,14 @@ fn tab_scroll_fade(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The gutter and paddings are reserved unconditionally, and every column
+    /// costs exactly one advance on top of them.
+    #[test]
+    fn review_diff_width_reserves_gutter_and_code_columns() {
+        assert_eq!(review_diff_content_width(0, px(6.5)), px(76.0));
+        assert_eq!(review_diff_content_width(100, px(6.5)), px(726.0));
+    }
 
     #[test]
     fn transcript_file_links_route_by_the_active_workspace() {
@@ -2750,7 +2805,7 @@ impl Waku {
         .detach();
     }
 
-    /// The editor body: a line-number gutter beside soft-wrapped text.
+    /// The editor body: a line-number gutter over horizontally scrolled text.
     ///
     /// The gutter is *painted*, not laid out — one canvas that shapes only the
     /// numbers currently on screen, the way Zed's editor element does. A div per
@@ -2758,8 +2813,13 @@ impl Waku {
     /// is what made large files crawl.
     ///
     /// Row heights come from the text's measured layout rather than a nominal
-    /// line height, so a soft-wrapped line still gets exactly one number and the
-    /// two columns cannot drift apart down a long file.
+    /// line height, so the two columns cannot drift apart down a long file even
+    /// if a row ever measures taller than the nominal height.
+    ///
+    /// The gutter follows the vertical scroll but not the horizontal one: it is
+    /// positioned absolutely inside the scrolled content and shifted back by the
+    /// horizontal offset, so long lines slide underneath it instead of pushing
+    /// the numbers off screen.
     fn render_file_editor_body(
         &mut self,
         relative_path: &str,
@@ -2779,12 +2839,13 @@ impl Waku {
         // visible file actually changes.
         self.sync_file_search_target(relative_path, cx);
         let find_bar = self.render_file_search_bar(pane_width, writable, window, cx);
+        self.follow_file_editor_caret(editor_state, cx);
 
         let theme = Theme::current(cx);
         let field = editor_state.read(cx);
         let line_count = field.content().split('\n').count().max(1);
         let heights = field.wrapped_line_heights();
-        let gutter_width = 20.0 + 6.0 * (line_count.to_string().len() as f32);
+        let gutter_width = file_editor_gutter_width(line_count);
         let content_height = if heights.is_empty() {
             px(LINE_HEIGHT) * line_count as f32
         } else {
@@ -2836,6 +2897,9 @@ impl Waku {
         .flex_none()
         .w(px(gutter_width - GUTTER_PAD_RIGHT))
         .h(content_height);
+        // Cancels the horizontal scroll the enclosing content div applies to
+        // every child, absolute ones included.
+        let gutter_offset = -self.right_panel_editor_scroll_handle.offset().x;
 
         // The find bar sits in normal flow above the scroll region — Zed's
         // buffer-search arrangement — so an open bar pushes the content and
@@ -2860,29 +2924,53 @@ impl Waku {
                         div()
                             .id(SharedString::from(format!("file-editor-{relative_path}")))
                             .size_full()
-                            .overflow_y_scroll()
+                            .flex()
+                            .overflow_scroll()
+                            .restrict_scroll_to_axis()
                             .track_scroll(&self.right_panel_editor_scroll_handle)
                             .child(
                                 div()
-                                    .w_full()
+                                    // The viewport floor comes from the measured
+                                    // parent, not from a predicted pane width:
+                                    // borders are inside the specified size, so a
+                                    // prediction runs a pixel or two narrow and
+                                    // leaves a sliver of dead scroll range.
+                                    .min_w_full()
+                                    .flex_none()
+                                    .relative()
                                     .pt(px(CONTENT_PAD_TOP))
                                     .pb(px(CONTENT_PAD_TOP))
                                     .flex()
                                     .items_start()
-                                    .child(gutter)
-                                    .child(div().w(px(GUTTER_PAD_RIGHT)).flex_none())
                                     .child(
                                         div()
-                                            .flex_1()
-                                            .min_w_0()
+                                            .flex_grow(1.0)
+                                            .flex_shrink_0()
+                                            .pl(px(gutter_width))
                                             .pr(px(10.0))
                                             .child(editor_state.clone()),
+                                    )
+                                    .child(
+                                        div()
+                                            .absolute()
+                                            .top(px(CONTENT_PAD_TOP))
+                                            .left(gutter_offset)
+                                            .w(px(gutter_width))
+                                            // Opaque, and painted after the text,
+                                            // so a long line disappears under the
+                                            // numbers instead of through them.
+                                            .bg(theme.surface)
+                                            .child(gutter),
                                     ),
                             ),
                     )
                     .child(scrollbar::vertical(
                         &self.right_panel_editor_scroll_handle,
-                        &self.right_panel_editor_scrollbar,
+                        &self.right_panel_editor_vertical_scrollbar,
+                    ))
+                    .child(scrollbar::horizontal(
+                        &self.right_panel_editor_scroll_handle,
+                        &self.right_panel_editor_horizontal_scrollbar,
                     )),
             )
     }
@@ -2985,7 +3073,7 @@ impl Waku {
                     .min_h_0()
                     .min_w_0()
                     .flex()
-                    .child(self.render_right_panel_unified_diff(snapshot.clone(), cx))
+                    .child(self.render_right_panel_unified_diff(snapshot.clone(), window, cx))
                     .child(
                         div()
                             .w(px(tree_width))
@@ -3196,6 +3284,7 @@ impl Waku {
     fn render_right_panel_unified_diff(
         &self,
         snapshot: Arc<ReviewDiffSnapshot>,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
         if snapshot.files.is_empty() {
@@ -3208,30 +3297,59 @@ impl Waku {
                 .into_any_element();
         }
         let entity = cx.entity().downgrade();
+        // The advance is measured rather than assumed: a guessed constant that
+        // runs narrow leaves the last glyphs of the widest line unscrollable,
+        // and the bundled mono font is free to change metrics or fall back.
+        let text_system = window.text_system();
+        let font_id = text_system.resolve_font(&font(md::render::MONO_FAMILY));
+        let advance = text_system
+            .em_advance(font_id, REVIEW_DIFF_TEXT_SIZE)
+            .unwrap_or(px(6.5));
+        let content_width = review_diff_content_width(snapshot.max_content_columns, advance);
         div()
             .flex_1()
             .min_h_0()
             .min_w_0()
             .relative()
             .child(
-                list(
-                    self.right_panel_diff_list_state.clone(),
-                    move |index, _window, cx| {
-                        entity
-                            .upgrade()
-                            .map(|entity| {
-                                entity.update(cx, |this, cx| {
-                                    this.render_right_panel_diff_line(index, cx)
-                                })
-                            })
-                            .unwrap_or_else(|| div().into_any_element())
-                    },
-                )
-                .size_full(),
+                div()
+                    .id("right-panel-diff-horizontal-scroll")
+                    .size_full()
+                    .flex()
+                    .overflow_x_scroll()
+                    .restrict_scroll_to_axis()
+                    .track_scroll(&self.right_panel_diff_horizontal_scroll_handle)
+                    .child(
+                        div()
+                            .h_full()
+                            .min_w_full()
+                            .w(content_width)
+                            .flex_none()
+                            .child(
+                                list(
+                                    self.right_panel_diff_list_state.clone(),
+                                    move |index, _window, cx| {
+                                        entity
+                                            .upgrade()
+                                            .map(|entity| {
+                                                entity.update(cx, |this, cx| {
+                                                    this.render_right_panel_diff_line(index, cx)
+                                                })
+                                            })
+                                            .unwrap_or_else(|| div().into_any_element())
+                                    },
+                                )
+                                .size_full(),
+                            ),
+                    ),
             )
             .child(scrollbar::vertical(
                 &self.right_panel_diff_list_state,
                 &self.right_panel_diff_scrollbar,
+            ))
+            .child(scrollbar::horizontal(
+                &self.right_panel_diff_horizontal_scroll_handle,
+                &self.right_panel_diff_horizontal_scrollbar,
             ))
             .into_any_element()
     }
@@ -3247,6 +3365,12 @@ impl Waku {
             return div().into_any_element();
         };
         let theme = Theme::current(cx);
+        // Chrome that must not slide away with the content cancels the offset
+        // the enclosing scroll container applies to every child, absolute ones
+        // included.
+        let scroll = &self.right_panel_diff_horizontal_scroll_handle;
+        let pin = -scroll.offset().x;
+        let viewport_width = scroll.bounds().size.width;
 
         match &line.kind {
             crate::review_diff::LineKind::FileHeader => div()
@@ -3254,37 +3378,53 @@ impl Waku {
                 .w_full()
                 .min_w_0()
                 .h(px(36.0))
-                .px(px(12.0))
-                .flex()
-                .items_center()
-                .gap(px(8.0))
+                .relative()
                 .border_b_1()
                 .border_color(theme.border)
                 .bg(theme.surface)
-                .child(file_icon(file_icon_for_path(&file.path), 14.0))
                 .child(
+                    // The band spans the whole content width so the border and
+                    // fill stay continuous, but the path and the counts are
+                    // pinned to the viewport: which file a hunk belongs to has
+                    // to stay readable however far right the code is scrolled.
                     div()
-                        .id(SharedString::from(format!("review-diff-file-path-{index}")))
-                        .min_w_0()
-                        .flex_1()
-                        .truncate()
-                        .text_size(px(11.5))
-                        .font_weight(FontWeight::MEDIUM)
-                        .text_color(theme.text_secondary)
-                        .tooltip(Tooltip::text(file.path.clone()))
-                        .child(file.path.clone()),
-                )
-                .child(
-                    div()
-                        .text_size(px(10.5))
-                        .text_color(theme.success)
-                        .child(format!("+{}", file.additions)),
-                )
-                .child(
-                    div()
-                        .text_size(px(10.5))
-                        .text_color(theme.danger)
-                        .child(format!("-{}", file.deletions)),
+                        .absolute()
+                        .left(pin)
+                        .top_0()
+                        .bottom_0()
+                        // Full width until the pane has been measured; an
+                        // unmeasured pane is also an unscrolled one.
+                        .w_full()
+                        .when(viewport_width > px(0.0), |chrome| chrome.w(viewport_width))
+                        .px(px(12.0))
+                        .flex()
+                        .items_center()
+                        .gap(px(8.0))
+                        .child(file_icon(file_icon_for_path(&file.path), 14.0))
+                        .child(
+                            div()
+                                .id(SharedString::from(format!("review-diff-file-path-{index}")))
+                                .min_w_0()
+                                .flex_1()
+                                .truncate()
+                                .text_size(px(11.5))
+                                .font_weight(FontWeight::MEDIUM)
+                                .text_color(theme.text_secondary)
+                                .tooltip(Tooltip::text(file.path.clone()))
+                                .child(file.path.clone()),
+                        )
+                        .child(
+                            div()
+                                .text_size(px(10.5))
+                                .text_color(theme.success)
+                                .child(format!("+{}", file.additions)),
+                        )
+                        .child(
+                            div()
+                                .text_size(px(10.5))
+                                .text_color(theme.danger)
+                                .child(format!("-{}", file.deletions)),
+                        ),
                 )
                 .into_any_element(),
             crate::review_diff::LineKind::Gap(gap) => {
@@ -3293,9 +3433,7 @@ impl Waku {
                 let directions = review_diff_gap_directions(gap.position, chunked);
                 let two_directions = directions.len() > 1;
                 let gutter = div()
-                    .w(px(52.0))
-                    .h_full()
-                    .flex_none()
+                    .size_full()
                     .flex()
                     .when(two_directions, |gutter| gutter.flex_col())
                     .border_r_1()
@@ -3327,7 +3465,8 @@ impl Waku {
                     .h_full()
                     .min_w_0()
                     .flex_1()
-                    .px(px(12.0))
+                    .pl(px(REVIEW_DIFF_GUTTER_WIDTH + 12.0))
+                    .pr(px(12.0))
                     .flex()
                     .items_center()
                     .bg(theme.overlay)
@@ -3369,18 +3508,20 @@ impl Waku {
                     .h(px(32.0))
                     .w_full()
                     .min_w_0()
+                    .relative()
                     .flex()
                     .items_center()
                     .text_size(px(10.5))
                     .text_color(theme.text_tertiary)
-                    .child(gutter)
                     .child(label)
+                    .child(review_diff_pinned_gutter(pin, theme.surface).child(gutter))
                     .into_any_element()
             }
             crate::review_diff::LineKind::HunkHeader => div()
                 .h(px(24.0))
                 .w_full()
                 .min_w_0()
+                .relative()
                 .flex()
                 .items_center()
                 .font_family(md::render::MONO_FAMILY)
@@ -3388,19 +3529,11 @@ impl Waku {
                 .text_color(theme.text_tertiary)
                 .child(
                     div()
-                        .w(px(52.0))
-                        .h_full()
-                        .flex_none()
-                        .border_r_1()
-                        .border_color(theme.border)
-                        .bg(theme.overlay),
-                )
-                .child(
-                    div()
                         .h_full()
                         .min_w_0()
                         .flex_1()
-                        .px(px(12.0))
+                        .pl(px(REVIEW_DIFF_GUTTER_WIDTH + 12.0))
+                        .pr(px(12.0))
                         .flex()
                         .items_center()
                         .overflow_hidden()
@@ -3408,26 +3541,37 @@ impl Waku {
                         .bg(theme.overlay)
                         .child(line.content.clone()),
                 )
+                .child(
+                    review_diff_pinned_gutter(pin, theme.surface).child(
+                        div()
+                            .size_full()
+                            .border_r_1()
+                            .border_color(theme.border)
+                            .bg(theme.overlay),
+                    ),
+                )
                 .into_any_element(),
             crate::review_diff::LineKind::Meta => div()
                 .h(px(24.0))
                 .w_full()
                 .min_w_0()
+                .relative()
                 .flex()
                 .items_center()
                 .font_family(md::render::MONO_FAMILY)
                 .text_size(px(10.5))
                 .text_color(theme.text_tertiary)
-                .child(div().w(px(52.0)).h_full().flex_none())
                 .child(
                     div()
                         .min_w_0()
                         .flex_1()
                         .overflow_hidden()
                         .whitespace_nowrap()
+                        .pl(px(REVIEW_DIFF_GUTTER_WIDTH))
                         .pr(px(10.0))
                         .child(line.content.clone()),
                 )
+                .child(review_diff_pinned_gutter(pin, theme.surface))
                 .into_any_element(),
             crate::review_diff::LineKind::Context
             | crate::review_diff::LineKind::Addition
@@ -3474,9 +3618,7 @@ impl Waku {
                     false,
                 );
                 let gutter = div()
-                    .w(px(52.0))
-                    .h_full()
-                    .flex_none()
+                    .size_full()
                     .pr(px(9.0))
                     .flex()
                     .items_center()
@@ -3492,7 +3634,7 @@ impl Waku {
                     .h_full()
                     .min_w_0()
                     .flex_1()
-                    .pl(px(12.0))
+                    .pl(px(REVIEW_DIFF_GUTTER_WIDTH + 12.0))
                     .flex()
                     .items_center()
                     .when_some(body_background, |body, background| body.bg(background))
@@ -3516,14 +3658,15 @@ impl Waku {
                     .w_full()
                     .min_w_0()
                     .h(px(20.0))
+                    .relative()
                     .flex()
                     .items_center()
                     .font_family(md::render::MONO_FAMILY)
-                    .text_size(px(10.5))
+                    .text_size(REVIEW_DIFF_TEXT_SIZE)
                     .line_height(px(20.0))
                     .when_some(edge, |row, edge| row.border_l_2().border_color(edge))
-                    .child(gutter)
                     .child(body)
+                    .child(review_diff_pinned_gutter(pin, theme.surface).child(gutter))
                     .into_any_element()
             }
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1411,7 +1411,7 @@ impl ComposerInput {
         cx.notify();
     }
 
-    fn cursor_offset(&self) -> usize {
+    pub fn cursor_offset(&self) -> usize {
         if self.selection_reversed {
             self.selected_range.start
         } else {
@@ -2232,6 +2232,9 @@ impl Render for ComposerInput {
                     .line_height(px(22.0))
                     .text_size(px(13.5))
             })
+            .when(self.mode == FieldMode::Code, |field| {
+                field.whitespace_nowrap()
+            })
             // A search-mode field is visually one line: the text never wraps,
             // and the overlong remainder slides horizontally under this
             // clipped viewport to follow the caret — no scrollbar.
@@ -2325,8 +2328,8 @@ mod tests {
 
     use gpui::{
         ClipboardEntry, ClipboardItem, Context, Entity, EntityInputHandler, ExternalPaths, Image,
-        ImageFormat, Pixels, Render, TestAppContext, TextRun, Window, div, font, hsla, prelude::*,
-        px,
+        ImageFormat, Pixels, Render, ScrollDelta, ScrollHandle, ScrollWheelEvent, TestAppContext,
+        TextRun, Window, div, font, hsla, point, prelude::*, px,
     };
 
     use super::TokenClass;
@@ -2346,6 +2349,65 @@ mod tests {
         fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
             div().w(self.width).child(self.input.clone())
         }
+    }
+
+    struct CodeInputHarness {
+        input: Entity<ComposerInput>,
+        scroll: ScrollHandle,
+    }
+
+    impl Render for CodeInputHarness {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div().w(px(180.0)).h(px(80.0)).child(
+                div()
+                    .id("code-input-scroll-test")
+                    .size_full()
+                    .flex()
+                    .overflow_scroll()
+                    .restrict_scroll_to_axis()
+                    .track_scroll(&self.scroll)
+                    .child(
+                        div()
+                            .min_w(px(180.0))
+                            .flex_none()
+                            .flex()
+                            .child(div().w(px(28.0)).flex_none())
+                            .child(div().min_w(px(152.0)).flex_none().child(self.input.clone())),
+                    ),
+            )
+        }
+    }
+
+    #[gpui::test]
+    fn code_editor_exposes_horizontal_overflow(cx: &mut TestAppContext) {
+        cx.update(super::init);
+        let scroll = ScrollHandle::new();
+        let harness_scroll = scroll.clone();
+        let (_, cx) = cx.add_window_view(move |window, cx| {
+            let input = cx.new(|cx| {
+                let mut input = ComposerInput::new(window, cx).code_editor(None);
+                input.set_content(
+                    "let value = \"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\";",
+                    cx,
+                );
+                input
+            });
+            CodeInputHarness {
+                input,
+                scroll: harness_scroll,
+            }
+        });
+
+        assert!(
+            scroll.max_offset().x > px(0.0),
+            "an unwrapped code line must overflow horizontally"
+        );
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(90.0), px(20.0)),
+            delta: ScrollDelta::Pixels(point(px(-60.0), px(0.0))),
+            ..Default::default()
+        });
+        assert!(scroll.offset().x < px(0.0));
     }
 
     fn setup_input<'a>(

--- a/src/md/render.rs
+++ b/src/md/render.rs
@@ -24,9 +24,9 @@ use std::rc::Rc;
 use gpui::{
     AnyElement, BorderStyle, Bounds, CursorStyle, DispatchPhase, Font, FontStyle, FontWeight, Hsla,
     InteractiveText, IntoElement, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
-    ParentElement, Pixels, Point, SharedString, StrikethroughStyle, StyledText, TextLayout,
-    TextRun, UnderlineStyle, Window, canvas, div, font, img, point, prelude::*, px, quad, relative,
-    size,
+    ParentElement, Pixels, Point, ScrollHandle, SharedString, StrikethroughStyle, StyledText,
+    TextLayout, TextRun, UnderlineStyle, Window, canvas, div, font, img, point, prelude::*, px,
+    quad, relative, size,
 };
 
 use super::highlight::{self, Lang, TokenClass};
@@ -36,6 +36,7 @@ use super::selection::{
     RegisteredText, SelectionRegistry, SelectionState, TextKey, line_range, word_range,
 };
 use crate::theme::Theme;
+use crate::ui::scrollbar::{self, ScrollbarState};
 
 /// Selection geometry: the laid-out text handle for one painted element.
 pub type TextGeometry = TextLayout;
@@ -325,6 +326,7 @@ pub struct MarkdownView {
     /// Mended replacement for the final block while streaming.
     tail: Vec<TopBlock>,
     flats: RefCell<HashMap<usize, Rc<FlatText>>>,
+    code_scrolls: RefCell<HashMap<usize, CodeScrollState>>,
     /// First element ordinal belonging to the final block — the only block an
     /// append can change. Recorded during render, because only the renderer
     /// knows how many text elements each block expands into.
@@ -347,6 +349,7 @@ impl MarkdownView {
             parser: IncrementalParser::new(),
             tail: Vec::new(),
             flats: RefCell::new(HashMap::new()),
+            code_scrolls: RefCell::new(HashMap::new()),
             volatile_from: Cell::new(0),
             style: Cell::new(None),
         }
@@ -379,6 +382,9 @@ impl MarkdownView {
             self.flats
                 .borrow_mut()
                 .retain(|ordinal, _| *ordinal < boundary);
+            self.code_scrolls
+                .borrow_mut()
+                .retain(|ordinal, _| *ordinal < boundary);
         }
     }
 
@@ -400,6 +406,14 @@ impl MarkdownView {
             .clone()
     }
 
+    fn code_scroll(&self, ordinal: usize) -> CodeScrollState {
+        self.code_scrolls
+            .borrow_mut()
+            .entry(ordinal)
+            .or_default()
+            .clone()
+    }
+
     /// Display blocks in document order: the settled prefix, then the mended
     /// tail when one is active.
     fn blocks(&self) -> impl Iterator<Item = &Block> + '_ {
@@ -413,6 +427,21 @@ impl MarkdownView {
             .iter()
             .chain(self.tail.iter())
             .map(|top| &top.block)
+    }
+}
+
+#[derive(Clone)]
+struct CodeScrollState {
+    handle: ScrollHandle,
+    scrollbar: Rc<ScrollbarState>,
+}
+
+impl Default for CodeScrollState {
+    fn default() -> Self {
+        Self {
+            handle: ScrollHandle::new(),
+            scrollbar: ScrollbarState::new(),
+        }
     }
 }
 
@@ -493,6 +522,10 @@ impl<'a> Ctx<'a> {
             Some(view) => view.flat(ordinal, build),
             None => Rc::new(build()),
         }
+    }
+
+    fn code_scroll(&self, ordinal: usize) -> Option<CodeScrollState> {
+        self.cache.map(|view| view.code_scroll(ordinal))
     }
 }
 
@@ -1137,10 +1170,35 @@ fn render_code_block(language: Option<&str>, code: &str, ctx: &Ctx) -> AnyElemen
     let label = language
         .filter(|language| !language.is_empty())
         .map(|language| language.to_ascii_lowercase());
+    let code_scroll = ctx.code_scroll(key.index);
+    let viewport = div()
+        .id(SharedString::from(format!(
+            "code-{}-{}",
+            key.row, key.index
+        )))
+        .w_full()
+        .px(px(10.0))
+        .py(px(8.0))
+        .flex()
+        .overflow_x_scroll()
+        .restrict_scroll_to_axis()
+        .when_some(code_scroll.as_ref(), |element, state| {
+            element.track_scroll(&state.handle)
+        })
+        .child(
+            div()
+                .flex_none()
+                .whitespace_nowrap()
+                .text_size(px(ctx.metrics.code_text_size))
+                .line_height(px(ctx.metrics.code_line_height))
+                .text_color(ctx.palette.secondary)
+                .child(text_element(&flat, key, ctx)),
+        );
 
     div()
         .w_full()
         .min_w_0()
+        .relative()
         .rounded(px(8.0))
         .border_1()
         .border_color(ctx.palette.border)
@@ -1163,26 +1221,10 @@ fn render_code_block(language: Option<&str>, code: &str, ctx: &Ctx) -> AnyElemen
                     .child(SharedString::from(label)),
             )
         })
-        .child(
-            div()
-                .id(SharedString::from(format!(
-                    "code-{}-{}",
-                    key.row, key.index
-                )))
-                .w_full()
-                .px(px(10.0))
-                .py(px(8.0))
-                .overflow_x_scroll()
-                .child(
-                    div()
-                        .flex_none()
-                        .whitespace_nowrap()
-                        .text_size(px(ctx.metrics.code_text_size))
-                        .line_height(px(ctx.metrics.code_line_height))
-                        .text_color(ctx.palette.secondary)
-                        .child(text_element(&flat, key, ctx)),
-                ),
-        )
+        .child(viewport)
+        .when_some(code_scroll, |element, state| {
+            element.child(scrollbar::horizontal(&state.handle, &state.scrollbar))
+        })
         .into_any_element()
 }
 
@@ -1394,7 +1436,7 @@ fn column_widths(
 mod tests {
     use super::*;
     use crate::md::parser;
-    use gpui::TestAppContext;
+    use gpui::{ScrollDelta, ScrollWheelEvent, TestAppContext};
 
     fn palette() -> Palette {
         Palette::from_theme(&Theme::dark())
@@ -1537,6 +1579,67 @@ mod tests {
         assert!(
             rects.iter().all(|rect| rect.left() == left),
             "a full selection must include each wrapped row's first glyph: {rects:?}"
+        );
+    }
+
+    #[gpui::test]
+    fn long_code_lines_scroll_horizontally(cx: &mut TestAppContext) {
+        const LONG_CODE: &str = "let value = \"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\";";
+
+        struct CodeBlockHarness {
+            selection: TranscriptSelection,
+            markdown: MarkdownView,
+        }
+
+        impl gpui::Render for CodeBlockHarness {
+            fn render(&mut self, _: &mut Window, _: &mut gpui::Context<Self>) -> impl IntoElement {
+                let palette = palette();
+                let ctx = Ctx::new(
+                    "code-scroll-test",
+                    &palette,
+                    Metrics::BODY,
+                    self.selection.clone(),
+                );
+                div().w(px(180.0)).children(markdown(&self.markdown, &ctx))
+            }
+        }
+
+        let selection = TranscriptSelection::default();
+        let harness_selection = selection.clone();
+        let (harness, cx) = cx.add_window_view(move |_, _| {
+            let mut markdown = MarkdownView::new();
+            markdown.set_text(&format!("```\n{LONG_CODE}\n```"), false);
+            CodeBlockHarness {
+                selection: harness_selection,
+                markdown,
+            }
+        });
+        let scroll = cx.read_entity(&harness, |harness, _| {
+            harness.markdown.code_scrolls.borrow()[&0].handle.clone()
+        });
+        assert!(
+            scroll.max_offset().x > px(0.0),
+            "the cached code block must expose horizontal overflow"
+        );
+        let initial_left = selection.registry.borrow().entries()[0]
+            .geometry
+            .bounds()
+            .left();
+        selection.registry.borrow_mut().clear();
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(90.0), px(20.0)),
+            delta: ScrollDelta::Pixels(point(px(-80.0), px(0.0))),
+            ..Default::default()
+        });
+
+        let scrolled_left = selection.registry.borrow().entries()[0]
+            .geometry
+            .bounds()
+            .left();
+        assert!(
+            scrolled_left < initial_left,
+            "a horizontal gesture must move a long code line: {initial_left:?} -> {scrolled_left:?}"
         );
     }
 

--- a/src/review_diff.rs
+++ b/src/review_diff.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use std::process::{Command, Output};
 
 use anyhow::{Context as _, anyhow, bail};
+use unicode_width::UnicodeWidthChar;
 use uuid::Uuid;
 
 use crate::checkpoint;
@@ -132,6 +133,11 @@ pub struct Snapshot {
     pub source: Source,
     pub files: Vec<File>,
     pub lines: Vec<Line>,
+    /// Widest source line in monospace columns, counting the context retained
+    /// inside collapsed gaps so expanding a gap never changes the horizontal
+    /// extent, and skipping rows the visible-line cap dropped so the extent
+    /// never exceeds what the list can show.
+    pub max_content_columns: usize,
     pub additions: u64,
     pub deletions: u64,
     pub truncated: bool,
@@ -584,6 +590,7 @@ fn parse(source: Source, numstat: &str, patch: &str, complete_context: bool) -> 
         lines
     };
     let (lines, truncated) = cap_visible_lines(lines);
+    let max_content_columns = max_content_columns(&lines);
     recompute_diff_lines(&mut files, &lines);
     let additions = files.iter().map(|file| file.additions).sum();
     let deletions = files.iter().map(|file| file.deletions).sum();
@@ -591,10 +598,48 @@ fn parse(source: Source, numstat: &str, patch: &str, complete_context: bool) -> 
         source,
         files,
         lines,
+        max_content_columns,
         additions,
         deletions,
         truncated,
     }
+}
+
+/// Widest line among everything the list can ever show: the rows themselves
+/// plus the context retained inside collapsed gaps, so expanding a gap never
+/// changes the horizontal extent. Rows dropped by [`cap_visible_lines`] are
+/// excluded — they would only buy dead scroll range.
+fn max_content_columns(lines: &[Line]) -> usize {
+    lines
+        .iter()
+        .map(|line| {
+            let hidden = match &line.kind {
+                LineKind::Gap(gap) => gap
+                    .hidden
+                    .iter()
+                    .map(|line| monospace_columns(&line.content))
+                    .max()
+                    .unwrap_or_default(),
+                _ => 0,
+            };
+            monospace_columns(&line.content).max(hidden)
+        })
+        .max()
+        .unwrap_or_default()
+}
+
+/// Columns a rendered line occupies, where one column is one advance of the
+/// mono font.
+///
+/// Nothing expands tabs before shaping, and the mono font advances a tab by a
+/// single column, so that is what a tab costs here — charging it a tab stop
+/// would reserve scroll range that no glyph ever reaches. Wide characters are
+/// the only ones worth two: they are never wider than two advances, so the
+/// result stays an upper bound on the painted width.
+fn monospace_columns(text: &str) -> usize {
+    text.chars()
+        .map(|ch| UnicodeWidthChar::width(ch).unwrap_or(1))
+        .sum()
 }
 
 fn collapse_context(lines: Vec<Line>) -> Vec<Line> {
@@ -893,6 +938,17 @@ mod tests {
     use std::fs;
 
     use super::*;
+
+    #[test]
+    fn source_columns_match_the_advances_the_mono_font_paints() {
+        // A tab advances one column in the mono font, and nothing expands tabs
+        // before shaping, so a tab-indented line must not be charged a tab stop.
+        assert_eq!(monospace_columns("ab\tc"), 4);
+        // Accented Latin and arrows are single-advance despite not being ASCII.
+        assert_eq!(monospace_columns("é→"), 2);
+        // Wide characters are the only ones worth two.
+        assert_eq!(monospace_columns("a界b"), 4);
+    }
 
     fn git_ok(cwd: &Path, args: &[&str]) {
         let output = Command::new("git")

--- a/src/ui/scrollbar.rs
+++ b/src/ui/scrollbar.rs
@@ -1,4 +1,4 @@
-//! Overlay scrollbar for a virtualized [`ListState`].
+//! Overlay scrollbars for [`ListState`] and [`ScrollHandle`] surfaces.
 //!
 //! Drawn as a single quad from geometry the list already tracks, with the drag
 //! and click listeners registered during paint. That keeps it to one element
@@ -24,7 +24,7 @@ use crate::theme::Theme;
 const TRACK_WIDTH: f32 = 11.0;
 const THUMB_WIDTH: f32 = 5.0;
 const THUMB_WIDTH_ACTIVE: f32 = 8.0;
-const THUMB_MIN_HEIGHT: f32 = 28.0;
+const THUMB_MIN_LENGTH: f32 = 28.0;
 const TRACK_INSET: f32 = 2.0;
 
 /// How long the bar stays at full strength after the last scroll, and how long
@@ -68,7 +68,17 @@ impl ScrollbarState {
 
 /// Overlay opacity: solid while hovered or dragging, otherwise held briefly
 /// after a scroll and then faded out. Pure, so the timing is testable.
-fn opacity(since_scroll: Option<Duration>, hovered: bool, grabbed: bool) -> f32 {
+///
+/// Under reduce-motion the hold still applies but the ramp does not: the bar
+/// goes straight from solid to gone. Skipping the *frames* instead would leave
+/// the thumb painted at whatever opacity it last had, because nothing else
+/// repaints a resting surface.
+fn opacity(
+    since_scroll: Option<Duration>,
+    hovered: bool,
+    grabbed: bool,
+    reduce_motion: bool,
+) -> f32 {
     if hovered || grabbed {
         return 1.0;
     }
@@ -77,6 +87,9 @@ fn opacity(since_scroll: Option<Duration>, hovered: bool, grabbed: bool) -> f32 
     };
     if elapsed < HOLD {
         return 1.0;
+    }
+    if reduce_motion {
+        return 0.0;
     }
     let fading = (elapsed - HOLD).as_secs_f32() / FADE.as_secs_f32();
     (1.0 - fading).clamp(0.0, 1.0)
@@ -93,133 +106,179 @@ struct Geometry {
     max_offset: Pixels,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Axis {
+    Horizontal,
+    Vertical,
+}
+
+impl Axis {
+    fn extent(self, bounds: Bounds<Pixels>) -> Pixels {
+        match self {
+            Self::Horizontal => bounds.size.width,
+            Self::Vertical => bounds.size.height,
+        }
+    }
+
+    fn coordinate(self, point: Point<Pixels>) -> Pixels {
+        match self {
+            Self::Horizontal => point.x,
+            Self::Vertical => point.y,
+        }
+    }
+
+    fn start(self, bounds: Bounds<Pixels>) -> Pixels {
+        match self {
+            Self::Horizontal => bounds.left(),
+            Self::Vertical => bounds.top(),
+        }
+    }
+}
+
 /// Compute the thumb rect for a track. Pure, so the mapping between scroll
 /// offset and thumb position is unit-testable.
 fn geometry(
     track: Bounds<Pixels>,
-    viewport_height: Pixels,
+    axis: Axis,
+    viewport_extent: Pixels,
     max_offset: Pixels,
     offset: Pixels,
-    thumb_width: Pixels,
+    thumb_thickness: Pixels,
 ) -> Option<Geometry> {
-    if viewport_height <= Pixels::ZERO || max_offset <= px(0.5) || track.size.height <= Pixels::ZERO
-    {
+    let track_extent = axis.extent(track);
+    if viewport_extent <= Pixels::ZERO || max_offset <= px(0.5) || track_extent <= Pixels::ZERO {
         return None;
     }
-    let content_height = viewport_height + max_offset;
-    let track_height = track.size.height;
-    let thumb_height = (track_height * (viewport_height / content_height))
-        .max(px(THUMB_MIN_HEIGHT))
-        .min(track_height);
-    let travel = (track_height - thumb_height).max(Pixels::ZERO);
+    let content_extent = viewport_extent + max_offset;
+    let thumb_length = (track_extent * (viewport_extent / content_extent))
+        .max(px(THUMB_MIN_LENGTH))
+        .min(track_extent);
+    let travel = (track_extent - thumb_length).max(Pixels::ZERO);
     let progress = (offset / max_offset).clamp(0.0, 1.0);
-    Some(Geometry {
-        thumb: Bounds::new(
+    let thumb_start = axis.start(track) + travel * progress;
+    let thumb = match axis {
+        Axis::Horizontal => Bounds::new(
             point(
-                track.right() - thumb_width - px(TRACK_INSET),
-                track.top() + travel * progress,
+                thumb_start,
+                track.bottom() - thumb_thickness - px(TRACK_INSET),
             ),
-            size(thumb_width, thumb_height),
+            size(thumb_length, thumb_thickness),
         ),
+        Axis::Vertical => Bounds::new(
+            point(
+                track.right() - thumb_thickness - px(TRACK_INSET),
+                thumb_start,
+            ),
+            size(thumb_thickness, thumb_length),
+        ),
+    };
+    Some(Geometry {
+        thumb,
         travel,
         max_offset,
     })
 }
 
-/// How far down the content a thumb top of `thumb_top` corresponds to.
-fn offset_for_thumb_top(track_top: Pixels, thumb_top: Pixels, geometry: &Geometry) -> Pixels {
+/// How far through the content a thumb start corresponds to.
+fn offset_for_thumb_start(track_start: Pixels, thumb_start: Pixels, geometry: &Geometry) -> Pixels {
     if geometry.travel <= Pixels::ZERO {
         return Pixels::ZERO;
     }
-    let progress = ((thumb_top - track_top) / geometry.travel).clamp(0.0, 1.0);
+    let progress = ((thumb_start - track_start) / geometry.travel).clamp(0.0, 1.0);
     geometry.max_offset * progress
 }
 
-/// The two things a scrollable surface has to expose. GPUI stores both kinds of
-/// offset as a non-positive y; implementations report a downward distance so the
+/// The geometry a scrollable surface has to expose. GPUI stores offsets as a
+/// non-positive point; implementations report a positive distance so the
 /// geometry above reads the obvious way.
 pub trait Scrollable {
-    /// Height of the visible area.
-    fn viewport_height(&self) -> Pixels;
-    /// Content height beyond the viewport.
-    fn max_offset(&self) -> Pixels;
-    /// How far the content is currently scrolled down.
-    fn scrolled(&self) -> Pixels;
-    fn scroll_to(&self, offset: Pixels);
+    fn viewport_extent(&self, axis: Axis) -> Pixels;
+    fn max_offset(&self, axis: Axis) -> Pixels;
+    fn scrolled(&self, axis: Axis) -> Pixels;
+    fn scroll_to(&self, axis: Axis, offset: Pixels);
 }
 
 impl Scrollable for ListState {
-    fn viewport_height(&self) -> Pixels {
-        self.viewport_bounds().size.height
+    fn viewport_extent(&self, axis: Axis) -> Pixels {
+        axis.extent(self.viewport_bounds())
     }
 
-    fn max_offset(&self) -> Pixels {
-        self.max_offset_for_scrollbar().y
+    fn max_offset(&self, axis: Axis) -> Pixels {
+        axis.coordinate(self.max_offset_for_scrollbar())
     }
 
-    fn scrolled(&self) -> Pixels {
-        -self.scroll_px_offset_for_scrollbar().y
+    fn scrolled(&self, axis: Axis) -> Pixels {
+        -axis.coordinate(self.scroll_px_offset_for_scrollbar())
     }
 
-    fn scroll_to(&self, offset: Pixels) {
-        self.set_offset_from_scrollbar(point(Pixels::ZERO, -offset));
+    fn scroll_to(&self, axis: Axis, offset: Pixels) {
+        let current = self.scroll_px_offset_for_scrollbar();
+        self.set_offset_from_scrollbar(match axis {
+            Axis::Horizontal => point(-offset, current.y),
+            Axis::Vertical => point(current.x, -offset),
+        });
     }
 }
 
 impl Scrollable for ScrollHandle {
-    fn viewport_height(&self) -> Pixels {
-        self.bounds().size.height
+    fn viewport_extent(&self, axis: Axis) -> Pixels {
+        axis.extent(self.bounds())
     }
 
-    fn max_offset(&self) -> Pixels {
-        self.max_offset().y
+    fn max_offset(&self, axis: Axis) -> Pixels {
+        axis.coordinate(self.max_offset())
     }
 
-    fn scrolled(&self) -> Pixels {
-        -self.offset().y
+    fn scrolled(&self, axis: Axis) -> Pixels {
+        -axis.coordinate(self.offset())
     }
 
-    fn scroll_to(&self, offset: Pixels) {
-        let x = self.offset().x;
-        self.set_offset(Point::new(x, -offset));
+    fn scroll_to(&self, axis: Axis, offset: Pixels) {
+        let current = self.offset();
+        self.set_offset(match axis {
+            Axis::Horizontal => Point::new(-offset, current.y),
+            Axis::Vertical => Point::new(current.x, -offset),
+        });
     }
 }
 
-fn scroll_to(surface: &impl Scrollable, offset: Pixels, max_offset: Pixels) {
-    surface.scroll_to(offset.clamp(Pixels::ZERO, max_offset));
+fn scroll_to(surface: &impl Scrollable, axis: Axis, offset: Pixels, max_offset: Pixels) {
+    surface.scroll_to(axis, offset.clamp(Pixels::ZERO, max_offset));
 }
 
-/// An overlay vertical scrollbar pinned to the right edge of its parent.
-///
-/// The parent must be `relative()`; this element positions itself absolutely
-/// and never participates in layout, so adding it cannot change content size.
-pub fn vertical<S>(surface: &S, state: &Rc<ScrollbarState>) -> impl IntoElement
+fn overlay<S>(surface: &S, state: &Rc<ScrollbarState>, axis: Axis) -> impl IntoElement
 where
     S: Scrollable + Clone + 'static,
 {
-    let list = surface.clone();
+    let surface = surface.clone();
     let state = state.clone();
-    canvas(
+    let overlay = canvas(
         |_, _, _| (),
         move |track: Bounds<Pixels>, _, window: &mut Window, cx: &mut App| {
             let theme = Theme::current(cx);
-            let viewport_height = list.viewport_height();
-            let max_offset = Scrollable::max_offset(&list);
-            let offset = list.scrolled();
+            let viewport_extent = surface.viewport_extent(axis);
+            let max_offset = Scrollable::max_offset(&surface, axis);
+            let offset = surface.scrolled(axis);
             let now = Instant::now();
             state.observe(offset, now);
 
             let hovered = state.hovered.get();
             let grabbed = state.is_grabbed();
             let active = hovered || grabbed;
-            let thumb_width = px(if active {
+            let thumb_thickness = px(if active {
                 THUMB_WIDTH_ACTIVE
             } else {
                 THUMB_WIDTH
             });
 
-            let Some(geometry) = geometry(track, viewport_height, max_offset, offset, thumb_width)
-            else {
+            let Some(geometry) = geometry(
+                track,
+                axis,
+                viewport_extent,
+                max_offset,
+                offset,
+                thumb_thickness,
+            ) else {
                 // Not scrollable: drop any stale drag so a later resize cannot
                 // resume one, and paint nothing.
                 state.grab_offset.set(None);
@@ -231,11 +290,11 @@ where
                 .last_scroll
                 .get()
                 .map(|last| now.saturating_duration_since(last));
-            let opacity = opacity(since_scroll, hovered, grabbed);
+            let opacity = opacity(since_scroll, hovered, grabbed, cx.reduce_motion());
             if opacity > 0.0 {
                 window.paint_quad(quad(
                     geometry.thumb,
-                    thumb_width / 2.0,
+                    thumb_thickness / 2.0,
                     if active {
                         theme.text_tertiary
                     } else {
@@ -248,7 +307,9 @@ where
                 ));
                 if !active {
                     // Keep driving frames through the hold and the fade;
-                    // nothing else would repaint a resting transcript.
+                    // nothing else would repaint a resting transcript. The
+                    // requests stop on their own once `opacity` reaches zero,
+                    // which reduce-motion reaches a whole fade earlier.
                     window.request_animation_frame();
                 }
             }
@@ -270,7 +331,7 @@ where
             });
 
             window.on_mouse_event({
-                let list = list.clone();
+                let surface = surface.clone();
                 let state = state.clone();
                 move |event: &MouseDownEvent, phase, window, _| {
                     if phase != gpui::DispatchPhase::Bubble
@@ -279,18 +340,20 @@ where
                     {
                         return;
                     }
+                    let pointer = axis.coordinate(event.position);
                     if geometry.thumb.contains(&event.position) {
                         state
                             .grab_offset
-                            .set(Some(f32::from(event.position.y - geometry.thumb.top())));
+                            .set(Some(f32::from(pointer - axis.start(geometry.thumb))));
                     } else {
                         // A click on bare track centres the thumb there and
                         // begins dragging from its middle.
-                        let half = geometry.thumb.size.height / 2.0;
+                        let half = axis.extent(geometry.thumb) / 2.0;
                         state.grab_offset.set(Some(f32::from(half)));
                         scroll_to(
-                            &list,
-                            offset_for_thumb_top(track.top(), event.position.y - half, &geometry),
+                            &surface,
+                            axis,
+                            offset_for_thumb_start(axis.start(track), pointer - half, &geometry),
                             geometry.max_offset,
                         );
                     }
@@ -299,7 +362,7 @@ where
             });
 
             window.on_mouse_event({
-                let list = list.clone();
+                let surface = surface.clone();
                 let state = state.clone();
                 move |event: &MouseMoveEvent, phase, window, _| {
                     if phase != gpui::DispatchPhase::Bubble {
@@ -309,8 +372,13 @@ where
                         return;
                     };
                     scroll_to(
-                        &list,
-                        offset_for_thumb_top(track.top(), event.position.y - px(grab), &geometry),
+                        &surface,
+                        axis,
+                        offset_for_thumb_start(
+                            axis.start(track),
+                            axis.coordinate(event.position) - px(grab),
+                            &geometry,
+                        ),
                         geometry.max_offset,
                     );
                     window.refresh();
@@ -329,19 +397,82 @@ where
             });
         },
     )
-    .absolute()
-    .top_0()
-    .right_0()
-    .h_full()
-    .w(px(TRACK_WIDTH))
+    .absolute();
+
+    match axis {
+        // The horizontal track stops a track-width short of the right edge so
+        // it cannot overlap the vertical one. Both register window-level mouse
+        // listeners keyed only on `track.contains`, so a shared corner would
+        // let one click grab and jump both axes at once. AppKit reserves that
+        // corner for neither scroller; so do we.
+        Axis::Horizontal => overlay
+            .left_0()
+            .bottom_0()
+            .right(px(TRACK_WIDTH))
+            .h(px(TRACK_WIDTH)),
+        Axis::Vertical => overlay.top_0().right_0().h_full().w(px(TRACK_WIDTH)),
+    }
+}
+
+/// An overlay vertical scrollbar pinned to the right edge of its parent.
+///
+/// The parent must be `relative()`; this element positions itself absolutely
+/// and never participates in layout, so adding it cannot change content size.
+pub fn vertical<S>(surface: &S, state: &Rc<ScrollbarState>) -> impl IntoElement
+where
+    S: Scrollable + Clone + 'static,
+{
+    overlay(surface, state, Axis::Vertical)
+}
+
+/// An overlay horizontal scrollbar pinned to the bottom edge of its parent,
+/// stopping short of the bottom-right corner so a vertical bar on the same
+/// parent keeps sole ownership of it.
+///
+/// The parent must be `relative()`; this element positions itself absolutely
+/// and never participates in layout, so adding it cannot change content size.
+pub fn horizontal<S>(surface: &S, state: &Rc<ScrollbarState>) -> impl IntoElement
+where
+    S: Scrollable + Clone + 'static,
+{
+    overlay(surface, state, Axis::Horizontal)
 }
 
 #[cfg(test)]
 mod tests {
+    use gpui::{ParentElement, div, prelude::*};
+
     use super::*;
 
     fn track() -> Bounds<Pixels> {
         Bounds::new(point(px(500.0), px(100.0)), size(px(11.0), px(400.0)))
+    }
+
+    fn horizontal_track() -> Bounds<Pixels> {
+        Bounds::new(point(px(100.0), px(500.0)), size(px(400.0), px(11.0)))
+    }
+
+    fn vertical_geometry(
+        track: Bounds<Pixels>,
+        viewport_extent: Pixels,
+        max_offset: Pixels,
+        offset: Pixels,
+        thumb_thickness: Pixels,
+    ) -> Option<Geometry> {
+        geometry(
+            track,
+            Axis::Vertical,
+            viewport_extent,
+            max_offset,
+            offset,
+            thumb_thickness,
+        )
+    }
+
+    /// `opacity` with motion allowed, which is every case but the one test
+    /// below that is about reduce-motion.
+    fn opacity(since_scroll: Option<Duration>, hovered: bool, grabbed: bool) -> f32 {
+        super::opacity(since_scroll, hovered, grabbed, false)
     }
 
     #[test]
@@ -376,6 +507,26 @@ mod tests {
         assert_eq!(opacity(None, false, true), 1.0);
     }
 
+    /// Reduce-motion drops the ramp, not the disappearance: the thumb must not
+    /// be left painted at a resting opacity forever.
+    #[test]
+    fn reduce_motion_hides_the_bar_without_a_fade() {
+        let reduced = |since| super::opacity(Some(since), false, false, true);
+
+        // The hold is not motion, so it stays.
+        assert_eq!(reduced(Duration::ZERO), 1.0);
+        assert_eq!(reduced(HOLD - Duration::from_millis(1)), 1.0);
+
+        // Where the fade would have been, there is nothing at all.
+        assert_eq!(reduced(HOLD), 0.0);
+        assert_eq!(reduced(HOLD + FADE / 2), 0.0);
+        assert_eq!(reduced(HOLD + FADE * 10), 0.0);
+
+        // Hover and drag still pin it, reduce-motion or not.
+        assert_eq!(super::opacity(None, true, false, true), 1.0);
+        assert_eq!(super::opacity(Some(HOLD + FADE), false, true, true), 1.0);
+    }
+
     #[test]
     fn the_first_observed_offset_only_seeds_the_baseline() {
         let state = ScrollbarState::default();
@@ -397,15 +548,20 @@ mod tests {
 
     #[test]
     fn a_surface_that_does_not_scroll_has_no_thumb() {
-        assert!(geometry(track(), px(400.0), Pixels::ZERO, Pixels::ZERO, px(5.0)).is_none());
-        assert!(geometry(track(), Pixels::ZERO, px(900.0), Pixels::ZERO, px(5.0)).is_none());
+        assert!(
+            vertical_geometry(track(), px(400.0), Pixels::ZERO, Pixels::ZERO, px(5.0)).is_none()
+        );
+        assert!(
+            vertical_geometry(track(), Pixels::ZERO, px(900.0), Pixels::ZERO, px(5.0)).is_none()
+        );
     }
 
     #[test]
     fn thumb_height_tracks_the_visible_fraction() {
         // Viewport is a quarter of the content, so the thumb is a quarter of
         // the track.
-        let geometry = geometry(track(), px(400.0), px(1200.0), Pixels::ZERO, px(5.0)).unwrap();
+        let geometry =
+            vertical_geometry(track(), px(400.0), px(1200.0), Pixels::ZERO, px(5.0)).unwrap();
         assert_eq!(geometry.thumb.size.height, px(100.0));
         assert_eq!(geometry.thumb.top(), px(100.0));
         assert_eq!(geometry.travel, px(300.0));
@@ -413,18 +569,39 @@ mod tests {
 
     #[test]
     fn a_tiny_visible_fraction_still_leaves_a_grabbable_thumb() {
-        let geometry = geometry(track(), px(400.0), px(100_000.0), Pixels::ZERO, px(5.0)).unwrap();
-        assert_eq!(geometry.thumb.size.height, px(THUMB_MIN_HEIGHT));
+        let geometry =
+            vertical_geometry(track(), px(400.0), px(100_000.0), Pixels::ZERO, px(5.0)).unwrap();
+        assert_eq!(geometry.thumb.size.height, px(THUMB_MIN_LENGTH));
     }
 
     #[test]
     fn thumb_position_and_offset_are_inverse() {
         let track = track();
-        let geometry = geometry(track, px(400.0), px(1200.0), px(600.0), px(5.0)).unwrap();
+        let geometry = vertical_geometry(track, px(400.0), px(1200.0), px(600.0), px(5.0)).unwrap();
         // Halfway down the content puts the thumb halfway along its travel.
         assert_eq!(geometry.thumb.top(), track.top() + px(150.0));
         assert_eq!(
-            offset_for_thumb_top(track.top(), geometry.thumb.top(), &geometry),
+            offset_for_thumb_start(track.top(), geometry.thumb.top(), &geometry),
+            px(600.0)
+        );
+    }
+
+    #[test]
+    fn horizontal_thumb_tracks_width_and_offset() {
+        let track = horizontal_track();
+        let geometry = geometry(
+            track,
+            Axis::Horizontal,
+            px(400.0),
+            px(1200.0),
+            px(600.0),
+            px(5.0),
+        )
+        .unwrap();
+        assert_eq!(geometry.thumb.size.width, px(100.0));
+        assert_eq!(geometry.thumb.left(), track.left() + px(150.0));
+        assert_eq!(
+            offset_for_thumb_start(track.left(), geometry.thumb.left(), &geometry),
             px(600.0)
         );
     }
@@ -432,18 +609,19 @@ mod tests {
     #[test]
     fn offsets_clamp_at_both_ends() {
         let track = track();
-        let geometry = geometry(track, px(400.0), px(1200.0), px(1200.0), px(5.0)).unwrap();
+        let geometry =
+            vertical_geometry(track, px(400.0), px(1200.0), px(1200.0), px(5.0)).unwrap();
         assert_eq!(
             geometry.thumb.top(),
             track.bottom() - geometry.thumb.size.height
         );
 
         assert_eq!(
-            offset_for_thumb_top(track.top(), track.top() - px(9_999.0), &geometry),
+            offset_for_thumb_start(track.top(), track.top() - px(9_999.0), &geometry),
             Pixels::ZERO
         );
         assert_eq!(
-            offset_for_thumb_top(track.top(), track.bottom() + px(9_999.0), &geometry),
+            offset_for_thumb_start(track.top(), track.bottom() + px(9_999.0), &geometry),
             px(1200.0)
         );
     }
@@ -452,7 +630,73 @@ mod tests {
     fn overscrolled_offsets_do_not_push_the_thumb_past_the_track() {
         let track = track();
         // A momentum overscroll can report more than max for a frame.
-        let geometry = geometry(track, px(400.0), px(1200.0), px(5000.0), px(5.0)).unwrap();
+        let geometry =
+            vertical_geometry(track, px(400.0), px(1200.0), px(5000.0), px(5.0)).unwrap();
         assert!(geometry.thumb.bottom() <= track.bottom() + px(0.001));
+    }
+
+    /// Both bars register window-level listeners gated only on their own track
+    /// bounds, so an overlapping corner would let one press grab both axes and
+    /// the following drag move the content diagonally.
+    #[gpui::test]
+    fn the_shared_corner_belongs_to_one_bar_only(cx: &mut gpui::TestAppContext) {
+        const PANE: f32 = 200.0;
+
+        struct BothBars {
+            scroll: ScrollHandle,
+            vertical: Rc<ScrollbarState>,
+            horizontal: Rc<ScrollbarState>,
+        }
+
+        impl gpui::Render for BothBars {
+            fn render(&mut self, _: &mut Window, _: &mut gpui::Context<Self>) -> impl IntoElement {
+                div()
+                    .w(px(PANE))
+                    .h(px(PANE))
+                    .relative()
+                    .child(
+                        div()
+                            .id("corner-test-scroll")
+                            .size_full()
+                            .flex()
+                            .overflow_scroll()
+                            .track_scroll(&self.scroll)
+                            .child(div().w(px(1_000.0)).h(px(1_000.0)).flex_none()),
+                    )
+                    .child(vertical(&self.scroll, &self.vertical))
+                    .child(horizontal(&self.scroll, &self.horizontal))
+            }
+        }
+
+        let scroll = ScrollHandle::new();
+        let view_scroll = scroll.clone();
+        let (_, cx) = cx.add_window_view(move |_, _| BothBars {
+            scroll: view_scroll,
+            vertical: ScrollbarState::new(),
+            horizontal: ScrollbarState::new(),
+        });
+        assert!(
+            scroll.max_offset().x > px(0.0) && scroll.max_offset().y > px(0.0),
+            "the harness must scroll on both axes"
+        );
+
+        // Press in the bottom-right corner, inside both tracks were they to
+        // overlap. Only the vertical bar may claim it.
+        cx.simulate_event(MouseDownEvent {
+            button: MouseButton::Left,
+            position: point(px(PANE - 3.0), px(PANE - 3.0)),
+            modifiers: Default::default(),
+            click_count: 1,
+            first_mouse: false,
+        });
+        assert_eq!(
+            scroll.offset().x,
+            px(0.0),
+            "a press in the corner must not jump the horizontal axis"
+        );
+        assert!(
+            scroll.offset().y < px(0.0),
+            "the vertical bar still owns the corner"
+        );
     }
 }


### PR DESCRIPTION
Long lines were previously unreachable: markdown code blocks, the Review unified diff, and the file editor all clipped or wrapped whatever ran past the pane's right edge.

- `ui::scrollbar` is now generalized over an `Axis`, adding `scrollbar::horizontal` alongside `vertical`. The horizontal track stops a track-width short of the right edge so a press in the bottom-right corner cannot grab both axes at once, and `opacity` honors reduce-motion by dropping the fade ramp rather than the frames.
- Markdown code blocks keep a per-block `ScrollHandle` in `MarkdownView`, evicted with the same boundary as the flat-text cache, and paint an overlay bar.
- The Review diff reserves a content width from `Snapshot::max_content_columns` (measured in monospace columns via `unicode-width`) times the mono font's measured em advance. Row gutters and the file-header path and counts are pinned against the offset so they stay readable while code scrolls under them.
- The file editor scrolls on both axes, nowraps in `FieldMode::Code`, pins its line-number gutter, and follows the caret through `follow_file_editor_caret` and `revealed_scroll_offset_x` — a deliberate scroll is left alone, and reveals start past the gutter because it occludes the viewport's left edge.

---
Disclaimer: The change is fully done by AI but tested by me.

After the change:

- Markdown

<img width="885" height="482" alt="Screenshot 2026-08-13 at 13 49 22" src="https://github.com/user-attachments/assets/2ea15511-a4cc-439d-b5ba-52cb04f2c4f5" />

- Review diff
<img width="1624" height="1014" alt="Screenshot 2026-08-13 at 13 50 37" src="https://github.com/user-attachments/assets/94061058-a5f6-4e8a-b397-a02bf082f057" />

