### PR TITLE
Feat/native context menus

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -140,6 +140,24 @@ settings.theme_light:
   en: Light
 settings.theme_dark:
   en: Dark
+settings.theme_light_palette:
+  en: Light palette
+settings.theme_light_palette_description:
+  en: The palette used while the app is in light appearance
+settings.theme_dark_palette:
+  en: Dark palette
+settings.theme_dark_palette_description:
+  en: The palette used while the app is in dark appearance
+settings.theme_preview:
+  en: Preview
+settings.theme_preview_title:
+  en: Rename the theme tokens
+settings.theme_preview_body:
+  en: Surfaces, text tiers, accent and diff colors as they appear in a session.
+settings.theme_preview_action:
+  en: Send
+settings.theme_preview_caption:
+  en: waku/src/theme.rs
 
 input.do_anything:
   en: Do anything…

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -72,6 +72,15 @@ settings.theme_description: システム、ライト、ダークのいずれか�
 settings.theme_system: システム
 settings.theme_light: ライト
 settings.theme_dark: ダーク
+settings.theme_light_palette: ライトパレット
+settings.theme_light_palette_description: ライト外観のときに使用するパレット
+settings.theme_dark_palette: ダークパレット
+settings.theme_dark_palette_description: ダーク外観のときに使用するパレット
+settings.theme_preview: プレビュー
+settings.theme_preview_title: テーマトークンの名前を変更
+settings.theme_preview_body: セッションでの背景、文字階層、アクセント、差分の色。
+settings.theme_preview_action: 送信
+settings.theme_preview_caption: waku/src/theme.rs
 
 input.do_anything: 何でも依頼できます…
 input.search_models: モデルを検索…

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -68,6 +68,15 @@ settings.theme_description: 选择跟随系统、浅色或深色主题
 settings.theme_system: 跟随系统
 settings.theme_light: 浅色
 settings.theme_dark: 深色
+settings.theme_light_palette: 浅色调色板
+settings.theme_light_palette_description: 应用处于浅色外观时使用的调色板
+settings.theme_dark_palette: 深色调色板
+settings.theme_dark_palette_description: 应用处于深色外观时使用的调色板
+settings.theme_preview: 预览
+settings.theme_preview_title: 重命名主题令牌
+settings.theme_preview_body: 会话中的背景、文字层级、强调色与差异颜色。
+settings.theme_preview_action: 发送
+settings.theme_preview_caption: waku/src/theme.rs
 input.do_anything: 做什么都可以…
 input.search_models: 搜索模型…
 input.search_branches: 搜索分支

--- a/src/app.rs
+++ b/src/app.rs
@@ -57,7 +57,7 @@ use crate::persistence::{
 use crate::query::{Query, QueryCache};
 use crate::review_diff::{Snapshot as ReviewDiffSnapshot, Source as ReviewDiffSource};
 use crate::terminal::TerminalView;
-use crate::theme::{Theme, ThemePreference};
+use crate::theme::{Theme, ThemeId, ThemePreference};
 use crate::ui::text_field::TextField;
 use crate::ui::{
     MenuChip, ProjectNameSelector, activity_icon, activity_noun, file_icon, icon, icon_button,
@@ -1623,7 +1623,13 @@ impl Waku {
         );
         state.sidebar_width = sidebar_width;
         state.right_panel_width = right_panel_width;
-        crate::theme::apply_theme_preference(state.theme, window, cx);
+        crate::theme::apply_theme_preference(
+            state.theme,
+            state.light_theme,
+            state.dark_theme,
+            window,
+            cx,
+        );
         crate::platform::set_sidebar_material_width(window, sidebar_width);
         let project_paths = state
             .projects
@@ -1815,7 +1821,13 @@ impl Waku {
 
             cx.observe_window_appearance(window, |this: &mut Self, window, cx| {
                 if this.state.theme == ThemePreference::System {
-                    crate::theme::apply_theme_preference(this.state.theme, window, cx);
+                    crate::theme::apply_theme_preference(
+                        this.state.theme,
+                        this.state.light_theme,
+                        this.state.dark_theme,
+                        window,
+                        cx,
+                    );
                     cx.notify();
                 }
             })

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -648,73 +648,100 @@ impl Waku {
             .w_full()
             .flex()
             .flex_col()
-            .rounded(px(13.0))
-            .overflow_hidden()
-            .bg(theme.raised)
+            .gap(px(15.0))
             .child(
                 div()
                     .w_full()
-                    .min_h(px(60.0))
-                    .px(px(20.0))
-                    .py(px(12.0))
                     .flex()
-                    .items_center()
-                    .gap(px(24.0))
-                    .child(
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .child(
-                                div()
-                                    .text_size(px(13.5))
-                                    .font_weight(FontWeight::MEDIUM)
-                                    .text_color(theme.text)
-                                    .child(tr!("settings.theme")),
-                            )
-                            .child(
-                                div()
-                                    .mt(px(5.0))
-                                    .text_size(px(12.5))
-                                    .line_height(px(18.0))
-                                    .text_color(theme.text_secondary)
-                                    .child(tr!("settings.theme_description")),
-                            ),
-                    )
-                    .child(theme_selector),
+                    .flex_col()
+                    .rounded(px(13.0))
+                    .overflow_hidden()
+                    .bg(theme.raised)
+                    .child(settings_row(
+                        &theme,
+                        tr!("settings.theme"),
+                        tr!("settings.theme_description"),
+                        theme_selector.into_any_element(),
+                    ))
+                    .child(settings_divider(&theme))
+                    .child(settings_row(
+                        &theme,
+                        tr!("settings.theme_light_palette"),
+                        tr!("settings.theme_light_palette_description"),
+                        self.render_palette_selector(false, cx),
+                    ))
+                    .child(settings_divider(&theme))
+                    .child(settings_row(
+                        &theme,
+                        tr!("settings.theme_dark_palette"),
+                        tr!("settings.theme_dark_palette_description"),
+                        self.render_palette_selector(true, cx),
+                    )),
             )
-            .child(div().mx(px(20.0)).h(px(1.0)).bg(theme.border))
+            .child(render_palette_preview(&theme))
             .child(
                 div()
                     .w_full()
-                    .min_h(px(60.0))
-                    .px(px(20.0))
-                    .py(px(12.0))
                     .flex()
-                    .items_center()
-                    .gap(px(24.0))
-                    .child(
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .child(
-                                div()
-                                    .text_size(px(13.5))
-                                    .font_weight(FontWeight::MEDIUM)
-                                    .text_color(theme.text)
-                                    .child(tr!("language.title")),
-                            )
-                            .child(
-                                div()
-                                    .mt(px(5.0))
-                                    .text_size(px(12.5))
-                                    .line_height(px(18.0))
-                                    .text_color(theme.text_secondary)
-                                    .child(tr!("language.description")),
-                            ),
-                    )
-                    .child(language_selector),
+                    .flex_col()
+                    .rounded(px(13.0))
+                    .overflow_hidden()
+                    .bg(theme.raised)
+                    .child(settings_row(
+                        &theme,
+                        tr!("language.title"),
+                        tr!("language.description"),
+                        language_selector.into_any_element(),
+                    )),
             )
             .into_any_element()
+    }
+
+    /// One palette slot. Only ids that register the slot's variant are offered,
+    /// so a dark-only palette never becomes an unresolvable light choice.
+    fn render_palette_selector(&self, is_dark: bool, cx: &mut Context<Self>) -> AnyElement {
+        let selected = if is_dark {
+            self.state.dark_theme
+        } else {
+            self.state.light_theme
+        };
+        let id: SharedString = if is_dark {
+            "dark-palette-selector".into()
+        } else {
+            "light-palette-selector".into()
+        };
+        let menu_id: SharedString = format!("{id}-menu").into();
+        let handle = self.menu_handle(id.clone(), cx);
+        let weak = cx.entity().downgrade();
+
+        dropdown_menu(
+            MenuChip::new(id)
+                .label(selected.label())
+                .outlined()
+                .selected(handle.is_open())
+                .w(px(152.0))
+                .justify_between(),
+            menu_id,
+            &handle,
+            MenuAlign::BelowRight,
+            move |_| {
+                ThemeId::all_for(is_dark)
+                    .into_iter()
+                    .map(|id| {
+                        let weak = weak.clone();
+                        MenuItem::custom(move |_, cx| {
+                            palette_menu_row(id, is_dark, id == selected, cx)
+                        })
+                        .on_click(move |window, cx| {
+                            let _ = weak.update(cx, |this, cx| {
+                                this.set_palette(id, is_dark, window, cx);
+                            });
+                        })
+                    })
+                    .collect()
+            },
+        )
+        .into_any_element()
     }
 
     fn render_providers_settings(&self, cx: &mut Context<Self>) -> AnyElement {
@@ -1569,9 +1596,43 @@ impl Waku {
             return;
         }
         self.state.theme = preference;
-        crate::theme::apply_theme_preference(preference, window, cx);
+        self.reapply_theme(window, cx);
         self.save();
         cx.notify();
+    }
+
+    /// Assign a palette to one slot. The other slot is untouched, so a light
+    /// and a dark palette are chosen independently and `System` only decides
+    /// which of the two is live.
+    fn set_palette(
+        &mut self,
+        id: ThemeId,
+        is_dark: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let slot = if is_dark {
+            &mut self.state.dark_theme
+        } else {
+            &mut self.state.light_theme
+        };
+        if *slot == id {
+            return;
+        }
+        *slot = id;
+        self.reapply_theme(window, cx);
+        self.save();
+        cx.notify();
+    }
+
+    fn reapply_theme(&self, window: &mut Window, cx: &mut App) {
+        crate::theme::apply_theme_preference(
+            self.state.theme,
+            self.state.light_theme,
+            self.state.dark_theme,
+            window,
+            cx,
+        );
     }
 
     fn set_language(
@@ -1748,4 +1809,194 @@ mod tests {
             "/opt/homebrew/bin/codex"
         );
     }
+}
+
+/// The shared shape of a settings row: a title, a supporting line, and a
+/// trailing control.
+fn settings_row(
+    theme: &Theme,
+    title: String,
+    description: String,
+    control: AnyElement,
+) -> AnyElement {
+    div()
+        .w_full()
+        .min_h(px(60.0))
+        .px(px(20.0))
+        .py(px(12.0))
+        .flex()
+        .items_center()
+        .gap(px(24.0))
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .child(
+                    div()
+                        .text_size(px(13.5))
+                        .font_weight(FontWeight::MEDIUM)
+                        .text_color(theme.text)
+                        .child(title),
+                )
+                .child(
+                    div()
+                        .mt(px(5.0))
+                        .text_size(px(12.5))
+                        .line_height(px(18.0))
+                        .text_color(theme.text_secondary)
+                        .child(description),
+                ),
+        )
+        .child(control)
+        .into_any_element()
+}
+
+fn settings_divider(theme: &Theme) -> AnyElement {
+    div()
+        .mx(px(20.0))
+        .h(px(1.0))
+        .bg(theme.border)
+        .into_any_element()
+}
+
+/// A palette's identity at a glance: its own canvas, border and accent drawn
+/// in miniature, so the list reads as swatches rather than as a list of words.
+fn palette_swatch(palette: &Theme, size: f32) -> AnyElement {
+    div()
+        .w(px(size))
+        .h(px(size))
+        .rounded(px(size * 0.28))
+        .border_1()
+        .border_color(palette.border_strong)
+        .bg(palette.canvas)
+        .flex()
+        .items_center()
+        .justify_center()
+        .text_size(px(size * 0.44))
+        .line_height(px(size * 0.44))
+        .font_weight(FontWeight::MEDIUM)
+        .text_color(palette.accent)
+        .child("Aa")
+        .into_any_element()
+}
+
+fn palette_menu_row(id: ThemeId, is_dark: bool, selected: bool, cx: &App) -> AnyElement {
+    let theme = Theme::current(cx);
+    let palette = id.resolve(is_dark);
+    div()
+        .flex_1()
+        .min_w_0()
+        .flex()
+        .items_center()
+        .gap(px(8.0))
+        .child(palette_swatch(&palette, 20.0))
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .truncate()
+                .text_color(if selected {
+                    theme.text
+                } else {
+                    theme.text_secondary
+                })
+                .when(selected, |element| element.font_weight(FontWeight::MEDIUM))
+                .child(id.label()),
+        )
+        .when(selected, |element| {
+            element.child(icon("icons/check.svg", 11.0, theme.text_tertiary))
+        })
+        .into_any_element()
+}
+
+/// The active palette applied to the surfaces it actually governs — a raised
+/// panel, the three text tiers, the accent, and a diff pair — so a choice is
+/// judged before it is lived with.
+fn render_palette_preview(theme: &Theme) -> AnyElement {
+    let diff_line = |added: bool, text: &'static str| {
+        let color = if added { theme.success } else { theme.danger };
+        div()
+            .w_full()
+            .px(px(8.0))
+            .py(px(2.0))
+            .rounded(px(4.0))
+            .bg(gpui::Hsla { a: 0.12, ..color })
+            .text_size(px(11.5))
+            .line_height(px(17.0))
+            .text_color(color)
+            .child(text)
+    };
+
+    div()
+        .w_full()
+        .p(px(16.0))
+        .rounded(px(13.0))
+        .bg(theme.raised)
+        .flex()
+        .flex_col()
+        .gap(px(10.0))
+        .child(
+            div()
+                .text_size(px(11.0))
+                .font_weight(FontWeight::MEDIUM)
+                .text_color(theme.text_tertiary)
+                .child(tr!("settings.theme_preview")),
+        )
+        .child(
+            div()
+                .w_full()
+                .p(px(14.0))
+                .rounded(px(10.0))
+                .bg(theme.composer)
+                .border_1()
+                .border_color(theme.border)
+                .flex()
+                .flex_col()
+                .gap(px(8.0))
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap(px(7.0))
+                        .child(div().size(px(7.0)).rounded_full().bg(theme.accent))
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w_0()
+                                .truncate()
+                                .text_size(px(12.5))
+                                .font_weight(FontWeight::MEDIUM)
+                                .text_color(theme.text)
+                                .child(tr!("settings.theme_preview_title")),
+                        )
+                        .child(
+                            div()
+                                .px(px(8.0))
+                                .py(px(2.0))
+                                .rounded(px(5.0))
+                                .bg(theme.inverse)
+                                .text_size(px(10.5))
+                                .line_height(px(15.0))
+                                .font_weight(FontWeight::MEDIUM)
+                                .text_color(theme.on_inverse)
+                                .child(tr!("settings.theme_preview_action")),
+                        ),
+                )
+                .child(
+                    div()
+                        .text_size(px(12.0))
+                        .line_height(px(18.0))
+                        .text_color(theme.text_secondary)
+                        .child(tr!("settings.theme_preview_body")),
+                )
+                .child(diff_line(true, "+  let theme = Theme::current(cx);"))
+                .child(diff_line(false, "-  let theme = Theme::dark();"))
+                .child(
+                    div()
+                        .text_size(px(11.0))
+                        .text_color(theme.text_ghost)
+                        .child(tr!("settings.theme_preview_caption")),
+                ),
+        )
+        .into_any_element()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,9 +264,11 @@ fn main() {
 
             window
                 .update(cx, |_, window, cx| {
+                    let theme = crate::theme::Theme::current(cx);
                     crate::platform::configure_sidebar_material(
                         window,
-                        crate::theme::Theme::current(cx).is_dark,
+                        theme.is_dark,
+                        theme.sidebar_tint,
                     );
                     cx.activate(true);
                 })

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -30,7 +30,7 @@ use crate::model::{
     AgentSession, FavoriteModel, InteractionMode, Message, MessageAttachment, MessageRole, Project,
     ProviderKind, RuntimeMode, SessionWorkspace,
 };
-use crate::theme::ThemePreference;
+use crate::theme::{ThemeId, ThemePreference};
 
 const STATE_VERSION: u32 = 5;
 const APP_STATE_VERSION: u32 = 1;
@@ -261,6 +261,8 @@ pub struct AppSettings {
     pub analytics_enabled: bool,
     pub favorite_models: Vec<FavoriteModel>,
     pub theme: ThemePreference,
+    pub light_theme: ThemeId,
+    pub dark_theme: ThemeId,
     pub language: AppLanguage,
     pub computer_use_enabled: bool,
     pub computer_use_allowed_apps: Vec<ComputerAppGrant>,
@@ -278,6 +280,8 @@ impl Default for AppSettings {
             analytics_enabled: default_analytics_enabled(),
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
+            light_theme: ThemeId::default(),
+            dark_theme: ThemeId::default(),
             language: AppLanguage::default(),
             computer_use_enabled: default_computer_use_enabled(),
             computer_use_allowed_apps: Vec::new(),
@@ -346,6 +350,10 @@ pub struct PersistedState {
     #[serde(default)]
     pub theme: ThemePreference,
     #[serde(default)]
+    pub light_theme: ThemeId,
+    #[serde(default)]
+    pub dark_theme: ThemeId,
+    #[serde(default)]
     pub language: AppLanguage,
     #[serde(default = "default_sidebar_visibility")]
     pub sidebar_visible: bool,
@@ -412,6 +420,8 @@ impl PersistedState {
             remembered_model_traits: Vec::new(),
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
+            light_theme: ThemeId::default(),
+            dark_theme: ThemeId::default(),
             language: AppLanguage::default(),
             sidebar_visible: true,
             right_panel_visible: false,
@@ -497,6 +507,8 @@ impl PersistedState {
             analytics_enabled: self.analytics_enabled,
             favorite_models: self.favorite_models.clone(),
             theme: self.theme,
+            light_theme: self.light_theme,
+            dark_theme: self.dark_theme,
             language: self.language,
             computer_use_enabled: self.computer_use_enabled,
             computer_use_allowed_apps: self.computer_use_allowed_apps.clone(),
@@ -527,6 +539,8 @@ impl PersistedState {
         self.analytics_enabled = settings.analytics_enabled;
         self.favorite_models = settings.favorite_models;
         self.theme = settings.theme;
+        self.light_theme = settings.light_theme;
+        self.dark_theme = settings.dark_theme;
         self.language = settings.language;
         self.computer_use_enabled = settings.computer_use_enabled;
         self.computer_use_allowed_apps = settings.computer_use_allowed_apps;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -248,6 +248,153 @@ pub fn hide_window(window: &mut Window) {
     window.remove_window();
 }
 
+/// One row of a native context menu, in the order it should appear.
+pub struct NativeMenuItem {
+    pub label: String,
+    pub enabled: bool,
+    pub checked: bool,
+    pub separator: bool,
+}
+
+#[cfg(target_os = "macos")]
+mod native_menu {
+    use std::cell::Cell;
+
+    use gpui::{Pixels, Point, Window};
+    use objc2::rc::Retained;
+    use objc2::runtime::{NSObject, NSObjectProtocol};
+    use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
+    use objc2_app_kit::{
+        NSControlStateValueOff, NSControlStateValueOn, NSMenu, NSMenuItem, NSView,
+    };
+    use objc2_foundation::{NSPoint, NSString};
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    use super::NativeMenuItem;
+
+    define_class!(
+        // SAFETY: `NSObject` has no subclassing requirements and `MenuTarget`
+        // does not implement `Drop`.
+        #[unsafe(super(NSObject))]
+        #[thread_kind = MainThreadOnly]
+        #[name = "WakuContextMenuTarget"]
+        #[ivars = Cell<isize>]
+        struct MenuTarget;
+
+        unsafe impl NSObjectProtocol for MenuTarget {}
+
+        impl MenuTarget {
+            // AppKit sends this to the chosen item's target, and sends nothing
+            // at all when the menu is dismissed — which leaves the tag at -1.
+            #[unsafe(method(wakuContextMenuItemSelected:))]
+            fn item_selected(&self, item: &NSMenuItem) {
+                self.ivars().set(item.tag());
+            }
+        }
+    );
+
+    impl MenuTarget {
+        fn new(main_thread: MainThreadMarker) -> Retained<Self> {
+            let this = Self::alloc(main_thread).set_ivars(Cell::new(-1));
+            unsafe { msg_send![super(this), init] }
+        }
+    }
+
+    /// The window's native surface, captured while GPUI hands us a `Window` so
+    /// the menu itself can be popped later, from outside any GPUI borrow.
+    pub struct NativeContextMenu {
+        view: Retained<NSView>,
+    }
+
+    /// Capture that surface, or `None` when there is none — a headless test
+    /// window. The caller then falls back to the in-app menu card.
+    pub fn prepare_context_menu(window: &Window) -> Option<NativeContextMenu> {
+        let handle = HasWindowHandle::window_handle(window).ok()?;
+        let RawWindowHandle::AppKit(handle) = handle.as_raw() else {
+            return None;
+        };
+        MainThreadMarker::new()?;
+
+        // GPUI owns this view; we only read its geometry and anchor a menu to
+        // it.
+        let view = unsafe { Retained::retain(handle.ns_view.cast::<NSView>().as_ptr())? };
+        Some(NativeContextMenu { view })
+    }
+
+    impl NativeContextMenu {
+        /// Pop the menu at `position`, in GPUI's window coordinates, and block
+        /// on AppKit's tracking loop until it closes. Returns the index of the
+        /// chosen item within `items`.
+        ///
+        /// Must be called with no GPUI borrow held: the tracking loop keeps the
+        /// run loop turning, so GPUI redraws and its own timers still fire
+        /// while the menu is up.
+        pub fn show(&self, position: Point<Pixels>, items: &[NativeMenuItem]) -> Option<usize> {
+            let main_thread = MainThreadMarker::new()?;
+            let target = MenuTarget::new(main_thread);
+            let menu = NSMenu::new(main_thread);
+            // Enablement is ours to decide; AppKit's automatic validation
+            // would grey out every item, since a Rust target implements no
+            // validation protocol.
+            menu.setAutoenablesItems(false);
+
+            for (index, item) in items.iter().enumerate() {
+                if item.separator {
+                    menu.addItem(&NSMenuItem::separatorItem(main_thread));
+                    continue;
+                }
+                let entry = unsafe {
+                    NSMenuItem::initWithTitle_action_keyEquivalent(
+                        NSMenuItem::alloc(main_thread),
+                        &NSString::from_str(&item.label),
+                        Some(sel!(wakuContextMenuItemSelected:)),
+                        &NSString::from_str(""),
+                    )
+                };
+                unsafe { entry.setTarget(Some(&target)) };
+                entry.setTag(index as isize);
+                entry.setEnabled(item.enabled);
+                entry.setState(if item.checked {
+                    NSControlStateValueOn
+                } else {
+                    NSControlStateValueOff
+                });
+                menu.addItem(&entry);
+            }
+
+            // GPUI's coordinates start at the window's top-left; an unflipped
+            // AppKit view measures up from its bottom-left.
+            let height = self.view.bounds().size.height;
+            let y = f64::from(f32::from(position.y));
+            let y = if self.view.isFlipped() { y } else { height - y };
+            let location = NSPoint::new(f64::from(f32::from(position.x)), y);
+            menu.popUpMenuPositioningItem_atLocation_inView(None, location, Some(&self.view));
+
+            usize::try_from(target.ivars().get()).ok()
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub use native_menu::{NativeContextMenu, prepare_context_menu};
+
+#[cfg(not(target_os = "macos"))]
+pub struct NativeContextMenu {
+    _private: (),
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn prepare_context_menu(_: &Window) -> Option<NativeContextMenu> {
+    None
+}
+
+#[cfg(not(target_os = "macos"))]
+impl NativeContextMenu {
+    pub fn show(&self, _: gpui::Point<gpui::Pixels>, _: &[NativeMenuItem]) -> Option<usize> {
+        None
+    }
+}
+
 #[cfg(target_os = "macos")]
 thread_local! {
     static SIDEBAR_TINT_VIEW: std::cell::RefCell<Option<objc2::rc::Retained<objc2_app_kit::NSView>>> =

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -261,12 +261,20 @@ pub fn start_window_move(window: &Window) {
     window.start_window_move();
 }
 
+/// Whether the user has asked the system to reduce transparency. Read live so
+/// a change in System Settings is honored at the next theme application.
+#[cfg(target_os = "macos")]
+fn reduce_transparency() -> bool {
+    use objc2_app_kit::NSWorkspace;
+    NSWorkspace::sharedWorkspace().accessibilityDisplayShouldReduceTransparency()
+}
+
 /// Match Cursor's macOS glass window stack without asking GPUI's transparent
 /// Metal target to blend two translucent quads. The semantic tint is a native
 /// view above active Sidebar vibrancy; GPUI paints clear sidebar chrome and one
 /// translucent interaction layer above it.
 #[cfg(target_os = "macos")]
-pub fn configure_sidebar_material(window: &Window, dark: bool) {
+pub fn configure_sidebar_material(window: &Window, dark: bool, tint: gpui::Hsla) {
     use objc2::{MainThreadMarker, MainThreadOnly};
     use objc2_app_kit::{
         NSAutoresizingMaskOptions, NSColor, NSView, NSVisualEffectBlendingMode,
@@ -291,8 +299,14 @@ pub fn configure_sidebar_material(window: &Window, dark: bool) {
         let Some(native_window) = view.window() else {
             return;
         };
+        let backdrop = gpui::Rgba::from(tint);
         let background = if dark {
-            NSColor::colorWithSRGBRed_green_blue_alpha(0.0, 0.0, 0.0, 0.25)
+            NSColor::colorWithSRGBRed_green_blue_alpha(
+                f64::from(backdrop.r),
+                f64::from(backdrop.g),
+                f64::from(backdrop.b),
+                0.25,
+            )
         } else {
             NSColor::colorWithSRGBRed_green_blue_alpha(1.0, 1.0, 1.0, 0.0)
         };
@@ -316,8 +330,17 @@ pub fn configure_sidebar_material(window: &Window, dark: bool) {
             return;
         }
 
-        let channel = if dark { 0x18 } else { 0xF3 } as f64 / 255.0;
-        let tint = NSColor::colorWithSRGBRed_green_blue_alpha(channel, channel, channel, 0.92);
+        // The palette owns this color. Vibrancy still shows through, and the
+        // system's reduce-transparency setting closes that gap entirely rather
+        // than leaving the sidebar the one surface a theme cannot reach.
+        let tint = gpui::Rgba::from(tint);
+        let opacity = if reduce_transparency() { 1.0 } else { 0.92 };
+        let tint = NSColor::colorWithSRGBRed_green_blue_alpha(
+            f64::from(tint.r),
+            f64::from(tint.g),
+            f64::from(tint.b),
+            opacity,
+        );
 
         SIDEBAR_TINT_VIEW.with_borrow_mut(|slot| {
             let needs_new_view = slot.as_ref().is_none_or(|tint_view| {
@@ -348,7 +371,7 @@ pub fn configure_sidebar_material(window: &Window, dark: bool) {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn configure_sidebar_material(_: &Window, _: bool) {}
+pub fn configure_sidebar_material(_: &Window, _: bool, _: gpui::Hsla) {}
 
 #[cfg(target_os = "macos")]
 pub fn set_sidebar_material_width(window: &Window, width: f32) {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,5 +1,5 @@
-use gpui::{App, Global, Hsla, Window, WindowAppearance, hsla, rgb, transparent_black};
-use serde::{Deserialize, Serialize};
+use gpui::{App, Global, Hsla, Rgba, Window, WindowAppearance, hsla, rgb, transparent_black};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -21,7 +21,7 @@ impl ThemePreference {
         }
     }
 
-    fn resolves_to_dark(self, system_appearance: WindowAppearance) -> bool {
+    pub fn resolves_to_dark(self, system_appearance: WindowAppearance) -> bool {
         match self {
             Self::System => matches!(
                 system_appearance,
@@ -41,6 +41,464 @@ impl ThemePreference {
     }
 }
 
+/// The authored surface of a palette. Everything a [`Theme`] needs is derived
+/// from these fields, so a new palette is a handful of hexes rather than three
+/// dozen hand-tuned tokens. `contrast` scales every wash and text tier: low
+/// values keep secondary text and borders faint, high values push them toward
+/// the ink.
+#[derive(Clone, Copy)]
+pub struct ThemeSeed {
+    pub surface: u32,
+    pub ink: u32,
+    pub accent: u32,
+    pub contrast: u8,
+    pub added: u32,
+    pub removed: u32,
+    pub skill: u32,
+    pub warning: u32,
+}
+
+#[derive(Clone, Copy)]
+enum Palette {
+    Seed(ThemeSeed),
+    Authored(fn() -> Theme),
+}
+
+impl Palette {
+    fn resolve(self, is_dark: bool) -> Theme {
+        match self {
+            Self::Seed(seed) => Theme::from_seed(seed, is_dark),
+            Self::Authored(build) => build(),
+        }
+    }
+}
+
+pub struct ThemeDefinition {
+    id: ThemeId,
+    label: &'static str,
+    light: Option<Palette>,
+    dark: Option<Palette>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub enum ThemeId {
+    #[default]
+    Waku,
+    Catppuccin,
+    Dracula,
+    Everforest,
+    Github,
+    Gruvbox,
+    Monokai,
+    NightOwl,
+    Nord,
+    One,
+    RosePine,
+    Solarized,
+    TokyoNight,
+    Vercel,
+}
+
+impl ThemeId {
+    fn slug(self) -> &'static str {
+        match self {
+            Self::Waku => "waku",
+            Self::Catppuccin => "catppuccin",
+            Self::Dracula => "dracula",
+            Self::Everforest => "everforest",
+            Self::Github => "github",
+            Self::Gruvbox => "gruvbox",
+            Self::Monokai => "monokai",
+            Self::NightOwl => "night-owl",
+            Self::Nord => "nord",
+            Self::One => "one",
+            Self::RosePine => "rose-pine",
+            Self::Solarized => "solarized",
+            Self::TokyoNight => "tokyo-night",
+            Self::Vercel => "vercel",
+        }
+    }
+
+    fn from_slug(slug: &str) -> Option<Self> {
+        THEMES
+            .iter()
+            .map(|definition| definition.id)
+            .find(|id| id.slug() == slug)
+    }
+
+    fn definition(self) -> &'static ThemeDefinition {
+        THEMES
+            .iter()
+            .find(|definition| definition.id == self)
+            .unwrap_or(&THEMES[0])
+    }
+
+    pub fn label(self) -> &'static str {
+        self.definition().label
+    }
+
+    fn palette(self, is_dark: bool) -> Option<Palette> {
+        let definition = self.definition();
+        if is_dark {
+            definition.dark
+        } else {
+            definition.light
+        }
+    }
+
+    pub fn supports(self, is_dark: bool) -> bool {
+        self.palette(is_dark).is_some()
+    }
+
+    /// Palettes offered for one slot. A dark-only palette never appears in the
+    /// light picker, so a chosen id always has a variant to resolve.
+    pub fn all_for(is_dark: bool) -> Vec<Self> {
+        THEMES
+            .iter()
+            .map(|definition| definition.id)
+            .filter(|id| id.supports(is_dark))
+            .collect()
+    }
+
+    pub fn resolve(self, is_dark: bool) -> Theme {
+        self.palette(is_dark)
+            .or_else(|| Self::default().palette(is_dark))
+            .map(|palette| palette.resolve(is_dark))
+            .unwrap_or_else(|| {
+                if is_dark {
+                    Theme::dark()
+                } else {
+                    Theme::light()
+                }
+            })
+    }
+}
+
+impl Serialize for ThemeId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.slug())
+    }
+}
+
+impl<'de> Deserialize<'de> for ThemeId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let slug = String::deserialize(deserializer)?;
+        Ok(Self::from_slug(&slug).unwrap_or_default())
+    }
+}
+
+const THEMES: &[ThemeDefinition] = &[
+    ThemeDefinition {
+        id: ThemeId::Waku,
+        label: "Waku",
+        light: Some(Palette::Authored(Theme::light)),
+        dark: Some(Palette::Authored(Theme::dark)),
+    },
+    ThemeDefinition {
+        id: ThemeId::Catppuccin,
+        label: "Catppuccin",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xEFF1F5,
+            ink: 0x4C4F69,
+            accent: 0x1E66D5,
+            contrast: 46,
+            added: 0x40A02B,
+            removed: 0xD20F39,
+            skill: 0x8839EF,
+            warning: 0xDF8E1D,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x1E1E2E,
+            ink: 0xCDD6F4,
+            accent: 0x89B4FA,
+            contrast: 58,
+            added: 0xA6E3A1,
+            removed: 0xF38BA8,
+            skill: 0xCBA6F7,
+            warning: 0xF9E2AF,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Dracula,
+        label: "Dracula",
+        light: None,
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x282A36,
+            ink: 0xF8F8F2,
+            accent: 0xBD93F9,
+            contrast: 56,
+            added: 0x50FA7B,
+            removed: 0xFF5555,
+            skill: 0xFF79C6,
+            warning: 0xF1FA8C,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Everforest,
+        label: "Everforest",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFDF6E3,
+            ink: 0x5C6A72,
+            accent: 0x8DA101,
+            contrast: 48,
+            added: 0x8DA101,
+            removed: 0xF85552,
+            skill: 0xDF69BA,
+            warning: 0xDFA000,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x2D353B,
+            ink: 0xD3C6AA,
+            accent: 0xA7C080,
+            contrast: 58,
+            added: 0xA7C080,
+            removed: 0xE67E80,
+            skill: 0xD699B6,
+            warning: 0xDBBC7F,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Github,
+        label: "GitHub",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFFFFFF,
+            ink: 0x1F2328,
+            accent: 0x0969DA,
+            contrast: 45,
+            added: 0x1A7F37,
+            removed: 0xCF222E,
+            skill: 0x8250DF,
+            warning: 0x9A6700,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x0D1117,
+            ink: 0xE6EDF3,
+            accent: 0x2F81F7,
+            contrast: 60,
+            added: 0x3FB950,
+            removed: 0xF85149,
+            skill: 0xA371F7,
+            warning: 0xD29922,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Gruvbox,
+        label: "Gruvbox",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFBF1C7,
+            ink: 0x3C3836,
+            accent: 0x076678,
+            contrast: 48,
+            added: 0x79740E,
+            removed: 0x9D0006,
+            skill: 0x8F3F71,
+            warning: 0xB57614,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x282828,
+            ink: 0xEBDBB2,
+            accent: 0x83A598,
+            contrast: 56,
+            added: 0xB8BB26,
+            removed: 0xFB4934,
+            skill: 0xD3869B,
+            warning: 0xFABD2F,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Monokai,
+        label: "Monokai",
+        light: None,
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x272822,
+            ink: 0xF8F8F2,
+            accent: 0x66D9EF,
+            contrast: 56,
+            added: 0xA6E22E,
+            removed: 0xF92672,
+            skill: 0xAE81FF,
+            warning: 0xE6DB74,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::NightOwl,
+        label: "Night Owl",
+        light: None,
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x011627,
+            ink: 0xD6DEEB,
+            accent: 0x82AAFF,
+            contrast: 58,
+            added: 0xADDB67,
+            removed: 0xEF5350,
+            skill: 0xC792EA,
+            warning: 0xECC48D,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Nord,
+        label: "Nord",
+        light: None,
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x2E3440,
+            ink: 0xD8DEE9,
+            accent: 0x88C0D0,
+            contrast: 58,
+            added: 0xA3BE8C,
+            removed: 0xBF616A,
+            skill: 0xB48EAD,
+            warning: 0xEBCB8B,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::One,
+        label: "One",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFAFAFA,
+            ink: 0x383A42,
+            accent: 0x4078F2,
+            contrast: 46,
+            added: 0x50A14F,
+            removed: 0xE45649,
+            skill: 0xA626A4,
+            warning: 0xC18401,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x282C34,
+            ink: 0xABB2BF,
+            accent: 0x61AFEF,
+            contrast: 60,
+            added: 0x98C379,
+            removed: 0xE06C75,
+            skill: 0xC678DD,
+            warning: 0xE5C07B,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::RosePine,
+        label: "Rosé Pine",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFAF4ED,
+            ink: 0x575279,
+            accent: 0x907AA9,
+            contrast: 48,
+            added: 0x286983,
+            removed: 0xB4637A,
+            skill: 0x907AA9,
+            warning: 0xEA9D34,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x232136,
+            ink: 0xE0DEF4,
+            accent: 0xC4A7E7,
+            contrast: 58,
+            added: 0x9CCFD8,
+            removed: 0xEB6F92,
+            skill: 0xC4A7E7,
+            warning: 0xF6C177,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Solarized,
+        label: "Solarized",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFDF6E3,
+            ink: 0x586E75,
+            accent: 0x268BD2,
+            contrast: 50,
+            added: 0x859900,
+            removed: 0xDC322F,
+            skill: 0x6C71C4,
+            warning: 0xB58900,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x002B36,
+            ink: 0x93A1A1,
+            accent: 0x268BD2,
+            contrast: 62,
+            added: 0x859900,
+            removed: 0xDC322F,
+            skill: 0x6C71C4,
+            warning: 0xB58900,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::TokyoNight,
+        label: "Tokyo Night",
+        light: None,
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x1A1B26,
+            ink: 0xC0CAF5,
+            accent: 0x7AA2F7,
+            contrast: 58,
+            added: 0x9ECE6A,
+            removed: 0xF7768E,
+            skill: 0xBB9AF7,
+            warning: 0xE0AF68,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Vercel,
+        label: "Vercel",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFFFFFF,
+            ink: 0x171717,
+            accent: 0x0070F3,
+            contrast: 44,
+            added: 0x1A7F37,
+            removed: 0xE5484D,
+            skill: 0x8E4EC6,
+            warning: 0xA35200,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x0A0A0A,
+            ink: 0xEDEDED,
+            accent: 0x0072F5,
+            contrast: 60,
+            added: 0x45A557,
+            removed: 0xE5484D,
+            skill: 0x8E4EC6,
+            warning: 0xF5A623,
+        })),
+    },
+];
+
+fn hex(value: u32) -> Hsla {
+    rgb(value).into()
+}
+
+fn with_alpha(color: Hsla, alpha: f32) -> Hsla {
+    Hsla { a: alpha, ..color }
+}
+
+fn with_lightness(color: Hsla, lightness: f32) -> Hsla {
+    Hsla {
+        l: lightness.clamp(0.0, 1.0),
+        ..color
+    }
+}
+
+fn shift_lightness(color: Hsla, delta: f32) -> Hsla {
+    with_lightness(color, color.l + delta)
+}
+
+fn mix(base: Hsla, other: Hsla, amount: f32) -> Hsla {
+    let amount = amount.clamp(0.0, 1.0);
+    let base = Rgba::from(base);
+    let other = Rgba::from(other);
+    Hsla::from(Rgba {
+        r: base.r + (other.r - base.r) * amount,
+        g: base.g + (other.g - base.g) * amount,
+        b: base.b + (other.b - base.b) * amount,
+        a: base.a + (other.a - base.a) * amount,
+    })
+}
+
+fn luminance(color: Hsla) -> f32 {
+    let color = Rgba::from(color);
+    0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b
+}
+
 /// Waku's visual language, take two: neutral graphite surfaces in the spirit
 /// of Cursor — color is reserved for meaning. On macOS the sidebar's semantic
 /// tint is installed as a native layer above Sidebar vibrancy; keeping this
@@ -52,6 +510,11 @@ pub struct Theme {
     pub canvas: Hsla,
     pub sidebar: Hsla,
     pub sidebar_drag_background: Hsla,
+    /// The sidebar's own base color, painted as a native layer above Sidebar
+    /// vibrancy. It has to live in the palette rather than in the platform
+    /// layer: a themed canvas beside a fixed graphite sidebar reads as two
+    /// different apps.
+    pub sidebar_tint: Hsla,
     pub sidebar_item_background: Hsla,
     pub surface: Hsla,
     pub raised: Hsla,
@@ -73,6 +536,9 @@ pub struct Theme {
 
     /// Brand coral. Logo, caret, live-activity pulses — nothing structural.
     pub accent: Hsla,
+    /// Glyph laid directly on `accent`, flipped by the accent's own luminance
+    /// so a pale palette does not print white on near-white.
+    pub on_accent: Hsla,
     pub resize_handle: Hsla,
     /// Meter fills in the usage panel. Quota-meter blue by convention;
     /// warning/danger take over as a lane fills.
@@ -106,12 +572,117 @@ impl Theme {
         }
     }
 
+    /// Expand a palette's authored fields into every token the app reads. The
+    /// two branches mirror how depth reads in each mode: dark panels rise off
+    /// the canvas by getting lighter, light panels recede by getting darker,
+    /// and the composer is the one surface that goes the other way in light so
+    /// it stays paper against a tinted canvas.
+    pub fn from_seed(seed: ThemeSeed, is_dark: bool) -> Self {
+        let seed_surface = hex(seed.surface);
+        let ink = hex(seed.ink);
+        let accent = hex(seed.accent);
+        let contrast = f32::from(seed.contrast).clamp(0.0, 100.0) / 100.0;
+
+        let (canvas, raised, composer, inset) = if is_dark {
+            (
+                seed_surface,
+                shift_lightness(seed_surface, 0.035),
+                shift_lightness(seed_surface, 0.027),
+                shift_lightness(seed_surface, -0.020),
+            )
+        } else {
+            (
+                shift_lightness(seed_surface, -0.035),
+                shift_lightness(seed_surface, -0.070),
+                seed_surface,
+                shift_lightness(seed_surface, -0.100),
+            )
+        };
+        let terminal = if is_dark { inset } else { seed_surface };
+
+        let wash = hsla(
+            ink.h,
+            ink.s.min(0.12),
+            if is_dark { 0.90 } else { 0.12 },
+            1.0,
+        );
+
+        let text_base = canvas;
+        let warning = hex(seed.warning);
+
+        Self {
+            is_dark,
+            canvas,
+            sidebar: transparent_black(),
+            sidebar_drag_background: shift_lightness(canvas, -0.012),
+            sidebar_tint: shift_lightness(canvas, -0.012),
+            sidebar_item_background: with_alpha(
+                with_lightness(wash, if is_dark { 0.94 } else { 0.08 }),
+                0.06,
+            ),
+            surface: canvas,
+            raised,
+            composer,
+            inset,
+            terminal,
+            overlay: with_alpha(wash, 0.030 + contrast * 0.040),
+            overlay_strong: with_alpha(wash, 0.055 + contrast * 0.070),
+
+            border: with_alpha(wash, 0.040 + contrast * 0.060),
+            border_strong: with_alpha(wash, 0.080 + contrast * 0.120),
+            sidebar_border: if is_dark {
+                shift_lightness(canvas, 0.058)
+            } else {
+                with_alpha(wash, 0.12)
+            },
+
+            text: ink,
+            text_secondary: mix(text_base, ink, 0.60 + contrast * 0.17),
+            text_tertiary: mix(text_base, ink, 0.40 + contrast * 0.21),
+            text_ghost: mix(text_base, ink, 0.22 + contrast * 0.20),
+
+            accent,
+            on_accent: if luminance(accent) > 0.55 {
+                with_lightness(accent, 0.10)
+            } else {
+                with_lightness(with_alpha(accent, 1.0), 0.98)
+            },
+            resize_handle: accent,
+            gauge: accent,
+
+            selection: with_alpha(accent, if is_dark { 0.42 } else { 0.28 }),
+            code_text: hex(seed.skill),
+            code_wash: with_alpha(wash, 0.060 + contrast * 0.040),
+
+            inverse: if is_dark {
+                with_lightness(ink, 0.91)
+            } else {
+                with_lightness(ink, 0.13)
+            },
+            on_inverse: if is_dark {
+                with_lightness(canvas, 0.09)
+            } else {
+                with_lightness(canvas, 0.97)
+            },
+
+            warning,
+            success: hex(seed.added),
+            favorite: Hsla {
+                s: (warning.s * 1.6).min(1.0),
+                ..warning
+            },
+            danger: hex(seed.removed),
+            danger_soft: with_alpha(hex(seed.removed), 0.10),
+        }
+    }
+
     pub fn dark() -> Self {
         Self {
             is_dark: true,
             canvas: rgb(0x1A1A1A).into(),
             sidebar: transparent_black(),
             sidebar_drag_background: rgb(0x181818).into(),
+            sidebar_tint: rgb(0x181818).into(),
             sidebar_item_background: hsla(0.0, 0.0, 0.941, 0.06),
             surface: rgb(0x1A1A1A).into(),
             raised: rgb(0x232323).into(),
@@ -131,6 +702,7 @@ impl Theme {
             text_ghost: rgb(0x575757).into(),
 
             accent: rgb(0xE2795B).into(),
+            on_accent: rgb(0xFFFFFF).into(),
             resize_handle: rgb(0x3B82F6).into(),
             gauge: rgb(0x3B82F6).into(),
 
@@ -155,6 +727,7 @@ impl Theme {
             canvas: rgb(0xF6F5F6).into(),
             sidebar: transparent_black(),
             sidebar_drag_background: rgb(0xF3F3F3).into(),
+            sidebar_tint: rgb(0xF3F3F3).into(),
             sidebar_item_background: hsla(0.0, 0.0, 0.078, 0.06),
             surface: rgb(0xF6F5F6).into(),
             raised: rgb(0xECECEC).into(),
@@ -174,6 +747,7 @@ impl Theme {
             text_ghost: rgb(0xA4A4A4).into(),
 
             accent: rgb(0xC85F44).into(),
+            on_accent: rgb(0xFFFFFF).into(),
             resize_handle: rgb(0x2563EB).into(),
             gauge: rgb(0x2563EB).into(),
 
@@ -207,25 +781,99 @@ fn set_active_theme(theme: Theme, cx: &mut App) {
 /// Resolve and publish the startup palette, before any window exists.
 pub fn init(cx: &mut App) {
     let system_appearance = cx.window_appearance();
-    let theme = if ThemePreference::System.resolves_to_dark(system_appearance) {
-        Theme::dark()
-    } else {
-        Theme::light()
-    };
-    set_active_theme(theme, cx);
+    let is_dark = ThemePreference::System.resolves_to_dark(system_appearance);
+    set_active_theme(ThemeId::default().resolve(is_dark), cx);
 }
 
-pub fn apply_theme_preference(preference: ThemePreference, window: &mut Window, cx: &mut App) {
+pub fn apply_theme_preference(
+    preference: ThemePreference,
+    light_theme: ThemeId,
+    dark_theme: ThemeId,
+    window: &mut Window,
+    cx: &mut App,
+) {
     crate::platform::set_window_appearance(window, preference.native_override());
     let is_dark = preference.resolves_to_dark(cx.window_appearance());
-    set_active_theme(
-        if is_dark {
-            Theme::dark()
-        } else {
-            Theme::light()
-        },
-        cx,
-    );
-    crate::platform::configure_sidebar_material(window, is_dark);
+    let selected = if is_dark { dark_theme } else { light_theme };
+    let theme = selected.resolve(is_dark);
+    set_active_theme(theme, cx);
+    crate::platform::configure_sidebar_material(window, is_dark, theme.sidebar_tint);
     window.refresh();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_theme_offers_at_least_one_variant() {
+        for definition in THEMES {
+            assert!(
+                definition.light.is_some() || definition.dark.is_some(),
+                "{} registers no variant",
+                definition.label
+            );
+        }
+    }
+
+    #[test]
+    fn slugs_round_trip_and_are_unique() {
+        for definition in THEMES {
+            assert_eq!(
+                ThemeId::from_slug(definition.id.slug()),
+                Some(definition.id)
+            );
+        }
+        let mut slugs: Vec<_> = THEMES
+            .iter()
+            .map(|definition| definition.id.slug())
+            .collect();
+        slugs.sort_unstable();
+        let count = slugs.len();
+        slugs.dedup();
+        assert_eq!(slugs.len(), count);
+    }
+
+    #[test]
+    fn unknown_slug_falls_back_to_default() {
+        let id: ThemeId = serde_json::from_str("\"not-a-theme\"").unwrap();
+        assert_eq!(id, ThemeId::default());
+        assert_eq!(
+            serde_json::to_string(&ThemeId::TokyoNight).unwrap(),
+            "\"tokyo-night\""
+        );
+    }
+
+    #[test]
+    fn pickers_only_offer_supported_variants() {
+        assert!(!ThemeId::all_for(false).contains(&ThemeId::Dracula));
+        assert!(ThemeId::all_for(true).contains(&ThemeId::Dracula));
+        for is_dark in [false, true] {
+            for id in ThemeId::all_for(is_dark) {
+                assert_eq!(id.resolve(is_dark).is_dark, is_dark);
+            }
+        }
+    }
+
+    #[test]
+    fn derived_surfaces_separate_from_the_canvas() {
+        for is_dark in [false, true] {
+            for id in ThemeId::all_for(is_dark) {
+                let theme = id.resolve(is_dark);
+                assert_ne!(
+                    theme.raised,
+                    theme.canvas,
+                    "{} {} has a flat raised surface",
+                    id.slug(),
+                    is_dark
+                );
+                assert!(
+                    (luminance(theme.text) - luminance(theme.canvas)).abs() > 0.25,
+                    "{} {} text is too close to its canvas",
+                    id.slug(),
+                    is_dark
+                );
+            }
+        }
+    }
 }

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -188,6 +188,9 @@ struct MenuState {
     /// outside-click capture must leave that click alone so the later trigger
     /// handler can close it; a context-menu row has no such handler.
     trigger_click_toggles: bool,
+    /// AppKit is drawing this menu, so the site reports itself open — for a
+    /// trigger's pressed styling — while drawing no card of its own.
+    native: bool,
 }
 
 /// Cross-frame state for one context menu. The owner keeps one per menu site.
@@ -205,6 +208,11 @@ pub struct ContextMenuHandle {
     /// own on top.
     #[allow(clippy::type_complexity)]
     on_toggle: Rc<Vec<Rc<dyn Fn(bool, &mut Window, &mut App)>>>,
+    /// The site's item builder, recorded on every frame [`context_menu`]
+    /// renders, so a menu can also be raised from outside that call — a
+    /// keyboard trigger, or AppKit's own menu.
+    #[allow(clippy::type_complexity)]
+    items: Rc<RefCell<Option<Rc<dyn Fn(&mut App) -> Vec<MenuItem>>>>>,
 }
 
 impl ContextMenuHandle {
@@ -215,6 +223,7 @@ impl ContextMenuHandle {
             focus: cx.focus_handle(),
             trigger_bounds: Rc::new(Cell::new(None)),
             on_toggle: Rc::new(Vec::new()),
+            items: Rc::new(RefCell::new(None)),
         }
     }
 
@@ -257,6 +266,9 @@ impl ContextMenuHandle {
             .get()
             .map(|bounds| Point::new(bounds.left() + px(8.0), bounds.bottom()))
             .unwrap_or_else(|| window.mouse_position());
+        if open_native_menu(self, position, window, cx) {
+            return;
+        }
         open_menu(self, position, SurfaceFocus::Card, false, window, cx);
     }
 
@@ -267,6 +279,7 @@ impl ContextMenuHandle {
             state.open = None;
             state.highlighted = None;
             state.trigger_click_toggles = false;
+            state.native = false;
             was_open
         };
         if was_open {
@@ -349,6 +362,94 @@ fn open_menu(
         });
     }
     window.refresh();
+}
+
+/// Raise this site's menu as a real AppKit menu, returning whether it opened.
+///
+/// Falls back to the in-app card when there is no native window (tests), when
+/// the site has not rendered its item builder yet, or when the item list needs
+/// a drawn row that no `NSMenuItem` can carry.
+///
+/// AppKit's tracking loop blocks, so it runs from a foreground task rather than
+/// inside the event handler: by then GPUI holds no borrow, and the app keeps
+/// drawing and animating underneath the open menu.
+fn open_native_menu(
+    handle: &ContextMenuHandle,
+    position: Point<Pixels>,
+    window: &mut Window,
+    cx: &mut App,
+) -> bool {
+    // A test window has no platform window to ask, and answers the question by
+    // panicking rather than by failing, so it never gets asked.
+    if cfg!(test) {
+        return false;
+    }
+    let Some(native): Option<crate::platform::NativeContextMenu> =
+        crate::platform::prepare_context_menu(window)
+    else {
+        return false;
+    };
+    let Some(build) = handle.items.borrow().clone() else {
+        return false;
+    };
+    let items = build(cx);
+    if items
+        .iter()
+        .any(|item| matches!(item, MenuItem::Custom { .. }))
+    {
+        return false;
+    }
+
+    let entries: Vec<crate::platform::NativeMenuItem> = items
+        .iter()
+        .map(|item| match item {
+            MenuItem::Entry {
+                label,
+                selected,
+                disabled,
+                ..
+            } => crate::platform::NativeMenuItem {
+                label: label.to_string(),
+                enabled: !disabled,
+                checked: *selected,
+                separator: false,
+            },
+            MenuItem::Header(label) => crate::platform::NativeMenuItem {
+                label: label.to_string(),
+                enabled: false,
+                checked: false,
+                separator: false,
+            },
+            MenuItem::Separator | MenuItem::Custom { .. } => crate::platform::NativeMenuItem {
+                label: String::new(),
+                enabled: false,
+                checked: false,
+                separator: true,
+            },
+        })
+        .collect();
+    let actions: Vec<Option<Rc<dyn Fn(&mut Window, &mut App)>>> =
+        items.into_iter().map(MenuItem::click_handler).collect();
+
+    handle.open_at(position, false, window, cx);
+    handle.state.borrow_mut().native = true;
+    window.refresh();
+
+    let handle = handle.clone();
+    let mut async_window = window.to_async(cx);
+    cx.foreground_executor()
+        .spawn(async move {
+            let chosen = native.show(position, &entries);
+            let _ = async_window.update(|window, cx| {
+                handle.close(window, cx);
+                if let Some(action) = chosen.and_then(|index| actions[index].clone()) {
+                    action(window, cx);
+                }
+                window.refresh();
+            });
+        })
+        .detach();
+    true
 }
 
 /// A zero-cost canvas that records its parent's bounds into the handle.
@@ -844,7 +945,12 @@ where
     E: ParentElement + Styled + InteractiveElement + IntoElement + 'static,
 {
     let id: ElementId = id.into();
-    let open_at = handle.state.borrow().open;
+    let items: Rc<dyn Fn(&mut App) -> Vec<MenuItem>> = Rc::new(items);
+    *handle.items.borrow_mut() = Some(items.clone());
+    let (open_at, native) = {
+        let state = handle.state.borrow();
+        (state.open, state.native)
+    };
     let handle_for_down = handle.clone();
 
     let element = element
@@ -853,20 +959,22 @@ where
         .on_mouse_down(
             MouseButton::Right,
             move |event: &MouseDownEvent, window, cx| {
-                open_menu(
-                    &handle_for_down,
-                    event.position,
-                    SurfaceFocus::Card,
-                    false,
-                    window,
-                    cx,
-                );
+                if !open_native_menu(&handle_for_down, event.position, window, cx) {
+                    open_menu(
+                        &handle_for_down,
+                        event.position,
+                        SurfaceFocus::Card,
+                        false,
+                        window,
+                        cx,
+                    );
+                }
                 cx.stop_propagation();
                 window.prevent_default();
             },
         );
 
-    let Some(position) = open_at else {
+    let Some(position) = open_at.filter(|_| !native) else {
         return element.into_any_element();
     };
 
@@ -879,7 +987,7 @@ where
                     .child(MenuCard {
                         id,
                         handle: handle.clone(),
-                        items: Rc::new(items),
+                        items,
                     }),
             )
             .with_priority(1),


### PR DESCRIPTION
This pull request introduces customizable light and dark theme palettes to the application, allowing users to independently select and preview different palettes for light and dark modes. It updates the settings UI to support these changes, adds new localization strings, and ensures the selected palettes are persisted and applied throughout the app.

**Theme palette customization and persistence:**

- Added support for independently selecting light and dark theme palettes in the settings UI, including new dropdown selectors and a preview section to visualize palette choices. (`src/app/settings.rs`, [[1]](diffhunk://#diff-16e26b0228eb4d9d7a263315762b3dcac73aeb6677eae6e2dcb83e3e03752f1dL651-R742) [[2]](diffhunk://#diff-16e26b0228eb4d9d7a263315762b3dcac73aeb6677eae6e2dcb83e3e03752f1dL1572-R1637)
- Updated the persistence layer to store and load the selected `light_theme` and `dark_theme` (`ThemeId`) alongside the theme preference, ensuring user choices are remembered across sessions. (`src/persistence.rs`, [[1]](diffhunk://#diff-dc2852d4c0a9a6f148427cb8de2d4e77bee220c26f5cf1872ea17a574deae1d9R264-R265) [[2]](diffhunk://#diff-dc2852d4c0a9a6f148427cb8de2d4e77bee220c26f5cf1872ea17a574deae1d9R283-R284) [[3]](diffhunk://#diff-dc2852d4c0a9a6f148427cb8de2d4e77bee220c26f5cf1872ea17a574deae1d9R353-R356) [[4]](diffhunk://#diff-dc2852d4c0a9a6f148427cb8de2d4e77bee220c26f5cf1872ea17a574deae1d9R423-R424) [[5]](diffhunk://#diff-dc2852d4c0a9a6f148427cb8de2d4e77bee220c26f5cf1872ea17a574deae1d9R510-R511) [[6]](diffhunk://#diff-dc2852d4c0a9a6f148427cb8de2d4e77bee220c26f5cf1872ea17a574deae1d9R542-R543)

**Theme application logic:**

- Refactored theme application to use both light and dark palettes, updating calls to `apply_theme_preference` to include the selected palette IDs and ensuring the correct palette is applied based on the current appearance. (`src/app.rs`, [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L60-R60) [[2]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L1626-R1632) [[3]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L1818-R1830)

**Localization:**

- Added new localization strings for the theme palette selection and preview features in English, Japanese, and Simplified Chinese. (`locales/app.yml`, [[1]](diffhunk://#diff-681a487f00ab4a5ee6626370cd26e3cb6ccae10eb9bf06af92b2d75536427f04R143-R160); `locales/ja.yml`, [[2]](diffhunk://#diff-7ebd161d0d8b0036c403f0b4c82fcd9b4349f84fea80eca785c825b7423bb22bR75-R83); `locales/zh-CN.yml`, [[3]](diffhunk://#diff-bfd7909c5b5509cfbff6cd57efed3123ded57c31f09ea5fbf2e2ce2628dff6a3R71-R79)

**UI improvements:**

- Refactored the settings UI to use reusable row and divider components, improving consistency and maintainability. Added palette swatches and a live preview to help users understand their theme choices. (`src/app/settings.rs`, [src/app/settings.rsR1813-R2002](diffhunk://#diff-16e26b0228eb4d9d7a263315762b3dcac73aeb6677eae6e2dcb83e3e03752f1dR1813-R2002))

**Sidebar theming:**

- Updated sidebar theming logic to use the currently selected palette's sidebar tint, ensuring visual consistency with the active theme. (`src/main.rs`, [src/main.rsR267-R271](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR267-R271))

fixes #69