### PR TITLE
Feat/subagent improvements

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -140,6 +140,24 @@ settings.theme_light:
   en: Light
 settings.theme_dark:
   en: Dark
+settings.theme_light_palette:
+  en: Light palette
+settings.theme_light_palette_description:
+  en: The palette used while the app is in light appearance
+settings.theme_dark_palette:
+  en: Dark palette
+settings.theme_dark_palette_description:
+  en: The palette used while the app is in dark appearance
+settings.theme_preview:
+  en: Preview
+settings.theme_preview_title:
+  en: Rename the theme tokens
+settings.theme_preview_body:
+  en: Surfaces, text tiers, accent and diff colors as they appear in a session.
+settings.theme_preview_action:
+  en: Send
+settings.theme_preview_caption:
+  en: waku/src/theme.rs
 
 input.do_anything:
   en: Do anything…

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -159,6 +159,10 @@ settings.theme_preview_action:
 settings.theme_preview_caption:
   en: waku/src/theme.rs
 
+composer.subagent_read_only:
+  en: This agent was launched by the task. You can watch it and stop it, but not message it.
+composer.subagent_read_only_role:
+  en: This %{role} agent was launched by the task. You can watch it and stop it, but not message it.
 input.do_anything:
   en: Do anything…
 input.search_models:
@@ -1038,6 +1042,10 @@ right_panel.browser:
   en: Browser
 right_panel.terminal:
   en: Terminal
+right_panel.agents:
+  en: Agents
+right_panel.agents_description:
+  en: Watch the subagents this task is running
 right_panel.files:
   en: Files
 right_panel.diff:
@@ -1113,6 +1121,16 @@ background.processes:
   en: Background processes
 background.agents:
   en: Subagents
+background.agents_working:
+  en: Working
+background.agents_finished:
+  en: Finished
+background.agents_all_finished:
+  en: All agents finished
+background.no_agents:
+  en: No subagents yet
+background.no_agents_description:
+  en: Agents this task delegates to will appear here while they work.
 background.process:
   en: Process
 background.monitor:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -72,6 +72,15 @@ settings.theme_description: システム、ライト、ダークのいずれか�
 settings.theme_system: システム
 settings.theme_light: ライト
 settings.theme_dark: ダーク
+settings.theme_light_palette: ライトパレット
+settings.theme_light_palette_description: ライト外観のときに使用するパレット
+settings.theme_dark_palette: ダークパレット
+settings.theme_dark_palette_description: ダーク外観のときに使用するパレット
+settings.theme_preview: プレビュー
+settings.theme_preview_title: テーマトークンの名前を変更
+settings.theme_preview_body: セッションでの背景、文字階層、アクセント、差分の色。
+settings.theme_preview_action: 送信
+settings.theme_preview_caption: waku/src/theme.rs
 
 input.do_anything: 何でも依頼できます…
 input.search_models: モデルを検索…

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -68,6 +68,15 @@ settings.theme_description: 选择跟随系统、浅色或深色主题
 settings.theme_system: 跟随系统
 settings.theme_light: 浅色
 settings.theme_dark: 深色
+settings.theme_light_palette: 浅色调色板
+settings.theme_light_palette_description: 应用处于浅色外观时使用的调色板
+settings.theme_dark_palette: 深色调色板
+settings.theme_dark_palette_description: 应用处于深色外观时使用的调色板
+settings.theme_preview: 预览
+settings.theme_preview_title: 重命名主题令牌
+settings.theme_preview_body: 会话中的背景、文字层级、强调色与差异颜色。
+settings.theme_preview_action: 发送
+settings.theme_preview_caption: waku/src/theme.rs
 input.do_anything: 做什么都可以…
 input.search_models: 搜索模型…
 input.search_branches: 搜索分支

--- a/src/app.rs
+++ b/src/app.rs
@@ -472,6 +472,9 @@ enum RightPanelSurface {
         key: BackgroundWorkKey,
         title: String,
     },
+    /// The session's subagent roster. `BackgroundWork` is one agent's detail;
+    /// this is the list that says what is running at all.
+    Agents,
     Files,
     Diff,
     File(String),

--- a/src/app.rs
+++ b/src/app.rs
@@ -57,7 +57,7 @@ use crate::persistence::{
 use crate::query::{Query, QueryCache};
 use crate::review_diff::{Snapshot as ReviewDiffSnapshot, Source as ReviewDiffSource};
 use crate::terminal::TerminalView;
-use crate::theme::{Theme, ThemePreference};
+use crate::theme::{Theme, ThemeId, ThemePreference};
 use crate::ui::text_field::TextField;
 use crate::ui::{
     MenuChip, ProjectNameSelector, activity_icon, activity_noun, file_icon, icon, icon_button,
@@ -1623,7 +1623,13 @@ impl Waku {
         );
         state.sidebar_width = sidebar_width;
         state.right_panel_width = right_panel_width;
-        crate::theme::apply_theme_preference(state.theme, window, cx);
+        crate::theme::apply_theme_preference(
+            state.theme,
+            state.light_theme,
+            state.dark_theme,
+            window,
+            cx,
+        );
         crate::platform::set_sidebar_material_width(window, sidebar_width);
         let project_paths = state
             .projects
@@ -1815,7 +1821,13 @@ impl Waku {
 
             cx.observe_window_appearance(window, |this: &mut Self, window, cx| {
                 if this.state.theme == ThemePreference::System {
-                    crate::theme::apply_theme_preference(this.state.theme, window, cx);
+                    crate::theme::apply_theme_preference(
+                        this.state.theme,
+                        this.state.light_theme,
+                        this.state.dark_theme,
+                        window,
+                        cx,
+                    );
                     cx.notify();
                 }
             })

--- a/src/app/background_work.rs
+++ b/src/app/background_work.rs
@@ -33,6 +33,72 @@ impl Default for BackgroundOutputViewport {
     }
 }
 
+/// One subagent as the roster needs it: everything a row draws, and nothing
+/// that would keep a whole output buffer alive per frame.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct SubagentEntry {
+    pub(super) key: BackgroundWorkKey,
+    pub(super) title: SharedString,
+    pub(super) role: Option<SharedString>,
+    pub(super) model: Option<SharedString>,
+    pub(super) detail: Option<SharedString>,
+    pub(super) status: BackgroundWorkStatus,
+    pub(super) started_at_ms: u64,
+    pub(super) updated_at_ms: u64,
+    pub(super) duration_ms: Option<u64>,
+    pub(super) can_stop: bool,
+}
+
+impl SubagentEntry {
+    fn from_item(item: &BackgroundWorkItem) -> Self {
+        Self {
+            key: item.key.clone(),
+            title: SharedString::from(if item.title.trim().is_empty() {
+                tr!("background.subagent")
+            } else {
+                item.title.clone()
+            }),
+            role: item
+                .role
+                .as_deref()
+                .map(str::trim)
+                .filter(|role| !role.is_empty())
+                .map(SharedString::from),
+            model: item
+                .model
+                .as_deref()
+                .map(short_model_label)
+                .filter(|model| !model.is_empty())
+                .map(SharedString::from),
+            detail: item
+                .detail
+                .as_deref()
+                .map(str::trim)
+                .filter(|detail| !detail.is_empty())
+                .map(SharedString::from),
+            status: item.status,
+            started_at_ms: item.started_at_ms,
+            updated_at_ms: item.updated_at_ms,
+            duration_ms: item.duration_ms,
+            can_stop: item.can_stop && item.status.is_stoppable(),
+        }
+    }
+
+    /// The same clock the Background surface shows, so a subagent reads the
+    /// same in both places.
+    pub(super) fn elapsed(&self) -> String {
+        let duration_ms = self.duration_ms.unwrap_or_else(|| {
+            let end = if self.status.is_live() {
+                unix_time_millis()
+            } else {
+                self.updated_at_ms
+            };
+            end.saturating_sub(self.started_at_ms)
+        });
+        format_work_duration(duration_ms)
+    }
+}
+
 #[derive(Clone)]
 struct BackgroundSummaryEntry {
     item: BackgroundWorkItem,
@@ -292,6 +358,27 @@ impl BackgroundWorkRegistry {
             })
     }
 
+    /// Every subagent, live first, for the roster. Live work holds the order
+    /// it started in so a working fleet never reshuffles as siblings settle.
+    fn all_subagents(&self) -> Vec<SubagentEntry> {
+        let mut live = Vec::new();
+        let mut settled = Vec::new();
+        for item in self
+            .order
+            .iter()
+            .filter_map(|key| self.items.get(key))
+            .filter(|item| item.key.kind == BackgroundWorkKind::Subagent)
+        {
+            if item.status.is_live() {
+                live.push(SubagentEntry::from_item(item));
+            } else {
+                settled.push(SubagentEntry::from_item(item));
+            }
+        }
+        live.extend(settled);
+        live
+    }
+
     fn ordered_items(&self) -> Vec<&BackgroundWorkItem> {
         self.order
             .iter()
@@ -475,6 +562,28 @@ fn work_elapsed(item: &BackgroundWorkItem) -> String {
         };
         end.saturating_sub(item.started_at_ms)
     });
+    format_work_duration(duration_ms)
+}
+
+/// Providers report models at wildly different verbosity — `claude-opus-4-8`,
+/// `anthropic/claude-sonnet-5`, `gpt-5.6`. A roster row has space for the part
+/// that distinguishes them, not the vendor prefix or the datestamp.
+fn short_model_label(model: &str) -> String {
+    let leaf = model.rsplit('/').next().unwrap_or(model).trim();
+    let leaf = leaf.strip_prefix("claude-").unwrap_or(leaf);
+    let mut parts = leaf.rsplitn(2, '-');
+    match (parts.next(), parts.next()) {
+        // Drop a trailing release datestamp such as `-20250514`.
+        (Some(tail), Some(head))
+            if tail.len() == 8 && tail.chars().all(|character| character.is_ascii_digit()) =>
+        {
+            head.to_owned()
+        }
+        _ => leaf.to_owned(),
+    }
+}
+
+fn format_work_duration(duration_ms: u64) -> String {
     let seconds = duration_ms / 1_000;
     if seconds < 60 {
         format!("{seconds}s")
@@ -534,11 +643,59 @@ impl Waku {
         self.handle_background_work_event(session_id, BackgroundWorkEvent::Upsert(item));
     }
 
+    /// Close a subagent's conversation when the agent itself settles.
+    ///
+    /// A child session is opened Working and nothing in the child's own event
+    /// stream ever ends its turn — the provider reports completion against the
+    /// parent, not the child. Without this the agent spins forever in the
+    /// roster and the transcript keeps a live turn open on a finished agent.
+    fn settle_subagent_session(&mut self, parent_id: Uuid, provider_id: &str, failed: bool) {
+        let Some(child_id) = self
+            .state
+            .sessions
+            .iter()
+            .find(|session| {
+                session.subagent.as_ref().is_some_and(|origin| {
+                    origin.parent_session_id == parent_id && origin.provider_id == provider_id
+                })
+            })
+            .map(|session| session.id)
+        else {
+            return;
+        };
+        self.finish_streaming_assistant(child_id);
+        self.complete_turn_blocks(child_id);
+        if let Some(session) = self.state.session_mut(child_id) {
+            session.finish_active_turn(if failed {
+                TurnStatus::Failed
+            } else {
+                TurnStatus::Completed
+            });
+            session.status = if failed {
+                SessionStatus::Failed
+            } else {
+                SessionStatus::Idle
+            };
+        }
+    }
+
     pub(super) fn handle_background_work_event(
         &mut self,
         session_id: Uuid,
         event: BackgroundWorkEvent,
     ) {
+        // A settled subagent must also close its conversation.
+        if let BackgroundWorkEvent::Upsert(item) = &event
+            && item.key.kind == BackgroundWorkKind::Subagent
+            && !item.status.is_live()
+        {
+            let provider_id = item.key.provider_id.clone();
+            let failed = matches!(
+                item.status,
+                BackgroundWorkStatus::Failed | BackgroundWorkStatus::Lost
+            );
+            self.settle_subagent_session(session_id, &provider_id, failed);
+        }
         self.background_work
             .entry(session_id)
             .or_default()
@@ -615,8 +772,14 @@ impl Waku {
             }
         }
 
+        // The Agents roster and the header summary both show elapsed clocks
+        // for work in any session, not only the selected one, so any live
+        // work has to keep the tick going.
         if self.last_background_work_tick.elapsed() >= BACKGROUND_WORK_TICK_INTERVAL
-            && selected.is_some_and(|session_id| self.session_has_live_background_work(session_id))
+            && self
+                .background_work
+                .values()
+                .any(BackgroundWorkRegistry::has_live)
         {
             self.last_background_work_tick = Instant::now();
             cx.notify();
@@ -653,6 +816,35 @@ impl Waku {
         );
         driver.stop_background_work(key, control_id);
         cx.notify();
+    }
+
+    /// Open a subagent as a conversation.
+    ///
+    /// A subagent that has said anything has a real session behind it, so this
+    /// selects that session and the ordinary transcript renders it — the whole
+    /// point of modelling subagents as sessions rather than as log panes. An
+    /// agent that has produced nothing yet has no session, and falls back to
+    /// its background-work card.
+    pub(super) fn open_subagent(
+        &mut self,
+        parent_id: Uuid,
+        key: BackgroundWorkKey,
+        cx: &mut Context<Self>,
+    ) {
+        let child = self
+            .state
+            .sessions
+            .iter()
+            .find(|session| {
+                session.subagent.as_ref().is_some_and(|origin| {
+                    origin.parent_session_id == parent_id && origin.provider_id == key.provider_id
+                })
+            })
+            .map(|session| session.id);
+        match child {
+            Some(child) => self.select_session(child, cx),
+            None => self.open_background_work_surface(parent_id, key, cx),
+        }
     }
 
     pub(super) fn open_background_work_surface(
@@ -841,6 +1033,405 @@ impl Waku {
             .children(git_status)
             .child(info)
             .into_any_element()
+    }
+
+    /// The session's subagent roster.
+    ///
+    /// Deliberately a list and not a tree: nesting answers "who spawned this",
+    /// which the transcript already shows, while the question this surface
+    /// exists for is "what is running right now". Live agents sort first and
+    /// hold their start order so a working fleet never reshuffles; finished
+    /// ones fall below in the order they landed.
+    pub(super) fn render_right_panel_agents(&self, cx: &mut Context<Self>) -> Stateful<Div> {
+        let theme = Theme::current(cx);
+        let Some(session_id) = self.state.selected_session else {
+            return self.render_agents_empty(&theme);
+        };
+        let subagents = self
+            .background_work
+            .get(&session_id)
+            .map(BackgroundWorkRegistry::all_subagents)
+            .unwrap_or_default();
+        if subagents.is_empty() {
+            return self.render_agents_empty(&theme);
+        }
+
+        let (live, settled): (Vec<_>, Vec<_>) = subagents
+            .into_iter()
+            .partition(|subagent| subagent.status.is_live());
+        let live_count = live.len();
+        let mut list = div()
+            .id("right-panel-agents-scroll")
+            .flex_1()
+            .min_h_0()
+            .overflow_y_scroll()
+            .p(px(10.0))
+            .flex()
+            .flex_col()
+            .gap(px(10.0));
+        for (label, group, working) in [
+            (tr!("background.agents_working"), live, true),
+            (tr!("background.agents_finished"), settled, false),
+        ] {
+            if group.is_empty() {
+                continue;
+            }
+            let mut section = div().w_full().flex().flex_col().gap(px(4.0)).child(
+                div()
+                    .h(px(22.0))
+                    .px(px(4.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(6.0))
+                    .text_size(px(11.0))
+                    .font_weight(FontWeight::MEDIUM)
+                    .child(
+                        div()
+                            .text_color(if working {
+                                theme.text_secondary
+                            } else {
+                                theme.text_tertiary
+                            })
+                            .child(SharedString::from(label)),
+                    )
+                    .child(
+                        // A count badge rather than a bare number: it reads as
+                        // a quantity at a glance and keeps its own width.
+                        div()
+                            .h(px(15.0))
+                            .min_w(px(15.0))
+                            .px(px(4.0))
+                            .rounded_full()
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .bg(if working {
+                                theme.accent.opacity(0.14)
+                            } else {
+                                theme.overlay
+                            })
+                            .text_size(px(10.0))
+                            .font_family(crate::md::render::MONO_FAMILY)
+                            .text_color(if working {
+                                theme.accent
+                            } else {
+                                theme.text_ghost
+                            })
+                            .child(SharedString::from(group.len().to_string())),
+                    )
+                    .child(div().flex_1()),
+            );
+            for subagent in group {
+                section = section.child(self.render_agent_roster_row(session_id, &subagent, cx));
+            }
+            list = list.child(section);
+        }
+
+        div()
+            .id("right-panel-agents")
+            .tab_group()
+            .flex_1()
+            .min_h_0()
+            .flex()
+            .flex_col()
+            .child(
+                // A standing answer to "what is running", so the question does
+                // not require reading the list.
+                div()
+                    .flex_none()
+                    .h(px(30.0))
+                    .px(px(12.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(6.0))
+                    .border_b_1()
+                    .border_color(theme.border)
+                    .text_size(px(11.0))
+                    .when(live_count > 0, |header| {
+                        header
+                            .child(
+                                icon("icons/loader-circle.svg", 10.0, theme.accent).with_animation(
+                                    SharedString::from("agents-header-spinner"),
+                                    Animation::new(Duration::from_millis(900))
+                                        .repeat()
+                                        .with_easing(gpui::linear),
+                                    |icon, delta| {
+                                        icon.with_transformation(gpui::Transformation::rotate(
+                                            gpui::percentage(delta),
+                                        ))
+                                    },
+                                ),
+                            )
+                            .child(
+                                div()
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .text_color(theme.accent)
+                                    .child(SharedString::from(if live_count == 1 {
+                                        tr!("background.agent_count_one")
+                                    } else {
+                                        tr!("background.agent_count", count = live_count)
+                                    })),
+                            )
+                    })
+                    .when(live_count == 0, |header| {
+                        header.child(
+                            div()
+                                .text_color(theme.text_tertiary)
+                                .child(tr!("background.agents_all_finished")),
+                        )
+                    })
+                    .child(div().flex_1()),
+            )
+            .child(list)
+    }
+
+    fn render_agents_empty(&self, theme: &Theme) -> Stateful<Div> {
+        div()
+            .id("right-panel-agents")
+            .tab_group()
+            .flex_1()
+            .min_h_0()
+            .flex()
+            .items_center()
+            .justify_center()
+            .px(px(24.0))
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .items_center()
+                    .gap(px(7.0))
+                    .child(icon("icons/bot.svg", 22.0, theme.text_ghost))
+                    .child(
+                        div()
+                            .text_size(px(12.0))
+                            .font_weight(FontWeight::MEDIUM)
+                            .text_color(theme.text_secondary)
+                            .child(tr!("background.no_agents")),
+                    )
+                    .child(
+                        div()
+                            .max_w(px(240.0))
+                            .text_center()
+                            .text_size(px(11.0))
+                            .line_height(px(16.0))
+                            .text_color(theme.text_ghost)
+                            .child(tr!("background.no_agents_description")),
+                    ),
+            )
+    }
+
+    /// One agent in the roster.
+    ///
+    /// Three reserved lines at a fixed height — identity, activity, metrics —
+    /// so a changing activity line or a ticking clock never reflows the list
+    /// under the pointer. Live work is marked by an accent rail and a filled
+    /// dot; every settled state has its own glyph shape, so nothing here is
+    /// carried by color alone.
+    fn render_agent_roster_row(
+        &self,
+        session_id: Uuid,
+        subagent: &SubagentEntry,
+        cx: &mut Context<Self>,
+    ) -> Stateful<Div> {
+        let theme = Theme::current(cx);
+        let live = subagent.status.is_live();
+        let color = work_status_color(subagent.status, theme);
+        let row_id = SharedString::from(format!("agent-row-{}", subagent.key.provider_id));
+        let open_key = subagent.key.clone();
+        let keyboard_key = subagent.key.clone();
+        let stop_key = subagent.key.clone();
+
+        // Live agents say what they are doing; settled ones say how they
+        // ended, in words as well as in color.
+        let activity = subagent
+            .detail
+            .clone()
+            .unwrap_or_else(|| SharedString::from(work_status_label(subagent.status)));
+        let metrics = [subagent.model.clone()]
+            .into_iter()
+            .flatten()
+            .map(|part| part.to_string())
+            .collect::<Vec<_>>()
+            .join(" · ");
+
+        let stop = (live && subagent.can_stop).then(|| {
+            div()
+                .id(SharedString::from(format!("{row_id}-stop")))
+                .track_focus(&self.transcript_control_focus(format!("{row_id}-stop"), cx))
+                .tab_index(0)
+                .size(px(20.0))
+                .rounded(px(5.0))
+                .flex()
+                .items_center()
+                .justify_center()
+                .cursor_default()
+                .invisible()
+                .group_hover(row_id.clone(), |style| style.visible())
+                .focus_visible(|style| style.visible().border_1().border_color(theme.accent))
+                .hover(|style| style.bg(theme.danger.opacity(0.14)))
+                .tooltip(Tooltip::text(tr_cow!("background.stop")))
+                .child(icon("icons/stop-filled.svg", 9.0, theme.danger))
+                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                .on_click(cx.listener({
+                    let stop_key = stop_key.clone();
+                    move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        this.stop_background_work(session_id, stop_key.clone(), cx);
+                    }
+                }))
+                .on_key_down(cx.listener(move |this, event: &KeyDownEvent, _, cx| {
+                    if matches!(event.keystroke.key.as_str(), "enter" | "space") {
+                        this.stop_background_work(session_id, stop_key.clone(), cx);
+                        cx.stop_propagation();
+                    }
+                }))
+        });
+
+        div()
+            .id(row_id.clone())
+            .group(row_id.clone())
+            .track_focus(&self.transcript_control_focus(row_id.to_string(), cx))
+            .tab_index(0)
+            .w_full()
+            .h(px(62.0))
+            .rounded(px(8.0))
+            .overflow_hidden()
+            .flex()
+            .cursor_default()
+            .bg(if live {
+                theme.accent.opacity(0.05)
+            } else {
+                theme.surface
+            })
+            .border_1()
+            .border_color(if live {
+                theme.accent.opacity(0.22)
+            } else {
+                theme.border
+            })
+            .focus_visible(|style| style.border_color(theme.accent))
+            .hover(|style| {
+                style.bg(if live {
+                    theme.accent.opacity(0.09)
+                } else {
+                    theme.overlay
+                })
+            })
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .px(px(10.0))
+                    .py(px(7.0))
+                    .flex()
+                    .flex_col()
+                    .gap(px(1.0))
+                    // Identity.
+                    .child(
+                        div()
+                            .h(px(17.0))
+                            .flex()
+                            .items_center()
+                            .gap(px(6.0))
+                            .child(rendered_work_status_icon(
+                                subagent.status,
+                                11.0,
+                                color,
+                                format!("{row_id}-status"),
+                            ))
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .truncate()
+                                    .text_size(px(12.5))
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .text_color(if live {
+                                        theme.text
+                                    } else {
+                                        theme.text_secondary
+                                    })
+                                    .child(subagent.title.clone()),
+                            )
+                            .child(
+                                div()
+                                    .flex_none()
+                                    .text_size(px(10.5))
+                                    .font_family(crate::md::render::MONO_FAMILY)
+                                    .text_color(if live {
+                                        theme.text_tertiary
+                                    } else {
+                                        theme.text_ghost
+                                    })
+                                    .child(SharedString::from(subagent.elapsed())),
+                            )
+                            // Reserved whether or not the button is showing, so
+                            // hovering a row never shifts its clock.
+                            .child(
+                                div()
+                                    .size(px(20.0))
+                                    .flex_none()
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .children(stop),
+                            ),
+                    )
+                    // Activity.
+                    .child(
+                        div().h(px(15.0)).pl(px(17.0)).flex().items_center().child(
+                            div()
+                                .w_full()
+                                .truncate()
+                                .text_size(px(11.0))
+                                .text_color(if live { color } else { theme.text_tertiary })
+                                .child(activity),
+                        ),
+                    )
+                    // Metrics: the role as a chip, then whatever else is known.
+                    .child(
+                        div()
+                            .h(px(15.0))
+                            .pl(px(17.0))
+                            .flex()
+                            .items_center()
+                            .gap(px(5.0))
+                            .children(subagent.role.clone().map(|role| {
+                                div()
+                                    .flex_none()
+                                    .h(px(14.0))
+                                    .px(px(5.0))
+                                    .rounded(px(4.0))
+                                    .flex()
+                                    .items_center()
+                                    .bg(theme.overlay)
+                                    .text_size(px(9.5))
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .text_color(theme.text_tertiary)
+                                    .child(role)
+                            }))
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .truncate()
+                                    .text_size(px(10.0))
+                                    .font_family(crate::md::render::MONO_FAMILY)
+                                    .text_color(theme.text_ghost)
+                                    .child(SharedString::from(metrics)),
+                            ),
+                    ),
+            )
+            .on_click(cx.listener(move |this, _, _, cx| {
+                this.open_subagent(session_id, open_key.clone(), cx);
+            }))
+            .on_key_down(cx.listener(move |this, event: &KeyDownEvent, _, cx| {
+                if matches!(event.keystroke.key.as_str(), "enter" | "space") {
+                    this.open_subagent(session_id, keyboard_key.clone(), cx);
+                    cx.stop_propagation();
+                }
+            }))
     }
 
     pub(super) fn render_background_work_surface(
@@ -1597,6 +2188,65 @@ mod tests {
         );
         item.background = background;
         item
+    }
+
+    fn subagent(id: &str, status: BackgroundWorkStatus) -> BackgroundWorkItem {
+        BackgroundWorkItem::new(
+            BackgroundWorkKind::Subagent,
+            id,
+            format!("agent {id}"),
+            status,
+        )
+    }
+
+    #[test]
+    fn the_roster_lists_live_agents_in_start_order_ahead_of_finished_ones() {
+        let mut registry = BackgroundWorkRegistry::default();
+        for id in ["settled-1", "settled-2"] {
+            registry.apply(BackgroundWorkEvent::Upsert(subagent(
+                id,
+                BackgroundWorkStatus::Completed,
+            )));
+        }
+        for id in ["live-1", "live-2"] {
+            registry.apply(BackgroundWorkEvent::Upsert(subagent(
+                id,
+                BackgroundWorkStatus::Running,
+            )));
+        }
+        // A background process shares the registry but is not a subagent.
+        registry.apply(BackgroundWorkEvent::Upsert(item(
+            "proc",
+            BackgroundWorkStatus::Running,
+            true,
+        )));
+
+        let ids = registry
+            .all_subagents()
+            .into_iter()
+            .map(|subagent| subagent.key.provider_id)
+            .collect::<Vec<_>>();
+        // Live work keeps the order it started in so a running fleet does not
+        // reshuffle under the pointer as siblings settle.
+        assert_eq!(ids, ["live-1", "live-2", "settled-1", "settled-2"]);
+    }
+
+    #[test]
+    fn roster_model_labels_drop_the_vendor_prefix_and_datestamp() {
+        assert_eq!(short_model_label("claude-sonnet-5-20250514"), "sonnet-5");
+        assert_eq!(short_model_label("anthropic/claude-opus-4-8"), "opus-4-8");
+        assert_eq!(short_model_label("gpt-5.6"), "gpt-5.6");
+    }
+
+    #[test]
+    fn a_subagents_elapsed_clock_freezes_when_it_settles() {
+        let mut item = subagent("a", BackgroundWorkStatus::Completed);
+        item.started_at_ms = 1_000;
+        item.updated_at_ms = 66_000;
+        assert_eq!(SubagentEntry::from_item(&item).elapsed(), "1m 05s");
+        // A reported duration wins over the wall clock either way.
+        item.duration_ms = Some(3_000);
+        assert_eq!(SubagentEntry::from_item(&item).elapsed(), "3s");
     }
 
     #[test]

--- a/src/app/command_palette.rs
+++ b/src/app/command_palette.rs
@@ -682,7 +682,7 @@ impl Waku {
         self.state
             .sessions
             .iter()
-            .filter(|session| session.has_started())
+            .filter(|session| session.has_started() && session.is_task())
             .enumerate()
             .map(|(order, session)| {
                 let (project, project_path) = projects

--- a/src/app/composer.rs
+++ b/src/app/composer.rs
@@ -404,7 +404,7 @@ impl Waku {
                                 .w_full()
                                 .rounded(px(11.0))
                                 .overflow_hidden()
-                                .bg(rgb(0x101010))
+                                .bg(theme.inset)
                                 .when_some(screenshot, |element, screenshot| {
                                     element.child(
                                         img(screenshot)
@@ -1905,9 +1905,51 @@ impl Waku {
         )
     }
 
+    /// Stands in for the composer on a subagent conversation, saying plainly
+    /// why there is nothing to type into.
+    fn render_subagent_composer_note(&self, role: Option<String>, theme: &Theme) -> Div {
+        div().flex_none().px(px(20.0)).pb(px(4.0)).child(
+            div()
+                .w_full()
+                .max_w(px(CONTENT_MAX_WIDTH))
+                .mx_auto()
+                .min_h(px(34.0))
+                .px(px(11.0))
+                .py(px(8.0))
+                .rounded(px(10.0))
+                .border_1()
+                .border_color(theme.border)
+                .bg(theme.inset)
+                .flex()
+                .items_center()
+                .gap(px(7.0))
+                .child(icon("icons/bot.svg", 12.0, theme.text_ghost))
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        .text_size(px(11.5))
+                        .line_height(px(16.0))
+                        .text_color(theme.text_tertiary)
+                        .child(SharedString::from(match role {
+                            Some(role) => tr!("composer.subagent_read_only_role", role = role),
+                            None => tr!("composer.subagent_read_only"),
+                        })),
+                ),
+        )
+    }
+
     pub(super) fn render_composer(&self, window: &Window, cx: &mut Context<Self>) -> Div {
         let theme = Theme::current(cx);
         let session = self.selected_session();
+        // A subagent's conversation is watched, not driven. Its model, effort,
+        // mode and persona were all fixed by the parent at spawn, so none of
+        // the composer's controls apply — and on most providers there is no
+        // route to the agent at all. A composer here would look like it works
+        // and silently deliver somewhere else, which is worse than none.
+        if let Some(origin) = session.and_then(|session| session.subagent.as_ref()) {
+            return self.render_subagent_composer_note(origin.role.clone(), &theme);
+        }
         let preparing = session.is_some_and(|session| {
             self.submission_preparations.contains(&session.id)
                 || self.response_fork_preparations.contains_key(&session.id)
@@ -2054,7 +2096,7 @@ impl Waku {
                                             element.child(icon("icons/stop.svg", 18.0, theme.text))
                                         })
                                         .on_click(cx.listener(|this, _, _, cx| {
-                                            this.cancel_turn(cx);
+                                            this.stop_turn_and_resume_queue(cx);
                                         })),
                                 )
                                 .when(steerable && has_draft, |element| {

--- a/src/app/right_panel.rs
+++ b/src/app/right_panel.rs
@@ -717,6 +717,7 @@ impl RightPanelSurface {
                     title.clone()
                 }
             }
+            Self::Agents => tr!("right_panel.agents"),
             Self::Files => tr!("right_panel.files"),
             Self::Diff => tr!("right_panel.diff"),
             Self::File(path) => path.rsplit('/').next().unwrap_or(path).to_owned(),
@@ -728,6 +729,7 @@ impl RightPanelSurface {
             Self::Browser(_) => "icons/globe.svg",
             Self::Terminal(_) => "icons/terminal.svg",
             Self::BackgroundWork { key, .. } => work_kind_icon(key.kind),
+            Self::Agents => "icons/bot.svg",
             Self::Files => "icons/folder.svg",
             Self::Diff => "icons/file-diff.svg",
             Self::File(path) => file_icon_for_path(path),
@@ -768,9 +770,10 @@ fn reusable_surface_index(
         RightPanelSurface::BackgroundWork { key, .. } => surfaces.iter().position(|surface| {
             matches!(surface, RightPanelSurface::BackgroundWork { key: candidate, .. } if candidate == key)
         }),
-        RightPanelSurface::Files | RightPanelSurface::Diff | RightPanelSurface::File(_) => {
-            surfaces.iter().position(|surface| surface == requested)
-        }
+        RightPanelSurface::Agents
+        | RightPanelSurface::Files
+        | RightPanelSurface::Diff
+        | RightPanelSurface::File(_) => surfaces.iter().position(|surface| surface == requested),
     }
 }
 
@@ -1861,6 +1864,9 @@ impl Waku {
         }
         let body = match self.active_right_panel_surface().cloned() {
             None => self.render_right_panel_chooser(cx).into_any_element(),
+            Some(RightPanelSurface::Agents) => {
+                self.render_right_panel_agents(cx).into_any_element()
+            }
             Some(RightPanelSurface::BackgroundWork { key, .. }) => self
                 .render_background_work_surface(&key, cx)
                 .into_any_element(),
@@ -2309,7 +2315,14 @@ impl Waku {
                                 tr!("right_panel.diff_description"),
                                 cx,
                             )),
-                    ),
+                    )
+                    .child(div().mt(px(8.0)).w_full().flex().gap(px(8.0)).child(
+                        self.render_right_panel_card(
+                            RightPanelSurface::Agents,
+                            tr!("right_panel.agents_description"),
+                            cx,
+                        ),
+                    )),
             )
     }
 

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -2174,6 +2174,14 @@ impl Waku {
         cx.notify();
     }
 
+    pub(super) fn resume_queue_after_stop(&mut self, session_id: Uuid, cx: &mut Context<Self>) {
+        if self.ending_checkpoint_pending(session_id) {
+            self.defer_queue_drain(session_id);
+        } else {
+            self.drain_queued_message(session_id, cx);
+        }
+    }
+
     /// Start the next queued follow-up as a fresh turn. Only called once a
     /// settled turn has been fully closed, so the session is Idle.
     fn drain_queued_message(&mut self, session_id: Uuid, cx: &mut Context<Self>) {

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -559,7 +559,7 @@ impl Waku {
             return;
         };
         match self.escape_stop_confirmation.press(target, Instant::now()) {
-            EscapeStopPress::Stop => self.cancel_turn(cx),
+            EscapeStopPress::Stop => self.stop_turn_and_resume_queue(cx),
             EscapeStopPress::Arm(arm) => {
                 cx.notify();
                 cx.spawn(async move |this, cx| {
@@ -846,6 +846,31 @@ impl Waku {
             self.reset_session_runtime(session_id);
             self.save();
             cx.notify();
+        }
+    }
+
+    /// Stop the running turn, then start whatever the user queued while it ran.
+    pub(super) fn stop_turn_and_resume_queue(&mut self, cx: &mut Context<Self>) {
+        let session_id = self.state.selected_session;
+        let stoppable = session_id.is_some_and(|session_id| {
+            !self.submission_preparations.contains(&session_id)
+                && self
+                    .state
+                    .sessions
+                    .iter()
+                    .any(|session| session.id == session_id && session.status.is_busy())
+        });
+        self.cancel_turn(cx);
+        let Some(session_id) = session_id.filter(|_| stoppable) else {
+            return;
+        };
+        let has_queued = self
+            .state
+            .sessions
+            .iter()
+            .any(|session| session.id == session_id && !session.queued_messages.is_empty());
+        if has_queued {
+            self.resume_queue_after_stop(session_id, cx);
         }
     }
 

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -648,73 +648,100 @@ impl Waku {
             .w_full()
             .flex()
             .flex_col()
-            .rounded(px(13.0))
-            .overflow_hidden()
-            .bg(theme.raised)
+            .gap(px(15.0))
             .child(
                 div()
                     .w_full()
-                    .min_h(px(60.0))
-                    .px(px(20.0))
-                    .py(px(12.0))
                     .flex()
-                    .items_center()
-                    .gap(px(24.0))
-                    .child(
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .child(
-                                div()
-                                    .text_size(px(13.5))
-                                    .font_weight(FontWeight::MEDIUM)
-                                    .text_color(theme.text)
-                                    .child(tr!("settings.theme")),
-                            )
-                            .child(
-                                div()
-                                    .mt(px(5.0))
-                                    .text_size(px(12.5))
-                                    .line_height(px(18.0))
-                                    .text_color(theme.text_secondary)
-                                    .child(tr!("settings.theme_description")),
-                            ),
-                    )
-                    .child(theme_selector),
+                    .flex_col()
+                    .rounded(px(13.0))
+                    .overflow_hidden()
+                    .bg(theme.raised)
+                    .child(settings_row(
+                        &theme,
+                        tr!("settings.theme"),
+                        tr!("settings.theme_description"),
+                        theme_selector.into_any_element(),
+                    ))
+                    .child(settings_divider(&theme))
+                    .child(settings_row(
+                        &theme,
+                        tr!("settings.theme_light_palette"),
+                        tr!("settings.theme_light_palette_description"),
+                        self.render_palette_selector(false, cx),
+                    ))
+                    .child(settings_divider(&theme))
+                    .child(settings_row(
+                        &theme,
+                        tr!("settings.theme_dark_palette"),
+                        tr!("settings.theme_dark_palette_description"),
+                        self.render_palette_selector(true, cx),
+                    )),
             )
-            .child(div().mx(px(20.0)).h(px(1.0)).bg(theme.border))
+            .child(render_palette_preview(&theme))
             .child(
                 div()
                     .w_full()
-                    .min_h(px(60.0))
-                    .px(px(20.0))
-                    .py(px(12.0))
                     .flex()
-                    .items_center()
-                    .gap(px(24.0))
-                    .child(
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .child(
-                                div()
-                                    .text_size(px(13.5))
-                                    .font_weight(FontWeight::MEDIUM)
-                                    .text_color(theme.text)
-                                    .child(tr!("language.title")),
-                            )
-                            .child(
-                                div()
-                                    .mt(px(5.0))
-                                    .text_size(px(12.5))
-                                    .line_height(px(18.0))
-                                    .text_color(theme.text_secondary)
-                                    .child(tr!("language.description")),
-                            ),
-                    )
-                    .child(language_selector),
+                    .flex_col()
+                    .rounded(px(13.0))
+                    .overflow_hidden()
+                    .bg(theme.raised)
+                    .child(settings_row(
+                        &theme,
+                        tr!("language.title"),
+                        tr!("language.description"),
+                        language_selector.into_any_element(),
+                    )),
             )
             .into_any_element()
+    }
+
+    /// One palette slot. Only ids that register the slot's variant are offered,
+    /// so a dark-only palette never becomes an unresolvable light choice.
+    fn render_palette_selector(&self, is_dark: bool, cx: &mut Context<Self>) -> AnyElement {
+        let selected = if is_dark {
+            self.state.dark_theme
+        } else {
+            self.state.light_theme
+        };
+        let id: SharedString = if is_dark {
+            "dark-palette-selector".into()
+        } else {
+            "light-palette-selector".into()
+        };
+        let menu_id: SharedString = format!("{id}-menu").into();
+        let handle = self.menu_handle(id.clone(), cx);
+        let weak = cx.entity().downgrade();
+
+        dropdown_menu(
+            MenuChip::new(id)
+                .label(selected.label())
+                .outlined()
+                .selected(handle.is_open())
+                .w(px(152.0))
+                .justify_between(),
+            menu_id,
+            &handle,
+            MenuAlign::BelowRight,
+            move |_| {
+                ThemeId::all_for(is_dark)
+                    .into_iter()
+                    .map(|id| {
+                        let weak = weak.clone();
+                        MenuItem::custom(move |_, cx| {
+                            palette_menu_row(id, is_dark, id == selected, cx)
+                        })
+                        .on_click(move |window, cx| {
+                            let _ = weak.update(cx, |this, cx| {
+                                this.set_palette(id, is_dark, window, cx);
+                            });
+                        })
+                    })
+                    .collect()
+            },
+        )
+        .into_any_element()
     }
 
     fn render_providers_settings(&self, cx: &mut Context<Self>) -> AnyElement {
@@ -1569,9 +1596,43 @@ impl Waku {
             return;
         }
         self.state.theme = preference;
-        crate::theme::apply_theme_preference(preference, window, cx);
+        self.reapply_theme(window, cx);
         self.save();
         cx.notify();
+    }
+
+    /// Assign a palette to one slot. The other slot is untouched, so a light
+    /// and a dark palette are chosen independently and `System` only decides
+    /// which of the two is live.
+    fn set_palette(
+        &mut self,
+        id: ThemeId,
+        is_dark: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let slot = if is_dark {
+            &mut self.state.dark_theme
+        } else {
+            &mut self.state.light_theme
+        };
+        if *slot == id {
+            return;
+        }
+        *slot = id;
+        self.reapply_theme(window, cx);
+        self.save();
+        cx.notify();
+    }
+
+    fn reapply_theme(&self, window: &mut Window, cx: &mut App) {
+        crate::theme::apply_theme_preference(
+            self.state.theme,
+            self.state.light_theme,
+            self.state.dark_theme,
+            window,
+            cx,
+        );
     }
 
     fn set_language(
@@ -1748,4 +1809,194 @@ mod tests {
             "/opt/homebrew/bin/codex"
         );
     }
+}
+
+/// The shared shape of a settings row: a title, a supporting line, and a
+/// trailing control.
+fn settings_row(
+    theme: &Theme,
+    title: String,
+    description: String,
+    control: AnyElement,
+) -> AnyElement {
+    div()
+        .w_full()
+        .min_h(px(60.0))
+        .px(px(20.0))
+        .py(px(12.0))
+        .flex()
+        .items_center()
+        .gap(px(24.0))
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .child(
+                    div()
+                        .text_size(px(13.5))
+                        .font_weight(FontWeight::MEDIUM)
+                        .text_color(theme.text)
+                        .child(title),
+                )
+                .child(
+                    div()
+                        .mt(px(5.0))
+                        .text_size(px(12.5))
+                        .line_height(px(18.0))
+                        .text_color(theme.text_secondary)
+                        .child(description),
+                ),
+        )
+        .child(control)
+        .into_any_element()
+}
+
+fn settings_divider(theme: &Theme) -> AnyElement {
+    div()
+        .mx(px(20.0))
+        .h(px(1.0))
+        .bg(theme.border)
+        .into_any_element()
+}
+
+/// A palette's identity at a glance: its own canvas, border and accent drawn
+/// in miniature, so the list reads as swatches rather than as a list of words.
+fn palette_swatch(palette: &Theme, size: f32) -> AnyElement {
+    div()
+        .w(px(size))
+        .h(px(size))
+        .rounded(px(size * 0.28))
+        .border_1()
+        .border_color(palette.border_strong)
+        .bg(palette.canvas)
+        .flex()
+        .items_center()
+        .justify_center()
+        .text_size(px(size * 0.44))
+        .line_height(px(size * 0.44))
+        .font_weight(FontWeight::MEDIUM)
+        .text_color(palette.accent)
+        .child("Aa")
+        .into_any_element()
+}
+
+fn palette_menu_row(id: ThemeId, is_dark: bool, selected: bool, cx: &App) -> AnyElement {
+    let theme = Theme::current(cx);
+    let palette = id.resolve(is_dark);
+    div()
+        .flex_1()
+        .min_w_0()
+        .flex()
+        .items_center()
+        .gap(px(8.0))
+        .child(palette_swatch(&palette, 20.0))
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .truncate()
+                .text_color(if selected {
+                    theme.text
+                } else {
+                    theme.text_secondary
+                })
+                .when(selected, |element| element.font_weight(FontWeight::MEDIUM))
+                .child(id.label()),
+        )
+        .when(selected, |element| {
+            element.child(icon("icons/check.svg", 11.0, theme.text_tertiary))
+        })
+        .into_any_element()
+}
+
+/// The active palette applied to the surfaces it actually governs — a raised
+/// panel, the three text tiers, the accent, and a diff pair — so a choice is
+/// judged before it is lived with.
+fn render_palette_preview(theme: &Theme) -> AnyElement {
+    let diff_line = |added: bool, text: &'static str| {
+        let color = if added { theme.success } else { theme.danger };
+        div()
+            .w_full()
+            .px(px(8.0))
+            .py(px(2.0))
+            .rounded(px(4.0))
+            .bg(gpui::Hsla { a: 0.12, ..color })
+            .text_size(px(11.5))
+            .line_height(px(17.0))
+            .text_color(color)
+            .child(text)
+    };
+
+    div()
+        .w_full()
+        .p(px(16.0))
+        .rounded(px(13.0))
+        .bg(theme.raised)
+        .flex()
+        .flex_col()
+        .gap(px(10.0))
+        .child(
+            div()
+                .text_size(px(11.0))
+                .font_weight(FontWeight::MEDIUM)
+                .text_color(theme.text_tertiary)
+                .child(tr!("settings.theme_preview")),
+        )
+        .child(
+            div()
+                .w_full()
+                .p(px(14.0))
+                .rounded(px(10.0))
+                .bg(theme.composer)
+                .border_1()
+                .border_color(theme.border)
+                .flex()
+                .flex_col()
+                .gap(px(8.0))
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap(px(7.0))
+                        .child(div().size(px(7.0)).rounded_full().bg(theme.accent))
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w_0()
+                                .truncate()
+                                .text_size(px(12.5))
+                                .font_weight(FontWeight::MEDIUM)
+                                .text_color(theme.text)
+                                .child(tr!("settings.theme_preview_title")),
+                        )
+                        .child(
+                            div()
+                                .px(px(8.0))
+                                .py(px(2.0))
+                                .rounded(px(5.0))
+                                .bg(theme.inverse)
+                                .text_size(px(10.5))
+                                .line_height(px(15.0))
+                                .font_weight(FontWeight::MEDIUM)
+                                .text_color(theme.on_inverse)
+                                .child(tr!("settings.theme_preview_action")),
+                        ),
+                )
+                .child(
+                    div()
+                        .text_size(px(12.0))
+                        .line_height(px(18.0))
+                        .text_color(theme.text_secondary)
+                        .child(tr!("settings.theme_preview_body")),
+                )
+                .child(diff_line(true, "+  let theme = Theme::current(cx);"))
+                .child(diff_line(false, "-  let theme = Theme::dark();"))
+                .child(
+                    div()
+                        .text_size(px(11.0))
+                        .text_color(theme.text_ghost)
+                        .child(tr!("settings.theme_preview_caption")),
+                ),
+        )
+        .into_any_element()
 }

--- a/src/app/streaming.rs
+++ b/src/app/streaming.rs
@@ -184,6 +184,79 @@ impl Waku {
             })
     }
 
+    /// The conversation for one subagent of `parent_id`, opened on first sight.
+    ///
+    /// A subagent session is a real [`AgentSession`]: same transcript, same
+    /// renderer, same everything, minus a place in the task list. It inherits
+    /// the parent's project and provider because it is literally running
+    /// inside the parent's process.
+    fn resolve_subagent_session(
+        &mut self,
+        parent_id: Uuid,
+        provider_id: &str,
+        launch: Option<crate::model::SubagentLaunchInfo>,
+    ) -> Option<Uuid> {
+        let existing = self
+            .state
+            .sessions
+            .iter()
+            .find(|session| {
+                session.subagent.as_ref().is_some_and(|origin| {
+                    origin.parent_session_id == parent_id && origin.provider_id == provider_id
+                })
+            })
+            .map(|session| (session.id, session.active_turn_id().is_some()));
+        if let Some((child_id, has_active_turn)) = existing {
+            // The agent is talking again after it had settled — Claude's
+            // orchestrator resumes a finished agent with `SendMessage`, and the
+            // resumed run arrives under the same spawning call. Its conversation
+            // needs a turn reopened or the app, which drops output it cannot
+            // attribute to a running turn, would discard the whole second run.
+            if !has_active_turn && let Some(session) = self.state.session_mut(child_id) {
+                session.begin_provider_turn();
+                session.status = SessionStatus::Working;
+            }
+            return Some(child_id);
+        }
+        // Without a launch there is nothing to open a conversation with, and
+        // inventing one from a stray delta would produce an untitled ghost.
+        let launch = launch?;
+        let parent = self
+            .state
+            .sessions
+            .iter()
+            .find(|session| session.id == parent_id)?;
+        let mut child = AgentSession::new(parent.project_id, parent.provider);
+        child.workspace = parent.workspace.clone();
+        child.runtime_mode = parent.runtime_mode;
+        child.interaction_mode = parent.interaction_mode;
+        child.model = launch.model.clone().or_else(|| parent.model.clone());
+        child.subagent = Some(crate::model::SubagentOrigin {
+            parent_session_id: parent_id,
+            provider_id: provider_id.to_owned(),
+            role: launch.role.clone(),
+            can_prompt: launch.can_prompt,
+            prompt_target: launch.prompt_target.clone(),
+        });
+        if !launch.title.trim().is_empty() {
+            child.set_auto_title(Some(launch.title.clone()));
+        }
+        let child_id = child.id;
+        // The prompt the parent handed over opens the transcript, because from
+        // this agent's side that is exactly what its first message was.
+        match launch.prompt.filter(|prompt| !prompt.trim().is_empty()) {
+            Some(prompt) => {
+                child.begin_turn_with_presentation(prompt, None, Vec::new());
+            }
+            None => {
+                child.begin_provider_turn();
+            }
+        }
+        child.status = SessionStatus::Working;
+        self.state.sessions.push(child);
+        Some(child_id)
+    }
+
     pub(super) fn accepts_turn_output(&self, session_id: Uuid) -> bool {
         // The turn begins at submission accept, before its prompt has reached
         // any provider. While preparation is still running, a reused runtime
@@ -221,6 +294,22 @@ impl Waku {
         cx: &mut Context<Self>,
     ) -> bool {
         runtime.last_active_at = Instant::now();
+        if let DriverEvent::Subagent {
+            provider_id,
+            launch,
+            event,
+        } = event
+        {
+            let Some(child_id) = self.resolve_subagent_session(session_id, &provider_id, launch)
+            else {
+                return false;
+            };
+            // The child's events are ordinary session events; they just belong
+            // to a different conversation. Replaying them through this same
+            // function is what makes a subagent render exactly like a task —
+            // one transcript implementation, not two.
+            return self.handle_driver_event(child_id, runtime, *event, false, cx);
+        }
         match event {
             DriverEvent::Connected { provider_cursor } => {
                 runtime.last_driver_error = None;
@@ -268,6 +357,23 @@ impl Waku {
                     && session.active_turn_id().is_some()
                 {
                     session.mark_active_turn_provider_started();
+                    session.status = SessionStatus::Working;
+                }
+            }
+            // Unwrapped above, before this match, so the child's own events
+            // are dispatched against the child's session.
+            DriverEvent::Subagent { .. } => {}
+            DriverEvent::ProviderTurnStarted => {
+                runtime.last_driver_error = None;
+                // A prompt already opened a turn; this only has to cover the
+                // case where the provider resumed on its own after one settled.
+                // Preparation means a submission is mid-flight and owns the
+                // next turn, so never race it with an unprompted one.
+                if !self.submission_preparations.contains(&session_id)
+                    && let Some(session) = self.state.session_mut(session_id)
+                    && session.active_turn_id().is_none()
+                {
+                    session.begin_provider_turn();
                     session.status = SessionStatus::Working;
                 }
             }

--- a/src/app/transcript_view.rs
+++ b/src/app/transcript_view.rs
@@ -421,7 +421,7 @@ impl Render for ConversationNavigationRail {
                     || emphasized_tick_index == Some(tick_index);
                 let tick_color = if prominent {
                     if theme.is_dark {
-                        rgb(0xFFFFFF).into()
+                        theme.inverse
                     } else {
                         theme.text
                     }
@@ -1549,6 +1549,12 @@ impl Waku {
                     self.background_work_for_activity(session_id, source_id)
                         .map(|item| (session_id, item.key.clone(), item.status))
                 });
+            // The call that summons an agent is a doorway to that agent, not a
+            // tool row to unfold: opening the panel is what the click is for.
+            let opens_agent = background_work
+                .as_ref()
+                .filter(|(_, key, _)| key.kind == BackgroundWorkKind::Subagent)
+                .map(|(session_id, key, _)| (*session_id, key.clone()));
             let background_badge = background_work.map(|(session_id, key, status)| {
                 let click_key = key.clone();
                 let focus = self.transcript_control_focus(format!("activity-background-{id}"), cx);
@@ -1684,7 +1690,9 @@ impl Waku {
                         })
                     })
                     .on_click(cx.listener(move |this, _, _, cx| {
-                        if has_detail {
+                        if let Some((session_id, key)) = opens_agent.clone() {
+                            this.open_subagent(session_id, key, cx);
+                        } else if has_detail {
                             this.toggle_activity_item(id, item_expanded, cx);
                         }
                     })),

--- a/src/driver/acp.rs
+++ b/src/driver/acp.rs
@@ -32,8 +32,8 @@ use crate::driver::{
     DriverControl, DriverEventSender, DriverEventSink, DriverStartOptions, SessionOptions,
 };
 use crate::model::{
-    ActivityKind, DriverEvent, InteractionMode, PermissionOption, ProviderKind,
-    ProviderResumeCursor, RuntimeMode,
+    ActivityKind, BackgroundWorkEvent, BackgroundWorkStatus, DriverEvent, InteractionMode,
+    PermissionOption, ProviderKind, ProviderResumeCursor, RuntimeMode,
 };
 
 enum CommandMessage {
@@ -1019,6 +1019,42 @@ fn tool_activity(update: &Value, events: &impl DriverEventSink, state: &mut AcpS
         .get("content")
         .filter(|value| !value.is_null())
         .or_else(|| update.get("rawOutput").filter(|value| !value.is_null()));
+    // ACP has no subagent tool kind, so delegation is recognized two ways: the
+    // `_meta.claudeCode.subagent` marker the official Claude adapter sets, or
+    // the spawning tool's own name for agents that only send the plain call.
+    if let Some(call_id) = id.as_deref() {
+        let marked = update
+            .pointer("/_meta/claudeCode/subagent")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let wire_name = update
+            .pointer("/_meta/claudeCode/toolName")
+            .and_then(Value::as_str)
+            .or(wire_title)
+            .unwrap_or_default();
+        if let Some(launch) = super::support::subagent_launch(wire_name, arguments)
+            .filter(|_| marked || super::support::is_subagent_tool(wire_name))
+        {
+            let work_status = match status {
+                "completed" => BackgroundWorkStatus::Completed,
+                "failed" => BackgroundWorkStatus::Failed,
+                "pending" => BackgroundWorkStatus::Starting,
+                _ => BackgroundWorkStatus::Running,
+            };
+            let mut work = super::support::subagent_item(call_id, &launch, work_status);
+            work.parent_id = update
+                .pointer("/_meta/claudeCode/parentToolUseId")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            if complete {
+                work.output = output.and_then(activity::format_output);
+            }
+            let _ = events.send(DriverEvent::BackgroundWork(BackgroundWorkEvent::Upsert(
+                work,
+            )));
+        }
+    }
+
     let item =
         activity::tool_activity(id, kind, title, arguments, output, output, failed, complete);
     let _ = events.send(DriverEvent::RichActivity(item));

--- a/src/driver/activity.rs
+++ b/src/driver/activity.rs
@@ -97,7 +97,7 @@ pub(super) fn format_json(value: &Value) -> Option<String> {
         .and_then(non_empty_text)
 }
 
-fn format_output(value: &Value) -> Option<String> {
+pub(super) fn format_output(value: &Value) -> Option<String> {
     if let Some(text) = value.as_str() {
         return non_empty_text(text.to_owned());
     }

--- a/src/driver/amp.rs
+++ b/src/driver/amp.rs
@@ -18,7 +18,7 @@
 //! against the real CLI; the attribute is in the manual's Streaming JSON
 //! section.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
@@ -32,10 +32,14 @@ use parking_lot::Mutex;
 use serde_json::{Value, json};
 
 use super::activity;
+use super::support::subagent_item;
 use crate::driver::{
     DriverControl, DriverEventSender, DriverEventSink, DriverStartOptions, SessionOptions,
 };
-use crate::model::{ActivityKind, DriverEvent, InteractionMode, ProviderResumeCursor, RuntimeMode};
+use crate::model::{
+    ActivityKind, BackgroundWorkEvent, BackgroundWorkItem, BackgroundWorkKind,
+    BackgroundWorkStatus, DriverEvent, InteractionMode, ProviderResumeCursor, RuntimeMode,
+};
 
 enum CommandMessage {
     Prompt(String),
@@ -404,6 +408,9 @@ fn write_line(writer: &mut impl Write, value: &Value) -> std::io::Result<()> {
 #[derive(Default)]
 struct AmpStreamState {
     tools: HashMap<String, (ActivityKind, String)>,
+    /// Tool-use ids of calls that launched a subagent, so the matching result
+    /// settles that subagent rather than looking like an ordinary tool return.
+    subagents: HashSet<String>,
     thread_id: Option<String>,
 }
 
@@ -471,6 +478,26 @@ fn handle_message(
                                 activity::input_title(block.get("input")).unwrap_or(wire_title);
                             if let Some(id) = &id {
                                 state.tools.insert(id.clone(), (kind, title.clone()));
+                                // Amp declares `parent_tool_use_id` but always
+                                // sends null, so the spawning call is the only
+                                // handle on a subagent. Surface it as live work
+                                // now; the tool result settles it.
+                                if let Some(launch) = super::support::subagent_launch(
+                                    block
+                                        .get("name")
+                                        .and_then(Value::as_str)
+                                        .unwrap_or_default(),
+                                    block.get("input"),
+                                ) {
+                                    state.subagents.insert(id.clone());
+                                    let _ = events.send(DriverEvent::BackgroundWork(
+                                        BackgroundWorkEvent::Upsert(subagent_item(
+                                            id,
+                                            &launch,
+                                            BackgroundWorkStatus::Running,
+                                        )),
+                                    ));
+                                }
                             }
                             let _ =
                                 events.send(DriverEvent::RichActivity(activity::tool_activity(
@@ -521,6 +548,24 @@ fn handle_message(
                     .and_then(|id| state.tools.remove(id))
                     .unwrap_or((ActivityKind::Tool, "Tool".to_owned()));
                 let failed = block.get("is_error").and_then(Value::as_bool) == Some(true);
+                if let Some(id) = id.as_ref().filter(|id| state.subagents.remove(*id)) {
+                    let mut item = BackgroundWorkItem::new(
+                        BackgroundWorkKind::Subagent,
+                        id.clone(),
+                        String::new(),
+                        if failed {
+                            BackgroundWorkStatus::Failed
+                        } else {
+                            BackgroundWorkStatus::Completed
+                        },
+                    );
+                    // The subagent's report is the tool result; Amp streams
+                    // nothing from inside the child thread.
+                    item.output = block.get("content").and_then(activity::format_output);
+                    let _ = events.send(DriverEvent::BackgroundWork(BackgroundWorkEvent::Upsert(
+                        item,
+                    )));
+                }
                 let _ = events.send(DriverEvent::RichActivity(activity::tool_activity(
                     id,
                     kind,

--- a/src/driver/claude.rs
+++ b/src/driver/claude.rs
@@ -111,6 +111,11 @@ fn configure_stream_command(
         // Echoes each user message back, which is how a queued prompt is
         // distinguished from one the agent has started on.
         "--replay-user-messages",
+        // Without this a subagent forwards only its tool calls: no narrative,
+        // no reasoning, and nothing at all from an agent it spawned in turn.
+        // Verified against 2.1.231 — a subagent transcript is empty prose
+        // without it.
+        "--forward-subagent-text",
         // Undocumented, and the whole reason Supervised can mean supervised:
         // without it the CLI decides permissions itself and only reports
         // denials after the fact.
@@ -493,13 +498,19 @@ struct ClaudeStreamState {
     /// on the main channel with `parent_tool_use_id` set — can be routed into
     /// that task's output pane instead of this session's transcript.
     subagent_tasks: HashMap<String, String>,
+    /// What an `Agent`/`Task` tool call said about the agent it launched, held
+    /// until something proves the agent is synchronous.
+    pending_subagent_launches: HashMap<String, super::support::SubagentLaunch>,
+    /// Subagents this driver published itself, from the tool call, because no
+    /// `task_started` announced them. Their tool result is what settles them.
+    tool_subagents: HashSet<String>,
+    /// Subagents whose conversation has already been opened, so the launch is
+    /// sent exactly once.
+    opened_subagents: HashSet<String>,
     /// The description each task started with. Progress events reuse the
     /// `description` field for the agent's current activity line, which
     /// belongs in the detail row, never the title.
     task_descriptions: HashMap<String, String>,
-    /// Tasks whose output pane already carries streamed transcript; the
-    /// settle notification's summary would only duplicate it.
-    streamed_task_output: HashSet<String>,
     pending_task_stops: Arc<Mutex<HashMap<String, BackgroundWorkKey>>>,
     /// Model of the latest main-thread assistant message, so the settled
     /// turn's `modelUsage` map can be read for that model's context window
@@ -686,7 +697,11 @@ fn claude_task_item(
     // The settle notification's summary is the subagent's final report and
     // belongs in the output pane — unless the live transcript already
     // streamed there.
-    if subtype == "task_notification" && !state.streamed_task_output.contains(&task_id) {
+    // The final report always lands on the agent's card. Its streamed
+    // narration goes to the agent's conversation, which is a different
+    // surface, so carrying both duplicates nothing — and suppressing the
+    // report here left a completed agent showing no output at all.
+    if subtype == "task_notification" {
         item.output = value
             .get("summary")
             .and_then(Value::as_str)
@@ -792,6 +807,11 @@ fn handle_claude_system(
         if subtype == "task_started"
             && let Some(tool_use_id) = item.origin_activity_id.clone()
         {
+            // The agent is backgrounded, so the task events own its
+            // background-work row from here. The launch stays: it is what
+            // opens the agent's conversation when its first message lands,
+            // and dropping it silently discarded every backgrounded agent's
+            // transcript.
             state.subagent_tasks.insert(tool_use_id, task_id.clone());
         }
         // Remember what the task is called: `task_started` names it, and a
@@ -817,74 +837,173 @@ fn handle_claude_system(
 
 /// Renders a subagent message into its task's output pane: narrative text
 /// as-is, tool calls as single `› tool · subject` lines.
+/// Reopen a turn for work the CLI started on its own.
+///
+/// A backgrounded subagent ends its parent's turn the moment it is launched:
+/// Claude sends `result`, and only wakes back up — with a synthetic task
+/// notification — once the subagent reports. Everything after that arrives on
+/// a settled turn, and the app drops output it cannot attribute, so the second
+/// stretch of work has to re-arm the turn it belongs to. Called only for
+/// main-thread messages; a subagent's own stream must never do this.
+fn rearm_provider_turn(turn_active: &Mutex<bool>, events: &impl DriverEventSink) {
+    let mut active = turn_active.lock();
+    if *active {
+        return;
+    }
+    *active = true;
+    drop(active);
+    let _ = events.send(DriverEvent::ProviderTurnStarted);
+}
+
+/// Replay a subagent's message as events against that agent's own
+/// conversation.
+///
+/// The child's blocks are the same shapes the main thread sends, so they are
+/// forwarded as ordinary `TextDelta`/`ReasoningDelta`/`RichActivity` events
+/// wrapped in [`DriverEvent::Subagent`]. That is what lets a subagent render
+/// through the same transcript as a task instead of as a flat log.
 fn forward_subagent_transcript(
     parent_tool_use_id: &str,
     value: &Value,
     events: &impl DriverEventSink,
     state: &mut ClaudeStreamState,
 ) {
-    let Some(task_id) = state.subagent_tasks.get(parent_tool_use_id).cloned() else {
-        return;
-    };
+    // The first message tagged with this call is what proves the agent exists;
+    // the launch it carries opens the conversation.
+    let launch = (!state.opened_subagents.contains(parent_tool_use_id))
+        .then(|| {
+            state
+                .pending_subagent_launches
+                .get(parent_tool_use_id)
+                .map(|launch| crate::model::SubagentLaunchInfo {
+                    title: launch.title.clone(),
+                    role: launch.role.clone(),
+                    model: launch.model.clone(),
+                    prompt: launch.prompt.clone(),
+                    // Verified against the CLI: no inbound control request or
+                    // user-message field addresses an agent, and sidechain
+                    // sessions are explicitly filtered from resume. A client
+                    // can watch a Claude subagent, never talk to it.
+                    can_prompt: false,
+                    prompt_target: None,
+                })
+        })
+        .flatten();
+    if launch.is_some() {
+        state.opened_subagents.insert(parent_tool_use_id.to_owned());
+    }
+
+    // A message tagged with this tool call and no task behind it means the
+    // agent is synchronous: `task_started` would have registered it already.
+    if !state.subagent_tasks.contains_key(parent_tool_use_id)
+        && let Some(pending) = state
+            .pending_subagent_launches
+            .get(parent_tool_use_id)
+            .cloned()
+    {
+        state.tool_subagents.insert(parent_tool_use_id.to_owned());
+        state
+            .subagent_tasks
+            .insert(parent_tool_use_id.to_owned(), parent_tool_use_id.to_owned());
+        let _ = events.send(DriverEvent::BackgroundWork(BackgroundWorkEvent::Upsert(
+            super::support::subagent_item(
+                parent_tool_use_id,
+                &pending,
+                BackgroundWorkStatus::Running,
+            ),
+        )));
+    }
     let Some(content) = value.pointer("/message/content").and_then(Value::as_array) else {
         return;
     };
-    let mut delta = String::new();
+
+    let mut launch = launch;
+    let mut emit = |event: DriverEvent| {
+        let _ = events.send(DriverEvent::Subagent {
+            provider_id: parent_tool_use_id.to_owned(),
+            launch: launch.take(),
+            event: Box::new(event),
+        });
+    };
     for block in content {
         match block.get("type").and_then(Value::as_str) {
             Some("text") => {
                 if let Some(text) = block
                     .get("text")
                     .and_then(Value::as_str)
-                    .map(str::trim)
-                    .filter(|text| !text.is_empty())
+                    .filter(|text| !text.trim().is_empty())
                 {
-                    delta.push_str(text);
-                    delta.push_str("\n\n");
+                    emit(DriverEvent::TextDelta(text.to_owned()));
+                }
+            }
+            Some("thinking") => {
+                if let Some(text) = block
+                    .get("thinking")
+                    .and_then(Value::as_str)
+                    .filter(|text| !text.trim().is_empty())
+                {
+                    emit(DriverEvent::ReasoningDelta(text.to_owned()));
                 }
             }
             Some("tool_use") => {
-                let name = block.get("name").and_then(Value::as_str).unwrap_or("tool");
-                let input = block.get("input");
-                let subject = activity::input_title(input).or_else(|| {
-                    input.and_then(|input| {
-                        [
-                            "command",
-                            "file_path",
-                            "path",
-                            "pattern",
-                            "query",
-                            "url",
-                            "description",
-                        ]
-                        .into_iter()
-                        .find_map(|key| input.get(key).and_then(Value::as_str))
-                        .and_then(one_line)
-                    })
-                });
-                match subject {
-                    Some(subject) => delta.push_str(&format!("› {name} · {subject}\n")),
-                    None => delta.push_str(&format!("› {name}\n")),
-                }
+                let id = block.get("id").and_then(Value::as_str).map(str::to_owned);
+                let wire_title = block
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("tool")
+                    .to_owned();
+                let kind = super::support::classify_tool(&wire_title);
+                let title = activity::input_title(block.get("input")).unwrap_or(wire_title);
+                emit(DriverEvent::RichActivity(activity::tool_activity(
+                    id,
+                    kind,
+                    title,
+                    block.get("input"),
+                    None,
+                    None,
+                    false,
+                    false,
+                )));
             }
             _ => {}
         }
     }
-    if delta.is_empty() {
+}
+
+/// A subagent's tool results arrive on the main channel too. They complete
+/// activities inside that agent's conversation, not this session's.
+fn forward_subagent_tool_result(
+    parent_tool_use_id: &str,
+    value: &Value,
+    events: &impl DriverEventSink,
+) {
+    let Some(content) = value.pointer("/message/content").and_then(Value::as_array) else {
         return;
+    };
+    for block in content
+        .iter()
+        .filter(|block| block.get("type").and_then(Value::as_str) == Some("tool_result"))
+    {
+        let id = block
+            .get("tool_use_id")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        let failed = block.get("is_error").and_then(Value::as_bool) == Some(true);
+        let _ = events.send(DriverEvent::Subagent {
+            provider_id: parent_tool_use_id.to_owned(),
+            launch: None,
+            event: Box::new(DriverEvent::RichActivity(activity::tool_activity(
+                id,
+                ActivityKind::Tool,
+                String::new(),
+                None,
+                block.get("content"),
+                block.get("content"),
+                failed,
+                true,
+            ))),
+        });
     }
-    let kind = state
-        .background_task_kinds
-        .get(&task_id)
-        .copied()
-        .unwrap_or(BackgroundWorkKind::Subagent);
-    state.streamed_task_output.insert(task_id.clone());
-    let _ = events.send(DriverEvent::BackgroundWork(
-        BackgroundWorkEvent::OutputDelta {
-            key: BackgroundWorkKey::new(kind, task_id),
-            delta,
-        },
-    ));
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -980,6 +1099,7 @@ fn handle_message(
             if event.get("type").and_then(Value::as_str) == Some("message_start") {
                 state.saw_text_delta = false;
                 state.saw_reasoning_delta = false;
+                rearm_provider_turn(turn_active, events);
             }
             let delta = event.get("delta").unwrap_or(&Value::Null);
             match delta.get("type").and_then(Value::as_str) {
@@ -1014,6 +1134,7 @@ fn handle_message(
                 forward_subagent_transcript(parent, value, events, state);
                 return;
             }
+            rearm_provider_turn(turn_active, events);
             if let Some(usage) = value.pointer("/message/usage") {
                 if let Some(model) = value.pointer("/message/model").and_then(Value::as_str) {
                     state.last_assistant_model = Some(model.to_owned());
@@ -1084,6 +1205,18 @@ fn handle_message(
                                 id.clone(),
                                 (kind, title.clone(), wire_title.clone(), command),
                             );
+                            // Only a backgrounded agent gets `task_started`; a
+                            // synchronous one is announced by this tool call
+                            // alone. Hold what the call said about it, but do
+                            // not publish yet — publishing here would race
+                            // `task_started` and put two rows in the sidebar
+                            // for one agent. The first message that arrives
+                            // tagged with this id decides.
+                            if let Some(launch) =
+                                super::support::subagent_launch(&wire_title, block.get("input"))
+                            {
+                                state.pending_subagent_launches.insert(id.clone(), launch);
+                            }
                         }
                         let _ = events.send(DriverEvent::RichActivity(activity::tool_activity(
                             id,
@@ -1101,13 +1234,10 @@ fn handle_message(
             }
         }
         Some("user") => {
-            // A subagent's tool results echo on the main channel too; its
-            // transcript lives in the task's output pane, not here.
-            if value
-                .get("parent_tool_use_id")
-                .and_then(Value::as_str)
-                .is_some()
-            {
+            // A subagent's tool results echo on the main channel too. They
+            // complete activities in that agent's conversation, not this one.
+            if let Some(parent) = value.get("parent_tool_use_id").and_then(Value::as_str) {
+                forward_subagent_tool_result(parent, value, events);
                 return;
             }
             // `--replay-user-messages` echoes Waku's own prompts back; they are
@@ -1136,6 +1266,29 @@ fn handle_message(
                         None,
                     ));
                 let failed = block.get("is_error").and_then(Value::as_bool) == Some(true);
+                if let Some(id) = id.as_ref() {
+                    state.pending_subagent_launches.remove(id);
+                }
+                // Settle a synchronous subagent this driver published from its
+                // own tool call. A backgrounded one keeps running past this
+                // result and is settled by `task_notification` instead.
+                if let Some(id) = id.as_ref().filter(|id| state.tool_subagents.remove(*id)) {
+                    let mut work = BackgroundWorkItem::new(
+                        BackgroundWorkKind::Subagent,
+                        id.clone(),
+                        String::new(),
+                        if failed {
+                            BackgroundWorkStatus::Failed
+                        } else {
+                            BackgroundWorkStatus::Completed
+                        },
+                    );
+                    work.output = block.get("content").and_then(activity::format_output);
+                    let _ = events.send(DriverEvent::BackgroundWork(BackgroundWorkEvent::Upsert(
+                        work,
+                    )));
+                    state.subagent_tasks.remove(id);
+                }
                 let _ = events.send(DriverEvent::RichActivity(activity::tool_activity(
                     id,
                     kind,
@@ -1634,6 +1787,261 @@ mod tests {
         assert_eq!(completed.status, BackgroundWorkStatus::Completed);
     }
 
+    /// A backgrounded agent is announced by `task_started`, which owns its
+    /// background-work row. The launch must survive that: it is what opens the
+    /// agent's conversation when its first message lands, and discarding it
+    /// silently threw away every backgrounded agent's whole transcript.
+    #[test]
+    fn a_backgrounded_agent_still_opens_a_conversation() {
+        let (events, event_rx, commands, _command_rx, turn, mut state) = harness();
+        handle_message(
+            &json!({
+                "type": "assistant",
+                "message": {"content": [{
+                    "type": "tool_use",
+                    "id": "toolu-agent",
+                    "name": "Agent",
+                    "input": {
+                        "description": "Test agent B",
+                        "subagent_type": "Explore",
+                        "prompt": "List the entries",
+                        "run_in_background": true
+                    }
+                }]}
+            }),
+            "s",
+            &events,
+            &commands,
+            &turn,
+            true,
+            &mut state,
+        );
+        handle_message(
+            &json!({
+                "type": "system",
+                "subtype": "task_started",
+                "task_id": "agent-42",
+                "tool_use_id": "toolu-agent",
+                "subagent_type": "Explore",
+                "is_backgrounded": true,
+                "description": "Test agent B"
+            }),
+            "s",
+            &events,
+            &commands,
+            &turn,
+            true,
+            &mut state,
+        );
+        let _ = event_rx.try_iter().count();
+
+        handle_message(
+            &json!({
+                "type": "assistant",
+                "parent_tool_use_id": "toolu-agent",
+                "message": {"content": [{"type": "text", "text": "AGENT-B OK"}]}
+            }),
+            "s",
+            &events,
+            &commands,
+            &turn,
+            true,
+            &mut state,
+        );
+        let DriverEvent::Subagent {
+            provider_id,
+            launch,
+            event,
+        } = event_rx.try_recv().unwrap()
+        else {
+            panic!("a backgrounded agent's message must reach its conversation");
+        };
+        assert_eq!(provider_id, "toolu-agent");
+        let launch = launch.expect("the launch opens the conversation");
+        assert_eq!(launch.title, "Test agent B");
+        assert_eq!(launch.role.as_deref(), Some("Explore"));
+        assert!(matches!(*event, DriverEvent::TextDelta(_)));
+    }
+
+    /// A backgrounded subagent ends its parent's turn the moment it launches,
+    /// then Claude wakes itself when the subagent reports back. That second
+    /// stretch of work has to reopen a turn, or the app — which drops output it
+    /// cannot attribute to a running turn — shows the agent as simply stopped.
+    #[test]
+    fn a_provider_wake_up_after_a_background_agent_reopens_the_turn() {
+        let (events, event_rx, commands, _command_rx, turn, mut state) = harness();
+        *turn.lock() = true;
+
+        handle_message(
+            &json!({"type": "result", "is_error": false}),
+            "s",
+            &events,
+            &commands,
+            &turn,
+            true,
+            &mut state,
+        );
+        assert!(
+            event_rx
+                .try_iter()
+                .any(|event| matches!(event, DriverEvent::TurnFinished { .. }))
+        );
+        assert!(!*turn.lock());
+
+        // The subagent reports; Claude resumes with no prompt behind it.
+        handle_message(
+            &json!({
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "The agent found it."}]}
+            }),
+            "s",
+            &events,
+            &commands,
+            &turn,
+            true,
+            &mut state,
+        );
+        assert!(matches!(
+            event_rx.try_recv().unwrap(),
+            DriverEvent::ProviderTurnStarted
+        ));
+        assert!(*turn.lock(), "the resumed turn must be armed");
+
+        // A subagent's own message must never reopen the main turn.
+        *turn.lock() = false;
+        handle_message(
+            &json!({
+                "type": "assistant",
+                "parent_tool_use_id": "toolu-agent",
+                "message": {"content": [{"type": "text", "text": "child chatter"}]}
+            }),
+            "s",
+            &events,
+            &commands,
+            &turn,
+            true,
+            &mut state,
+        );
+        assert!(!*turn.lock());
+
+        // And the reopened turn settles on its own result.
+        *turn.lock() = true;
+        let _ = event_rx.try_iter().count();
+        handle_message(
+            &json!({"type": "result", "is_error": false}),
+            "s",
+            &events,
+            &commands,
+            &turn,
+            true,
+            &mut state,
+        );
+        assert!(
+            event_rx
+                .try_iter()
+                .any(|event| matches!(event, DriverEvent::TurnFinished { .. }))
+        );
+    }
+
+    /// Claude only announces a *backgrounded* agent with `task_started`. A
+    /// synchronous one exists solely as a tool call plus messages tagged with
+    /// its id, so the driver has to publish that agent itself — and must not
+    /// publish a second row for the backgrounded case, which the test above
+    /// pins.
+    #[test]
+    fn a_synchronous_agent_reaches_the_sidebar_without_a_task_event() {
+        let (events, event_rx, commands, _command_rx, turn, mut state) = harness();
+        handle_message(
+            &json!({
+                "type": "assistant",
+                "message": {"content": [{
+                    "type": "tool_use",
+                    "id": "toolu-agent",
+                    "name": "Agent",
+                    "input": {
+                        "description": "Inspect the parser",
+                        "subagent_type": "Explore",
+                        "prompt": "Read every parser test"
+                    }
+                }]}
+            }),
+            "s",
+            &events,
+            &commands,
+            &turn,
+            true,
+            &mut state,
+        );
+        // The tool call alone publishes nothing: it cannot yet tell a
+        // synchronous agent from one about to be backgrounded.
+        assert!(matches!(
+            event_rx.try_recv().unwrap(),
+            DriverEvent::RichActivity(_)
+        ));
+        assert!(event_rx.try_recv().is_err());
+
+        handle_message(
+            &json!({
+                "type": "assistant",
+                "parent_tool_use_id": "toolu-agent",
+                "message": {"content": [{"type": "text", "text": "Reading the lexer."}]}
+            }),
+            "s",
+            &events,
+            &commands,
+            &turn,
+            true,
+            &mut state,
+        );
+        let DriverEvent::BackgroundWork(BackgroundWorkEvent::Upsert(started)) =
+            event_rx.try_recv().unwrap()
+        else {
+            panic!("a subagent message should publish the agent");
+        };
+        assert_eq!(started.key.kind, BackgroundWorkKind::Subagent);
+        assert_eq!(started.key.provider_id, "toolu-agent");
+        assert_eq!(started.title, "Inspect the parser");
+        assert_eq!(started.role.as_deref(), Some("Explore"));
+        assert_eq!(started.status, BackgroundWorkStatus::Running);
+        // Its narration is addressed to that agent's own conversation, and
+        // carries the launch that opens it.
+        assert!(matches!(
+            event_rx.try_recv().unwrap(),
+            DriverEvent::Subagent { provider_id, launch: Some(launch), event }
+                if provider_id == "toolu-agent"
+                    && launch.title == "Inspect the parser"
+                    && launch.role.as_deref() == Some("Explore")
+                    // Verified against the CLI: nothing on the wire addresses
+                    // a Claude subagent, so it is never given a composer.
+                    && !launch.can_prompt
+                    && matches!(*event, DriverEvent::TextDelta(_))
+        ));
+
+        handle_message(
+            &json!({
+                "type": "user",
+                "message": {"content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu-agent",
+                    "content": "Done."
+                }]}
+            }),
+            "s",
+            &events,
+            &commands,
+            &turn,
+            true,
+            &mut state,
+        );
+        let DriverEvent::BackgroundWork(BackgroundWorkEvent::Upsert(settled)) =
+            event_rx.try_recv().unwrap()
+        else {
+            panic!("the tool result should settle a synchronous agent");
+        };
+        assert_eq!(settled.key.provider_id, "toolu-agent");
+        assert_eq!(settled.status, BackgroundWorkStatus::Completed);
+    }
+
     /// Wire shapes read off CLI 2.1.226: progress events reuse `description`
     /// for the agent's current activity line, and the settle notification's
     /// `summary` is the whole final report. Neither may retitle the task —
@@ -1795,21 +2203,41 @@ mod tests {
         while let Ok(event) = event_rx.try_recv() {
             seen.push(event);
         }
-        assert_eq!(
-            seen.len(),
-            1,
+        // Everything the subagent said is addressed to the subagent's own
+        // conversation. Nothing reaches this session's transcript or meter.
+        assert!(
+            seen.iter()
+                .all(|event| matches!(event, DriverEvent::Subagent { .. })),
             "subagent content must not reach the transcript or usage meter"
         );
-        let DriverEvent::BackgroundWork(BackgroundWorkEvent::OutputDelta { key, delta }) = &seen[0]
-        else {
-            panic!("the subagent message should stream into its task output");
-        };
-        assert_eq!(key.provider_id, "agent-42");
-        assert_eq!(key.kind, BackgroundWorkKind::Subagent);
-        assert_eq!(delta, "Scanning the panel.\n\n› Bash · rg overlay src\n");
+        let addressed = seen
+            .iter()
+            .filter_map(|event| match event {
+                DriverEvent::Subagent {
+                    provider_id, event, ..
+                } => Some((provider_id.as_str(), event.as_ref())),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(addressed.iter().all(|(id, _)| *id == "toolu-agent"));
+        // Narrative, the tool call, and its result — the same event shapes a
+        // task's own transcript is built from.
+        assert!(matches!(
+            addressed[0].1,
+            DriverEvent::TextDelta(text) if text == "Scanning the panel."
+        ));
+        assert!(matches!(
+            addressed[1].1,
+            DriverEvent::RichActivity(item) if !item.complete
+        ));
+        assert!(matches!(
+            addressed[2].1,
+            DriverEvent::RichActivity(item) if item.complete
+        ));
 
-        // The settle notification's summary would duplicate the streamed
-        // transcript; the pane keeps what it already has.
+        // The final report lands on the agent's card even though its narration
+        // streamed to the agent's conversation: they are different surfaces,
+        // and suppressing it here left a completed agent showing no output.
         handle_message(
             &json!({
                 "type": "system",
@@ -1830,7 +2258,7 @@ mod tests {
         else {
             panic!("task_notification should settle the background item");
         };
-        assert!(settled.output.is_none());
+        assert_eq!(settled.output.as_deref(), Some("Scanning the panel."));
     }
 
     #[test]

--- a/src/driver/opencode.rs
+++ b/src/driver/opencode.rs
@@ -29,7 +29,8 @@ use crate::driver::{
     DriverControl, DriverEventSender, DriverEventSink, DriverStartOptions, SessionOptions,
 };
 use crate::model::{
-    ActivityKind, DriverEvent, InteractionMode, PermissionOption, ProviderResumeCursor, RuntimeMode,
+    ActivityKind, BackgroundWorkEvent, BackgroundWorkStatus, DriverEvent, InteractionMode,
+    PermissionOption, ProviderResumeCursor, RuntimeMode,
 };
 use crate::opencode_pool::PooledServer;
 use crate::opencode_session::{
@@ -1056,6 +1057,65 @@ fn tool_activity(part: &Value, events: &impl DriverEventSink, state: &mut OpenCo
             part.pointer("/state/output")
                 .filter(|value| !value.is_null())
         });
+    // opencode runs a subagent as a child session and reports the link on the
+    // `task` part itself, so the sidebar can name the agent and its model
+    // without reading the child's stream.
+    if let Some(call_id) = id.as_deref()
+        && let Some(launch) = super::support::subagent_launch(
+            part.get("tool").and_then(Value::as_str).unwrap_or_default(),
+            arguments,
+        )
+    {
+        let status = match part.pointer("/state/status").and_then(Value::as_str) {
+            Some("error") => BackgroundWorkStatus::Failed,
+            Some("completed") => BackgroundWorkStatus::Completed,
+            Some("pending") => BackgroundWorkStatus::Starting,
+            _ => BackgroundWorkStatus::Running,
+        };
+        let mut work = super::support::subagent_item(call_id, &launch, status);
+        work.parent_id = part
+            .pointer("/state/metadata/parentSessionId")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        // The child session is both what a follow-up prompt is addressed to
+        // and what an abort targets. It only appears once the part reaches
+        // `running`, so a pending subagent has none for a frame.
+        work.control_id = part
+            .pointer("/state/metadata/sessionId")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        if work.model.is_none() {
+            // Reported as `{providerID, modelID}`, not the slash-joined string
+            // the rest of Waku uses.
+            work.model = part
+                .pointer("/state/metadata/model")
+                .and_then(|model| {
+                    let provider = model.get("providerID").and_then(Value::as_str)?;
+                    let id = model.get("modelID").and_then(Value::as_str)?;
+                    Some(format!("{provider}/{id}"))
+                })
+                .or_else(|| {
+                    part.pointer("/state/metadata/model")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned)
+                });
+        }
+        if let Some(state_title) = part
+            .pointer("/state/title")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|title| !title.is_empty())
+        {
+            work.title = state_title.to_owned();
+        }
+        if complete {
+            work.output = output.and_then(activity::format_output);
+        }
+        let _ = events.send(DriverEvent::BackgroundWork(BackgroundWorkEvent::Upsert(
+            work,
+        )));
+    }
+
     let item = activity::tool_activity(
         id,
         kind,

--- a/src/driver/pi.rs
+++ b/src/driver/pi.rs
@@ -15,7 +15,10 @@ use super::{activity, computer_use as computer_use_runtime};
 use crate::driver::{
     DriverControl, DriverEventSender, DriverEventSink, DriverStartOptions, SessionOptions,
 };
-use crate::model::{ActivityKind, DriverEvent, InteractionMode, ProviderResumeCursor, RuntimeMode};
+use crate::model::{
+    ActivityKind, BackgroundWorkEvent, BackgroundWorkStatus, DriverEvent, InteractionMode,
+    ProviderResumeCursor, RuntimeMode,
+};
 
 const RPC_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -939,6 +942,31 @@ fn handle_pi_message(
             };
             let complete = event_type == "tool_execution_end";
             let failed = value.get("isError").and_then(Value::as_bool) == Some(true);
+            // Pi streams nothing from inside a delegated agent, so its
+            // execution events are the whole lifecycle: start it live here and
+            // settle it when the same call ends.
+            if let Some(call_id) = id.as_deref()
+                && let Some(launch) = super::support::subagent_launch(
+                    tool_name.unwrap_or_default(),
+                    value.get("args"),
+                )
+            {
+                let mut work = super::support::subagent_item(
+                    call_id,
+                    &launch,
+                    match (complete, failed) {
+                        (false, _) => BackgroundWorkStatus::Running,
+                        (true, false) => BackgroundWorkStatus::Completed,
+                        (true, true) => BackgroundWorkStatus::Failed,
+                    },
+                );
+                if complete {
+                    work.output = output.and_then(activity::format_output);
+                }
+                let _ = events.send(DriverEvent::BackgroundWork(BackgroundWorkEvent::Upsert(
+                    work,
+                )));
+            }
             let item = activity::tool_activity(
                 id.clone(),
                 kind,

--- a/src/driver/support.rs
+++ b/src/driver/support.rs
@@ -366,6 +366,154 @@ pub(super) fn classify_tool(name: &str) -> ActivityKind {
     ActivityKind::from_tool_name(name)
 }
 
+/// A nested agent a provider just launched, as read off the spawning tool call.
+///
+/// Every agent CLI Waku drives ends up expressing delegation the same way: one
+/// tool call that names a role and hands it a prompt. The transports disagree
+/// about everything after that — Codex opens a child thread, opencode opens a
+/// child session, Claude tags later messages with the spawning tool's id, and
+/// Amp declares `parent_tool_use_id` but always sends `null` — so the tool call
+/// itself is the one join point that exists everywhere.
+#[derive(Clone)]
+pub(super) struct SubagentLaunch {
+    /// The agent's kind, as the provider names it: `Explore`, `oracle`,
+    /// `general`. Shown as the role on the subagent's row.
+    pub(super) role: Option<String>,
+    /// The short human label for this run, preferring the provider's own
+    /// description over the first line of the prompt.
+    pub(super) title: String,
+    pub(super) prompt: Option<String>,
+    pub(super) model: Option<String>,
+}
+
+/// Whether `name` is a tool whose whole purpose is to run another agent.
+///
+/// Claude renamed `Task` to `Agent` in 2.x and still accepts both; Amp keeps
+/// `Task` plus a fixed set of named agent-backed tools; opencode and Qwen use
+/// lowercase `task`/`agent`; Cursor sends `taskToolCall`. Matching is done on
+/// the normalized leaf so MCP-namespaced variants (`mcp__x__task`) still hit.
+pub(super) fn is_subagent_tool(name: &str) -> bool {
+    let normalized = name.trim().to_ascii_lowercase().replace(['-', ' '], "_");
+    let leaf = normalized
+        .rsplit("__")
+        .next()
+        .unwrap_or(&normalized)
+        .rsplit([':', '.', '/'])
+        .next()
+        .unwrap_or(&normalized);
+    matches!(
+        leaf.replace('_', "").as_str(),
+        "agent"
+            | "task"
+            | "tasktoolcall"
+            | "subagent"
+            // DeepSeek ships the delegation tool twice, as `subagent` and
+            // `subagent_fork` for its one-shot mode.
+            | "subagentfork"
+            | "spawnagent"
+            // Grok names its delegation tool `spawn_subagent`; Cursor titles
+            // the ACP call `Task: Subagent task`.
+            | "spawnsubagent"
+            | "subagenttask"
+            // pi-minions, the delegation extension Pi actually loads.
+            | "spawn"
+            | "invokeagent"
+            | "runagent"
+            | "delegate"
+            | "oracle"
+            | "librarian"
+            | "codereview"
+    )
+}
+
+/// Read a subagent launch off a spawning tool call's arguments. Returns `None`
+/// for tools that are not delegation, so a caller can use it as the test.
+pub(super) fn subagent_launch(name: &str, input: Option<&Value>) -> Option<SubagentLaunch> {
+    if !is_subagent_tool(name) {
+        return None;
+    }
+    let field = |keys: &[&str]| -> Option<String> {
+        let input = input?;
+        keys.iter()
+            .find_map(|key| input.get(*key).and_then(Value::as_str))
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+    };
+    let prompt = field(&["prompt", "message", "task", "instructions", "input"]);
+    // A named tool such as `oracle` is itself the role; a generic `Task` names
+    // its role in the arguments, and falls back to the tool's own name so a row
+    // never reads as an anonymous agent.
+    let role = field(&[
+        "subagent_type",
+        "subagentType",
+        "agent_type",
+        "agentType",
+        "agent_name",
+        "agentName",
+        "agent",
+        "role",
+        "task_name",
+        "taskName",
+    ])
+    .or_else(|| {
+        let leaf = name.trim();
+        (!leaf.is_empty()
+            && !leaf.eq_ignore_ascii_case("task")
+            && !leaf.eq_ignore_ascii_case("agent"))
+        .then(|| leaf.to_owned())
+    });
+    let title = field(&["description", "title", "subject", "task_name", "taskName"])
+        .or_else(|| prompt.as_deref().and_then(subagent_title_from_prompt))
+        .or_else(|| role.clone())
+        .unwrap_or_else(|| tr!("background.subagent"));
+    Some(SubagentLaunch {
+        role,
+        title,
+        prompt,
+        model: field(&["model", "modelID", "model_id"]),
+    })
+}
+
+/// The background-work entry for a subagent launched by tool call `tool_id`.
+///
+/// Keying on the spawning tool call — rather than a provider-specific thread or
+/// session id — is what lets the transcript badge and the sidebar row address
+/// the same piece of work through `origin_activity_id`.
+pub(super) fn subagent_item(
+    tool_id: &str,
+    launch: &SubagentLaunch,
+    status: crate::model::BackgroundWorkStatus,
+) -> crate::model::BackgroundWorkItem {
+    use crate::model::{BackgroundWorkItem, BackgroundWorkKind};
+
+    let mut item = BackgroundWorkItem::new(
+        BackgroundWorkKind::Subagent,
+        tool_id,
+        launch.title.clone(),
+        status,
+    );
+    item.role = launch.role.clone();
+    item.model = launch.model.clone();
+    item.command = launch.prompt.clone();
+    item.origin_activity_id = Some(tool_id.to_owned());
+    item
+}
+
+/// A prompt's first non-empty line, clipped to something a sidebar row can
+/// hold. Prompts run to paragraphs; a title is one glance.
+fn subagent_title_from_prompt(prompt: &str) -> Option<String> {
+    let line = prompt
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())?;
+    let mut title = line.chars().take(96).collect::<String>();
+    if line.chars().count() > 96 {
+        title.push('…');
+    }
+    Some(title)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -381,6 +529,86 @@ mod tests {
             ),
             process_directory: PathBuf::from("/tmp/waku-computer-use/session"),
         }
+    }
+
+    #[test]
+    fn delegation_tools_are_recognized_across_providers() {
+        for name in [
+            "Agent",
+            "Task",
+            "task",
+            "taskToolCall",
+            "spawn_agent",
+            "subagent_fork",
+            "spawn",
+            "spawn_subagent",
+            "Task: Subagent task",
+            "invoke_agent",
+            "oracle",
+            "mcp__amp__code_review",
+        ] {
+            assert!(is_subagent_tool(name), "{name} should launch a subagent");
+        }
+        for name in [
+            "Bash",
+            "Read",
+            "todo_write",
+            "agent_skill",
+            "read_agents_md",
+        ] {
+            assert!(!is_subagent_tool(name), "{name} is not a subagent launch");
+        }
+    }
+
+    #[test]
+    fn a_launch_prefers_the_providers_description_over_the_prompt() {
+        let launch = subagent_launch(
+            "Agent",
+            Some(&serde_json::json!({
+                "description": "Audit the auth flow",
+                "subagent_type": "Explore",
+                "prompt": "Look at every call site of verifyToken.\nReport back.",
+                "model": "opus",
+            })),
+        )
+        .expect("Agent launches a subagent");
+        assert_eq!(launch.title, "Audit the auth flow");
+        assert_eq!(launch.role.as_deref(), Some("Explore"));
+        assert_eq!(launch.model.as_deref(), Some("opus"));
+        assert!(launch.prompt.unwrap().starts_with("Look at every"));
+    }
+
+    #[test]
+    fn a_launch_without_a_description_titles_itself_from_the_prompts_first_line() {
+        let launch = subagent_launch(
+            "task",
+            Some(&serde_json::json!({
+                "prompt": "\n\nFind the flaky test\nthen fix it",
+            })),
+        )
+        .expect("task launches a subagent");
+        assert_eq!(launch.title, "Find the flaky test");
+        // A generic tool name is not a role; only a named agent tool is.
+        assert_eq!(launch.role, None);
+        assert_eq!(
+            subagent_launch("oracle", None).unwrap().role.as_deref(),
+            Some("oracle")
+        );
+    }
+
+    #[test]
+    fn a_launch_keys_its_work_item_on_the_spawning_tool_call() {
+        let launch = subagent_launch("Agent", Some(&serde_json::json!({"description": "Probe"})))
+            .expect("Agent launches a subagent");
+        let item = subagent_item(
+            "toolu_01",
+            &launch,
+            crate::model::BackgroundWorkStatus::Running,
+        );
+        assert_eq!(item.key.kind, crate::model::BackgroundWorkKind::Subagent);
+        assert_eq!(item.key.provider_id, "toolu_01");
+        // The transcript badge finds its work through this field.
+        assert_eq!(item.origin_activity_id.as_deref(), Some("toolu_01"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,9 +264,11 @@ fn main() {
 
             window
                 .update(cx, |_, window, cx| {
+                    let theme = crate::theme::Theme::current(cx);
                     crate::platform::configure_sidebar_material(
                         window,
-                        crate::theme::Theme::current(cx).is_dark,
+                        theme.is_dark,
+                        theme.sidebar_tint,
                     );
                     cx.activate(true);
                 })

--- a/src/model.rs
+++ b/src/model.rs
@@ -739,9 +739,57 @@ pub struct ContextUsage {
     pub window: Option<u64>,
 }
 
+/// What a driver knows about a subagent the moment it first sees one, enough
+/// for the app to open a conversation for it.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SubagentLaunchInfo {
+    pub title: String,
+    pub role: Option<String>,
+    pub model: Option<String>,
+    /// The prompt the parent handed the agent. Shown as the opening message,
+    /// because from the agent's side that is exactly what it was.
+    pub prompt: Option<String>,
+    /// Whether this provider lets a client send into the agent. Almost none
+    /// do; see [`SubagentOrigin::can_prompt`].
+    pub can_prompt: bool,
+    pub prompt_target: Option<String>,
+}
+
+/// What ties a subagent conversation back to the agent that launched it.
+///
+/// Providers disagree about what a subagent *is* — Claude keeps it on the
+/// parent's stream behind a tool-call id, OpenCode gives it a child session,
+/// Codex a child thread — so the one identifier that exists everywhere is the
+/// tool call that spawned it. `provider_id` is that call, and it is what the
+/// driver tags the child's events with.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SubagentOrigin {
+    pub parent_session_id: Uuid,
+    pub provider_id: String,
+    /// The agent's kind as the provider names it: `Explore`, `oracle`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// Whether this provider lets a client send a message into the agent.
+    /// Most do not: delegation is usually a tool the orchestrating model
+    /// calls, with no client-facing route to the child. A composer is only
+    /// offered where this is true.
+    #[serde(default)]
+    pub can_prompt: bool,
+    /// Provider-side handle a prompt would be addressed to, when there is one
+    /// — OpenCode's child session id, Codex's child thread id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_target: Option<String>,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AgentSession {
     pub id: Uuid,
+    /// Set when this session is a subagent rather than something the user
+    /// started. Subagent sessions are real conversations — same transcript,
+    /// same rendering — but they are launched by another session's agent, so
+    /// they stay out of the task list and out of the sidebar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subagent: Option<SubagentOrigin>,
     /// A title explicitly chosen by the user. [`Self::DEFAULT_TITLE`] means
     /// no explicit title has been set, so [`Self::auto_title`] may be shown.
     pub title: String,
@@ -824,6 +872,7 @@ impl AgentSession {
         let now = unix_time();
         Self {
             id: Uuid::new_v4(),
+            subagent: None,
             title: Self::DEFAULT_TITLE.to_owned(),
             auto_title: None,
             project_id,
@@ -849,6 +898,13 @@ impl AgentSession {
             turns: Vec::new(),
             queued_messages: Vec::new(),
         }
+    }
+
+    /// A conversation the user started, as opposed to one an agent launched.
+    /// The sidebar, the command palette and every other place that enumerates
+    /// "tasks" means this.
+    pub fn is_task(&self) -> bool {
+        self.subagent.is_none()
     }
 
     pub fn is_busy(&self) -> bool {
@@ -1084,6 +1140,25 @@ impl AgentSession {
             Message::new_for_turn(MessageRole::User, prompt, id)
                 .with_presentation(display_content, attachments),
         );
+        self.last_reply_at = Some(now);
+        id
+    }
+
+    /// Open a turn the provider started on its own, with no user message —
+    /// nobody typed one. See [`DriverEvent::ProviderTurnStarted`].
+    pub fn begin_provider_turn(&mut self) -> Uuid {
+        let id = Uuid::new_v4();
+        let now = unix_time();
+        self.turns.push(AgentTurn {
+            id,
+            turn_count: self.turns.len() + 1,
+            status: TurnStatus::Running,
+            provider_turn_started: true,
+            provider_resume_at: None,
+            started_at: now,
+            completed_at: None,
+            checkpoint: None,
+        });
         self.last_reply_at = Some(now);
         id
     }
@@ -1496,6 +1571,12 @@ pub enum DriverEvent {
     /// dynamically registered commands.
     AvailableCommands(Vec<ReportedCommand>),
     TurnStarted,
+    /// The provider began a turn nobody prompted for. Claude ends the turn
+    /// that launched a backgrounded subagent, then wakes itself when that
+    /// subagent reports back and keeps working. Without a turn to hold it that
+    /// second stretch of work is dropped on the floor, so the app opens one
+    /// that has no user message behind it.
+    ProviderTurnStarted,
     TextDelta(String),
     ReasoningDelta(String),
     Activity {
@@ -1510,6 +1591,18 @@ pub enum DriverEvent {
     /// deliberately separate from transcript activities: completing a turn
     /// must not make a detached process or subagent look complete.
     BackgroundWork(BackgroundWorkEvent),
+    /// An event belonging to a subagent rather than to this session.
+    ///
+    /// Providers interleave a subagent's stream with the parent's on one
+    /// channel, so the driver tags each child event with the agent it came
+    /// from and the app replays it against that agent's own conversation.
+    /// `launch` is present on the first event for an agent and carries what is
+    /// needed to open that conversation.
+    Subagent {
+        provider_id: String,
+        launch: Option<SubagentLaunchInfo>,
+        event: Box<DriverEvent>,
+    },
     Permission {
         request_id: String,
         title: String,

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -30,7 +30,7 @@ use crate::model::{
     AgentSession, FavoriteModel, InteractionMode, Message, MessageAttachment, MessageRole, Project,
     ProviderKind, RuntimeMode, SessionWorkspace,
 };
-use crate::theme::ThemePreference;
+use crate::theme::{ThemeId, ThemePreference};
 
 const STATE_VERSION: u32 = 5;
 const APP_STATE_VERSION: u32 = 1;
@@ -261,6 +261,8 @@ pub struct AppSettings {
     pub analytics_enabled: bool,
     pub favorite_models: Vec<FavoriteModel>,
     pub theme: ThemePreference,
+    pub light_theme: ThemeId,
+    pub dark_theme: ThemeId,
     pub language: AppLanguage,
     pub computer_use_enabled: bool,
     pub computer_use_allowed_apps: Vec<ComputerAppGrant>,
@@ -278,6 +280,8 @@ impl Default for AppSettings {
             analytics_enabled: default_analytics_enabled(),
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
+            light_theme: ThemeId::default(),
+            dark_theme: ThemeId::default(),
             language: AppLanguage::default(),
             computer_use_enabled: default_computer_use_enabled(),
             computer_use_allowed_apps: Vec::new(),
@@ -346,6 +350,10 @@ pub struct PersistedState {
     #[serde(default)]
     pub theme: ThemePreference,
     #[serde(default)]
+    pub light_theme: ThemeId,
+    #[serde(default)]
+    pub dark_theme: ThemeId,
+    #[serde(default)]
     pub language: AppLanguage,
     #[serde(default = "default_sidebar_visibility")]
     pub sidebar_visible: bool,
@@ -412,6 +420,8 @@ impl PersistedState {
             remembered_model_traits: Vec::new(),
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
+            light_theme: ThemeId::default(),
+            dark_theme: ThemeId::default(),
             language: AppLanguage::default(),
             sidebar_visible: true,
             right_panel_visible: false,
@@ -497,6 +507,8 @@ impl PersistedState {
             analytics_enabled: self.analytics_enabled,
             favorite_models: self.favorite_models.clone(),
             theme: self.theme,
+            light_theme: self.light_theme,
+            dark_theme: self.dark_theme,
             language: self.language,
             computer_use_enabled: self.computer_use_enabled,
             computer_use_allowed_apps: self.computer_use_allowed_apps.clone(),
@@ -527,6 +539,8 @@ impl PersistedState {
         self.analytics_enabled = settings.analytics_enabled;
         self.favorite_models = settings.favorite_models;
         self.theme = settings.theme;
+        self.light_theme = settings.light_theme;
+        self.dark_theme = settings.dark_theme;
         self.language = settings.language;
         self.computer_use_enabled = settings.computer_use_enabled;
         self.computer_use_allowed_apps = settings.computer_use_allowed_apps;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1320,10 +1320,13 @@ impl StateStore {
         // does not leave this connection believing rows it never wrote are on
         // disk — which would make the next save skip them for good.
         let mut written_messages = Vec::new();
+        // Subagent conversations are runtime-only. They belong to a turn, the
+        // provider keeps its own transcript of them, and persisting a fan-out
+        // of them would bury the task list they are deliberately kept out of.
         for session in state
             .sessions
             .iter()
-            .filter(|session| session.has_started())
+            .filter(|session| session.has_started() && session.is_task())
         {
             live.insert(session.id);
             // A skeleton's empty transcript means "not fetched", not "empty".
@@ -1461,6 +1464,8 @@ fn session_skeleton(row: SessionColumns) -> Option<AgentSession> {
     ) = row;
     Some(AgentSession {
         id: Uuid::parse_str(&id).ok()?,
+        // Only tasks are stored, so a row is never a subagent.
+        subagent: None,
         title,
         auto_title,
         project_id: Uuid::parse_str(&project_id).ok()?,

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -248,6 +248,153 @@ pub fn hide_window(window: &mut Window) {
     window.remove_window();
 }
 
+/// One row of a native context menu, in the order it should appear.
+pub struct NativeMenuItem {
+    pub label: String,
+    pub enabled: bool,
+    pub checked: bool,
+    pub separator: bool,
+}
+
+#[cfg(target_os = "macos")]
+mod native_menu {
+    use std::cell::Cell;
+
+    use gpui::{Pixels, Point, Window};
+    use objc2::rc::Retained;
+    use objc2::runtime::{NSObject, NSObjectProtocol};
+    use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
+    use objc2_app_kit::{
+        NSControlStateValueOff, NSControlStateValueOn, NSMenu, NSMenuItem, NSView,
+    };
+    use objc2_foundation::{NSPoint, NSString};
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    use super::NativeMenuItem;
+
+    define_class!(
+        // SAFETY: `NSObject` has no subclassing requirements and `MenuTarget`
+        // does not implement `Drop`.
+        #[unsafe(super(NSObject))]
+        #[thread_kind = MainThreadOnly]
+        #[name = "WakuContextMenuTarget"]
+        #[ivars = Cell<isize>]
+        struct MenuTarget;
+
+        unsafe impl NSObjectProtocol for MenuTarget {}
+
+        impl MenuTarget {
+            // AppKit sends this to the chosen item's target, and sends nothing
+            // at all when the menu is dismissed — which leaves the tag at -1.
+            #[unsafe(method(wakuContextMenuItemSelected:))]
+            fn item_selected(&self, item: &NSMenuItem) {
+                self.ivars().set(item.tag());
+            }
+        }
+    );
+
+    impl MenuTarget {
+        fn new(main_thread: MainThreadMarker) -> Retained<Self> {
+            let this = Self::alloc(main_thread).set_ivars(Cell::new(-1));
+            unsafe { msg_send![super(this), init] }
+        }
+    }
+
+    /// The window's native surface, captured while GPUI hands us a `Window` so
+    /// the menu itself can be popped later, from outside any GPUI borrow.
+    pub struct NativeContextMenu {
+        view: Retained<NSView>,
+    }
+
+    /// Capture that surface, or `None` when there is none — a headless test
+    /// window. The caller then falls back to the in-app menu card.
+    pub fn prepare_context_menu(window: &Window) -> Option<NativeContextMenu> {
+        let handle = HasWindowHandle::window_handle(window).ok()?;
+        let RawWindowHandle::AppKit(handle) = handle.as_raw() else {
+            return None;
+        };
+        MainThreadMarker::new()?;
+
+        // GPUI owns this view; we only read its geometry and anchor a menu to
+        // it.
+        let view = unsafe { Retained::retain(handle.ns_view.cast::<NSView>().as_ptr())? };
+        Some(NativeContextMenu { view })
+    }
+
+    impl NativeContextMenu {
+        /// Pop the menu at `position`, in GPUI's window coordinates, and block
+        /// on AppKit's tracking loop until it closes. Returns the index of the
+        /// chosen item within `items`.
+        ///
+        /// Must be called with no GPUI borrow held: the tracking loop keeps the
+        /// run loop turning, so GPUI redraws and its own timers still fire
+        /// while the menu is up.
+        pub fn show(&self, position: Point<Pixels>, items: &[NativeMenuItem]) -> Option<usize> {
+            let main_thread = MainThreadMarker::new()?;
+            let target = MenuTarget::new(main_thread);
+            let menu = NSMenu::new(main_thread);
+            // Enablement is ours to decide; AppKit's automatic validation
+            // would grey out every item, since a Rust target implements no
+            // validation protocol.
+            menu.setAutoenablesItems(false);
+
+            for (index, item) in items.iter().enumerate() {
+                if item.separator {
+                    menu.addItem(&NSMenuItem::separatorItem(main_thread));
+                    continue;
+                }
+                let entry = unsafe {
+                    NSMenuItem::initWithTitle_action_keyEquivalent(
+                        NSMenuItem::alloc(main_thread),
+                        &NSString::from_str(&item.label),
+                        Some(sel!(wakuContextMenuItemSelected:)),
+                        &NSString::from_str(""),
+                    )
+                };
+                unsafe { entry.setTarget(Some(&target)) };
+                entry.setTag(index as isize);
+                entry.setEnabled(item.enabled);
+                entry.setState(if item.checked {
+                    NSControlStateValueOn
+                } else {
+                    NSControlStateValueOff
+                });
+                menu.addItem(&entry);
+            }
+
+            // GPUI's coordinates start at the window's top-left; an unflipped
+            // AppKit view measures up from its bottom-left.
+            let height = self.view.bounds().size.height;
+            let y = f64::from(f32::from(position.y));
+            let y = if self.view.isFlipped() { y } else { height - y };
+            let location = NSPoint::new(f64::from(f32::from(position.x)), y);
+            menu.popUpMenuPositioningItem_atLocation_inView(None, location, Some(&self.view));
+
+            usize::try_from(target.ivars().get()).ok()
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub use native_menu::{NativeContextMenu, prepare_context_menu};
+
+#[cfg(not(target_os = "macos"))]
+pub struct NativeContextMenu {
+    _private: (),
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn prepare_context_menu(_: &Window) -> Option<NativeContextMenu> {
+    None
+}
+
+#[cfg(not(target_os = "macos"))]
+impl NativeContextMenu {
+    pub fn show(&self, _: gpui::Point<gpui::Pixels>, _: &[NativeMenuItem]) -> Option<usize> {
+        None
+    }
+}
+
 #[cfg(target_os = "macos")]
 thread_local! {
     static SIDEBAR_TINT_VIEW: std::cell::RefCell<Option<objc2::rc::Retained<objc2_app_kit::NSView>>> =

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -261,12 +261,20 @@ pub fn start_window_move(window: &Window) {
     window.start_window_move();
 }
 
+/// Whether the user has asked the system to reduce transparency. Read live so
+/// a change in System Settings is honored at the next theme application.
+#[cfg(target_os = "macos")]
+fn reduce_transparency() -> bool {
+    use objc2_app_kit::NSWorkspace;
+    NSWorkspace::sharedWorkspace().accessibilityDisplayShouldReduceTransparency()
+}
+
 /// Match Cursor's macOS glass window stack without asking GPUI's transparent
 /// Metal target to blend two translucent quads. The semantic tint is a native
 /// view above active Sidebar vibrancy; GPUI paints clear sidebar chrome and one
 /// translucent interaction layer above it.
 #[cfg(target_os = "macos")]
-pub fn configure_sidebar_material(window: &Window, dark: bool) {
+pub fn configure_sidebar_material(window: &Window, dark: bool, tint: gpui::Hsla) {
     use objc2::{MainThreadMarker, MainThreadOnly};
     use objc2_app_kit::{
         NSAutoresizingMaskOptions, NSColor, NSView, NSVisualEffectBlendingMode,
@@ -291,8 +299,14 @@ pub fn configure_sidebar_material(window: &Window, dark: bool) {
         let Some(native_window) = view.window() else {
             return;
         };
+        let backdrop = gpui::Rgba::from(tint);
         let background = if dark {
-            NSColor::colorWithSRGBRed_green_blue_alpha(0.0, 0.0, 0.0, 0.25)
+            NSColor::colorWithSRGBRed_green_blue_alpha(
+                f64::from(backdrop.r),
+                f64::from(backdrop.g),
+                f64::from(backdrop.b),
+                0.25,
+            )
         } else {
             NSColor::colorWithSRGBRed_green_blue_alpha(1.0, 1.0, 1.0, 0.0)
         };
@@ -316,8 +330,17 @@ pub fn configure_sidebar_material(window: &Window, dark: bool) {
             return;
         }
 
-        let channel = if dark { 0x18 } else { 0xF3 } as f64 / 255.0;
-        let tint = NSColor::colorWithSRGBRed_green_blue_alpha(channel, channel, channel, 0.92);
+        // The palette owns this color. Vibrancy still shows through, and the
+        // system's reduce-transparency setting closes that gap entirely rather
+        // than leaving the sidebar the one surface a theme cannot reach.
+        let tint = gpui::Rgba::from(tint);
+        let opacity = if reduce_transparency() { 1.0 } else { 0.92 };
+        let tint = NSColor::colorWithSRGBRed_green_blue_alpha(
+            f64::from(tint.r),
+            f64::from(tint.g),
+            f64::from(tint.b),
+            opacity,
+        );
 
         SIDEBAR_TINT_VIEW.with_borrow_mut(|slot| {
             let needs_new_view = slot.as_ref().is_none_or(|tint_view| {
@@ -348,7 +371,7 @@ pub fn configure_sidebar_material(window: &Window, dark: bool) {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn configure_sidebar_material(_: &Window, _: bool) {}
+pub fn configure_sidebar_material(_: &Window, _: bool, _: gpui::Hsla) {}
 
 #[cfg(target_os = "macos")]
 pub fn set_sidebar_material_width(window: &Window, width: f32) {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,5 +1,5 @@
-use gpui::{App, Global, Hsla, Window, WindowAppearance, hsla, rgb, transparent_black};
-use serde::{Deserialize, Serialize};
+use gpui::{App, Global, Hsla, Rgba, Window, WindowAppearance, hsla, rgb, transparent_black};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -21,7 +21,7 @@ impl ThemePreference {
         }
     }
 
-    fn resolves_to_dark(self, system_appearance: WindowAppearance) -> bool {
+    pub fn resolves_to_dark(self, system_appearance: WindowAppearance) -> bool {
         match self {
             Self::System => matches!(
                 system_appearance,
@@ -41,6 +41,464 @@ impl ThemePreference {
     }
 }
 
+/// The authored surface of a palette. Everything a [`Theme`] needs is derived
+/// from these fields, so a new palette is a handful of hexes rather than three
+/// dozen hand-tuned tokens. `contrast` scales every wash and text tier: low
+/// values keep secondary text and borders faint, high values push them toward
+/// the ink.
+#[derive(Clone, Copy)]
+pub struct ThemeSeed {
+    pub surface: u32,
+    pub ink: u32,
+    pub accent: u32,
+    pub contrast: u8,
+    pub added: u32,
+    pub removed: u32,
+    pub skill: u32,
+    pub warning: u32,
+}
+
+#[derive(Clone, Copy)]
+enum Palette {
+    Seed(ThemeSeed),
+    Authored(fn() -> Theme),
+}
+
+impl Palette {
+    fn resolve(self, is_dark: bool) -> Theme {
+        match self {
+            Self::Seed(seed) => Theme::from_seed(seed, is_dark),
+            Self::Authored(build) => build(),
+        }
+    }
+}
+
+pub struct ThemeDefinition {
+    id: ThemeId,
+    label: &'static str,
+    light: Option<Palette>,
+    dark: Option<Palette>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub enum ThemeId {
+    #[default]
+    Waku,
+    Catppuccin,
+    Dracula,
+    Everforest,
+    Github,
+    Gruvbox,
+    Monokai,
+    NightOwl,
+    Nord,
+    One,
+    RosePine,
+    Solarized,
+    TokyoNight,
+    Vercel,
+}
+
+impl ThemeId {
+    fn slug(self) -> &'static str {
+        match self {
+            Self::Waku => "waku",
+            Self::Catppuccin => "catppuccin",
+            Self::Dracula => "dracula",
+            Self::Everforest => "everforest",
+            Self::Github => "github",
+            Self::Gruvbox => "gruvbox",
+            Self::Monokai => "monokai",
+            Self::NightOwl => "night-owl",
+            Self::Nord => "nord",
+            Self::One => "one",
+            Self::RosePine => "rose-pine",
+            Self::Solarized => "solarized",
+            Self::TokyoNight => "tokyo-night",
+            Self::Vercel => "vercel",
+        }
+    }
+
+    fn from_slug(slug: &str) -> Option<Self> {
+        THEMES
+            .iter()
+            .map(|definition| definition.id)
+            .find(|id| id.slug() == slug)
+    }
+
+    fn definition(self) -> &'static ThemeDefinition {
+        THEMES
+            .iter()
+            .find(|definition| definition.id == self)
+            .unwrap_or(&THEMES[0])
+    }
+
+    pub fn label(self) -> &'static str {
+        self.definition().label
+    }
+
+    fn palette(self, is_dark: bool) -> Option<Palette> {
+        let definition = self.definition();
+        if is_dark {
+            definition.dark
+        } else {
+            definition.light
+        }
+    }
+
+    pub fn supports(self, is_dark: bool) -> bool {
+        self.palette(is_dark).is_some()
+    }
+
+    /// Palettes offered for one slot. A dark-only palette never appears in the
+    /// light picker, so a chosen id always has a variant to resolve.
+    pub fn all_for(is_dark: bool) -> Vec<Self> {
+        THEMES
+            .iter()
+            .map(|definition| definition.id)
+            .filter(|id| id.supports(is_dark))
+            .collect()
+    }
+
+    pub fn resolve(self, is_dark: bool) -> Theme {
+        self.palette(is_dark)
+            .or_else(|| Self::default().palette(is_dark))
+            .map(|palette| palette.resolve(is_dark))
+            .unwrap_or_else(|| {
+                if is_dark {
+                    Theme::dark()
+                } else {
+                    Theme::light()
+                }
+            })
+    }
+}
+
+impl Serialize for ThemeId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.slug())
+    }
+}
+
+impl<'de> Deserialize<'de> for ThemeId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let slug = String::deserialize(deserializer)?;
+        Ok(Self::from_slug(&slug).unwrap_or_default())
+    }
+}
+
+const THEMES: &[ThemeDefinition] = &[
+    ThemeDefinition {
+        id: ThemeId::Waku,
+        label: "Waku",
+        light: Some(Palette::Authored(Theme::light)),
+        dark: Some(Palette::Authored(Theme::dark)),
+    },
+    ThemeDefinition {
+        id: ThemeId::Catppuccin,
+        label: "Catppuccin",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xEFF1F5,
+            ink: 0x4C4F69,
+            accent: 0x1E66D5,
+            contrast: 46,
+            added: 0x40A02B,
+            removed: 0xD20F39,
+            skill: 0x8839EF,
+            warning: 0xDF8E1D,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x1E1E2E,
+            ink: 0xCDD6F4,
+            accent: 0x89B4FA,
+            contrast: 58,
+            added: 0xA6E3A1,
+            removed: 0xF38BA8,
+            skill: 0xCBA6F7,
+            warning: 0xF9E2AF,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Dracula,
+        label: "Dracula",
+        light: None,
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x282A36,
+            ink: 0xF8F8F2,
+            accent: 0xBD93F9,
+            contrast: 56,
+            added: 0x50FA7B,
+            removed: 0xFF5555,
+            skill: 0xFF79C6,
+            warning: 0xF1FA8C,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Everforest,
+        label: "Everforest",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFDF6E3,
+            ink: 0x5C6A72,
+            accent: 0x8DA101,
+            contrast: 48,
+            added: 0x8DA101,
+            removed: 0xF85552,
+            skill: 0xDF69BA,
+            warning: 0xDFA000,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x2D353B,
+            ink: 0xD3C6AA,
+            accent: 0xA7C080,
+            contrast: 58,
+            added: 0xA7C080,
+            removed: 0xE67E80,
+            skill: 0xD699B6,
+            warning: 0xDBBC7F,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Github,
+        label: "GitHub",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFFFFFF,
+            ink: 0x1F2328,
+            accent: 0x0969DA,
+            contrast: 45,
+            added: 0x1A7F37,
+            removed: 0xCF222E,
+            skill: 0x8250DF,
+            warning: 0x9A6700,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x0D1117,
+            ink: 0xE6EDF3,
+            accent: 0x2F81F7,
+            contrast: 60,
+            added: 0x3FB950,
+            removed: 0xF85149,
+            skill: 0xA371F7,
+            warning: 0xD29922,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Gruvbox,
+        label: "Gruvbox",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFBF1C7,
+            ink: 0x3C3836,
+            accent: 0x076678,
+            contrast: 48,
+            added: 0x79740E,
+            removed: 0x9D0006,
+            skill: 0x8F3F71,
+            warning: 0xB57614,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x282828,
+            ink: 0xEBDBB2,
+            accent: 0x83A598,
+            contrast: 56,
+            added: 0xB8BB26,
+            removed: 0xFB4934,
+            skill: 0xD3869B,
+            warning: 0xFABD2F,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Monokai,
+        label: "Monokai",
+        light: None,
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x272822,
+            ink: 0xF8F8F2,
+            accent: 0x66D9EF,
+            contrast: 56,
+            added: 0xA6E22E,
+            removed: 0xF92672,
+            skill: 0xAE81FF,
+            warning: 0xE6DB74,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::NightOwl,
+        label: "Night Owl",
+        light: None,
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x011627,
+            ink: 0xD6DEEB,
+            accent: 0x82AAFF,
+            contrast: 58,
+            added: 0xADDB67,
+            removed: 0xEF5350,
+            skill: 0xC792EA,
+            warning: 0xECC48D,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Nord,
+        label: "Nord",
+        light: None,
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x2E3440,
+            ink: 0xD8DEE9,
+            accent: 0x88C0D0,
+            contrast: 58,
+            added: 0xA3BE8C,
+            removed: 0xBF616A,
+            skill: 0xB48EAD,
+            warning: 0xEBCB8B,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::One,
+        label: "One",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFAFAFA,
+            ink: 0x383A42,
+            accent: 0x4078F2,
+            contrast: 46,
+            added: 0x50A14F,
+            removed: 0xE45649,
+            skill: 0xA626A4,
+            warning: 0xC18401,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x282C34,
+            ink: 0xABB2BF,
+            accent: 0x61AFEF,
+            contrast: 60,
+            added: 0x98C379,
+            removed: 0xE06C75,
+            skill: 0xC678DD,
+            warning: 0xE5C07B,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::RosePine,
+        label: "Rosé Pine",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFAF4ED,
+            ink: 0x575279,
+            accent: 0x907AA9,
+            contrast: 48,
+            added: 0x286983,
+            removed: 0xB4637A,
+            skill: 0x907AA9,
+            warning: 0xEA9D34,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x232136,
+            ink: 0xE0DEF4,
+            accent: 0xC4A7E7,
+            contrast: 58,
+            added: 0x9CCFD8,
+            removed: 0xEB6F92,
+            skill: 0xC4A7E7,
+            warning: 0xF6C177,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Solarized,
+        label: "Solarized",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFDF6E3,
+            ink: 0x586E75,
+            accent: 0x268BD2,
+            contrast: 50,
+            added: 0x859900,
+            removed: 0xDC322F,
+            skill: 0x6C71C4,
+            warning: 0xB58900,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x002B36,
+            ink: 0x93A1A1,
+            accent: 0x268BD2,
+            contrast: 62,
+            added: 0x859900,
+            removed: 0xDC322F,
+            skill: 0x6C71C4,
+            warning: 0xB58900,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::TokyoNight,
+        label: "Tokyo Night",
+        light: None,
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x1A1B26,
+            ink: 0xC0CAF5,
+            accent: 0x7AA2F7,
+            contrast: 58,
+            added: 0x9ECE6A,
+            removed: 0xF7768E,
+            skill: 0xBB9AF7,
+            warning: 0xE0AF68,
+        })),
+    },
+    ThemeDefinition {
+        id: ThemeId::Vercel,
+        label: "Vercel",
+        light: Some(Palette::Seed(ThemeSeed {
+            surface: 0xFFFFFF,
+            ink: 0x171717,
+            accent: 0x0070F3,
+            contrast: 44,
+            added: 0x1A7F37,
+            removed: 0xE5484D,
+            skill: 0x8E4EC6,
+            warning: 0xA35200,
+        })),
+        dark: Some(Palette::Seed(ThemeSeed {
+            surface: 0x0A0A0A,
+            ink: 0xEDEDED,
+            accent: 0x0072F5,
+            contrast: 60,
+            added: 0x45A557,
+            removed: 0xE5484D,
+            skill: 0x8E4EC6,
+            warning: 0xF5A623,
+        })),
+    },
+];
+
+fn hex(value: u32) -> Hsla {
+    rgb(value).into()
+}
+
+fn with_alpha(color: Hsla, alpha: f32) -> Hsla {
+    Hsla { a: alpha, ..color }
+}
+
+fn with_lightness(color: Hsla, lightness: f32) -> Hsla {
+    Hsla {
+        l: lightness.clamp(0.0, 1.0),
+        ..color
+    }
+}
+
+fn shift_lightness(color: Hsla, delta: f32) -> Hsla {
+    with_lightness(color, color.l + delta)
+}
+
+fn mix(base: Hsla, other: Hsla, amount: f32) -> Hsla {
+    let amount = amount.clamp(0.0, 1.0);
+    let base = Rgba::from(base);
+    let other = Rgba::from(other);
+    Hsla::from(Rgba {
+        r: base.r + (other.r - base.r) * amount,
+        g: base.g + (other.g - base.g) * amount,
+        b: base.b + (other.b - base.b) * amount,
+        a: base.a + (other.a - base.a) * amount,
+    })
+}
+
+fn luminance(color: Hsla) -> f32 {
+    let color = Rgba::from(color);
+    0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b
+}
+
 /// Waku's visual language, take two: neutral graphite surfaces in the spirit
 /// of Cursor — color is reserved for meaning. On macOS the sidebar's semantic
 /// tint is installed as a native layer above Sidebar vibrancy; keeping this
@@ -52,6 +510,11 @@ pub struct Theme {
     pub canvas: Hsla,
     pub sidebar: Hsla,
     pub sidebar_drag_background: Hsla,
+    /// The sidebar's own base color, painted as a native layer above Sidebar
+    /// vibrancy. It has to live in the palette rather than in the platform
+    /// layer: a themed canvas beside a fixed graphite sidebar reads as two
+    /// different apps.
+    pub sidebar_tint: Hsla,
     pub sidebar_item_background: Hsla,
     pub surface: Hsla,
     pub raised: Hsla,
@@ -73,6 +536,9 @@ pub struct Theme {
 
     /// Brand coral. Logo, caret, live-activity pulses — nothing structural.
     pub accent: Hsla,
+    /// Glyph laid directly on `accent`, flipped by the accent's own luminance
+    /// so a pale palette does not print white on near-white.
+    pub on_accent: Hsla,
     pub resize_handle: Hsla,
     /// Meter fills in the usage panel. Quota-meter blue by convention;
     /// warning/danger take over as a lane fills.
@@ -106,12 +572,117 @@ impl Theme {
         }
     }
 
+    /// Expand a palette's authored fields into every token the app reads. The
+    /// two branches mirror how depth reads in each mode: dark panels rise off
+    /// the canvas by getting lighter, light panels recede by getting darker,
+    /// and the composer is the one surface that goes the other way in light so
+    /// it stays paper against a tinted canvas.
+    pub fn from_seed(seed: ThemeSeed, is_dark: bool) -> Self {
+        let seed_surface = hex(seed.surface);
+        let ink = hex(seed.ink);
+        let accent = hex(seed.accent);
+        let contrast = f32::from(seed.contrast).clamp(0.0, 100.0) / 100.0;
+
+        let (canvas, raised, composer, inset) = if is_dark {
+            (
+                seed_surface,
+                shift_lightness(seed_surface, 0.035),
+                shift_lightness(seed_surface, 0.027),
+                shift_lightness(seed_surface, -0.020),
+            )
+        } else {
+            (
+                shift_lightness(seed_surface, -0.035),
+                shift_lightness(seed_surface, -0.070),
+                seed_surface,
+                shift_lightness(seed_surface, -0.100),
+            )
+        };
+        let terminal = if is_dark { inset } else { seed_surface };
+
+        let wash = hsla(
+            ink.h,
+            ink.s.min(0.12),
+            if is_dark { 0.90 } else { 0.12 },
+            1.0,
+        );
+
+        let text_base = canvas;
+        let warning = hex(seed.warning);
+
+        Self {
+            is_dark,
+            canvas,
+            sidebar: transparent_black(),
+            sidebar_drag_background: shift_lightness(canvas, -0.012),
+            sidebar_tint: shift_lightness(canvas, -0.012),
+            sidebar_item_background: with_alpha(
+                with_lightness(wash, if is_dark { 0.94 } else { 0.08 }),
+                0.06,
+            ),
+            surface: canvas,
+            raised,
+            composer,
+            inset,
+            terminal,
+            overlay: with_alpha(wash, 0.030 + contrast * 0.040),
+            overlay_strong: with_alpha(wash, 0.055 + contrast * 0.070),
+
+            border: with_alpha(wash, 0.040 + contrast * 0.060),
+            border_strong: with_alpha(wash, 0.080 + contrast * 0.120),
+            sidebar_border: if is_dark {
+                shift_lightness(canvas, 0.058)
+            } else {
+                with_alpha(wash, 0.12)
+            },
+
+            text: ink,
+            text_secondary: mix(text_base, ink, 0.60 + contrast * 0.17),
+            text_tertiary: mix(text_base, ink, 0.40 + contrast * 0.21),
+            text_ghost: mix(text_base, ink, 0.22 + contrast * 0.20),
+
+            accent,
+            on_accent: if luminance(accent) > 0.55 {
+                with_lightness(accent, 0.10)
+            } else {
+                with_lightness(with_alpha(accent, 1.0), 0.98)
+            },
+            resize_handle: accent,
+            gauge: accent,
+
+            selection: with_alpha(accent, if is_dark { 0.42 } else { 0.28 }),
+            code_text: hex(seed.skill),
+            code_wash: with_alpha(wash, 0.060 + contrast * 0.040),
+
+            inverse: if is_dark {
+                with_lightness(ink, 0.91)
+            } else {
+                with_lightness(ink, 0.13)
+            },
+            on_inverse: if is_dark {
+                with_lightness(canvas, 0.09)
+            } else {
+                with_lightness(canvas, 0.97)
+            },
+
+            warning,
+            success: hex(seed.added),
+            favorite: Hsla {
+                s: (warning.s * 1.6).min(1.0),
+                ..warning
+            },
+            danger: hex(seed.removed),
+            danger_soft: with_alpha(hex(seed.removed), 0.10),
+        }
+    }
+
     pub fn dark() -> Self {
         Self {
             is_dark: true,
             canvas: rgb(0x1A1A1A).into(),
             sidebar: transparent_black(),
             sidebar_drag_background: rgb(0x181818).into(),
+            sidebar_tint: rgb(0x181818).into(),
             sidebar_item_background: hsla(0.0, 0.0, 0.941, 0.06),
             surface: rgb(0x1A1A1A).into(),
             raised: rgb(0x232323).into(),
@@ -131,6 +702,7 @@ impl Theme {
             text_ghost: rgb(0x575757).into(),
 
             accent: rgb(0xE2795B).into(),
+            on_accent: rgb(0xFFFFFF).into(),
             resize_handle: rgb(0x3B82F6).into(),
             gauge: rgb(0x3B82F6).into(),
 
@@ -155,6 +727,7 @@ impl Theme {
             canvas: rgb(0xF6F5F6).into(),
             sidebar: transparent_black(),
             sidebar_drag_background: rgb(0xF3F3F3).into(),
+            sidebar_tint: rgb(0xF3F3F3).into(),
             sidebar_item_background: hsla(0.0, 0.0, 0.078, 0.06),
             surface: rgb(0xF6F5F6).into(),
             raised: rgb(0xECECEC).into(),
@@ -174,6 +747,7 @@ impl Theme {
             text_ghost: rgb(0xA4A4A4).into(),
 
             accent: rgb(0xC85F44).into(),
+            on_accent: rgb(0xFFFFFF).into(),
             resize_handle: rgb(0x2563EB).into(),
             gauge: rgb(0x2563EB).into(),
 
@@ -207,25 +781,99 @@ fn set_active_theme(theme: Theme, cx: &mut App) {
 /// Resolve and publish the startup palette, before any window exists.
 pub fn init(cx: &mut App) {
     let system_appearance = cx.window_appearance();
-    let theme = if ThemePreference::System.resolves_to_dark(system_appearance) {
-        Theme::dark()
-    } else {
-        Theme::light()
-    };
-    set_active_theme(theme, cx);
+    let is_dark = ThemePreference::System.resolves_to_dark(system_appearance);
+    set_active_theme(ThemeId::default().resolve(is_dark), cx);
 }
 
-pub fn apply_theme_preference(preference: ThemePreference, window: &mut Window, cx: &mut App) {
+pub fn apply_theme_preference(
+    preference: ThemePreference,
+    light_theme: ThemeId,
+    dark_theme: ThemeId,
+    window: &mut Window,
+    cx: &mut App,
+) {
     crate::platform::set_window_appearance(window, preference.native_override());
     let is_dark = preference.resolves_to_dark(cx.window_appearance());
-    set_active_theme(
-        if is_dark {
-            Theme::dark()
-        } else {
-            Theme::light()
-        },
-        cx,
-    );
-    crate::platform::configure_sidebar_material(window, is_dark);
+    let selected = if is_dark { dark_theme } else { light_theme };
+    let theme = selected.resolve(is_dark);
+    set_active_theme(theme, cx);
+    crate::platform::configure_sidebar_material(window, is_dark, theme.sidebar_tint);
     window.refresh();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_theme_offers_at_least_one_variant() {
+        for definition in THEMES {
+            assert!(
+                definition.light.is_some() || definition.dark.is_some(),
+                "{} registers no variant",
+                definition.label
+            );
+        }
+    }
+
+    #[test]
+    fn slugs_round_trip_and_are_unique() {
+        for definition in THEMES {
+            assert_eq!(
+                ThemeId::from_slug(definition.id.slug()),
+                Some(definition.id)
+            );
+        }
+        let mut slugs: Vec<_> = THEMES
+            .iter()
+            .map(|definition| definition.id.slug())
+            .collect();
+        slugs.sort_unstable();
+        let count = slugs.len();
+        slugs.dedup();
+        assert_eq!(slugs.len(), count);
+    }
+
+    #[test]
+    fn unknown_slug_falls_back_to_default() {
+        let id: ThemeId = serde_json::from_str("\"not-a-theme\"").unwrap();
+        assert_eq!(id, ThemeId::default());
+        assert_eq!(
+            serde_json::to_string(&ThemeId::TokyoNight).unwrap(),
+            "\"tokyo-night\""
+        );
+    }
+
+    #[test]
+    fn pickers_only_offer_supported_variants() {
+        assert!(!ThemeId::all_for(false).contains(&ThemeId::Dracula));
+        assert!(ThemeId::all_for(true).contains(&ThemeId::Dracula));
+        for is_dark in [false, true] {
+            for id in ThemeId::all_for(is_dark) {
+                assert_eq!(id.resolve(is_dark).is_dark, is_dark);
+            }
+        }
+    }
+
+    #[test]
+    fn derived_surfaces_separate_from_the_canvas() {
+        for is_dark in [false, true] {
+            for id in ThemeId::all_for(is_dark) {
+                let theme = id.resolve(is_dark);
+                assert_ne!(
+                    theme.raised,
+                    theme.canvas,
+                    "{} {} has a flat raised surface",
+                    id.slug(),
+                    is_dark
+                );
+                assert!(
+                    (luminance(theme.text) - luminance(theme.canvas)).abs() > 0.25,
+                    "{} {} text is too close to its canvas",
+                    id.slug(),
+                    is_dark
+                );
+            }
+        }
+    }
 }

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -188,6 +188,9 @@ struct MenuState {
     /// outside-click capture must leave that click alone so the later trigger
     /// handler can close it; a context-menu row has no such handler.
     trigger_click_toggles: bool,
+    /// AppKit is drawing this menu, so the site reports itself open — for a
+    /// trigger's pressed styling — while drawing no card of its own.
+    native: bool,
 }
 
 /// Cross-frame state for one context menu. The owner keeps one per menu site.
@@ -205,6 +208,11 @@ pub struct ContextMenuHandle {
     /// own on top.
     #[allow(clippy::type_complexity)]
     on_toggle: Rc<Vec<Rc<dyn Fn(bool, &mut Window, &mut App)>>>,
+    /// The site's item builder, recorded on every frame [`context_menu`]
+    /// renders, so a menu can also be raised from outside that call — a
+    /// keyboard trigger, or AppKit's own menu.
+    #[allow(clippy::type_complexity)]
+    items: Rc<RefCell<Option<Rc<dyn Fn(&mut App) -> Vec<MenuItem>>>>>,
 }
 
 impl ContextMenuHandle {
@@ -215,6 +223,7 @@ impl ContextMenuHandle {
             focus: cx.focus_handle(),
             trigger_bounds: Rc::new(Cell::new(None)),
             on_toggle: Rc::new(Vec::new()),
+            items: Rc::new(RefCell::new(None)),
         }
     }
 
@@ -257,6 +266,9 @@ impl ContextMenuHandle {
             .get()
             .map(|bounds| Point::new(bounds.left() + px(8.0), bounds.bottom()))
             .unwrap_or_else(|| window.mouse_position());
+        if open_native_menu(self, position, window, cx) {
+            return;
+        }
         open_menu(self, position, SurfaceFocus::Card, false, window, cx);
     }
 
@@ -267,6 +279,7 @@ impl ContextMenuHandle {
             state.open = None;
             state.highlighted = None;
             state.trigger_click_toggles = false;
+            state.native = false;
             was_open
         };
         if was_open {
@@ -349,6 +362,94 @@ fn open_menu(
         });
     }
     window.refresh();
+}
+
+/// Raise this site's menu as a real AppKit menu, returning whether it opened.
+///
+/// Falls back to the in-app card when there is no native window (tests), when
+/// the site has not rendered its item builder yet, or when the item list needs
+/// a drawn row that no `NSMenuItem` can carry.
+///
+/// AppKit's tracking loop blocks, so it runs from a foreground task rather than
+/// inside the event handler: by then GPUI holds no borrow, and the app keeps
+/// drawing and animating underneath the open menu.
+fn open_native_menu(
+    handle: &ContextMenuHandle,
+    position: Point<Pixels>,
+    window: &mut Window,
+    cx: &mut App,
+) -> bool {
+    // A test window has no platform window to ask, and answers the question by
+    // panicking rather than by failing, so it never gets asked.
+    if cfg!(test) {
+        return false;
+    }
+    let Some(native): Option<crate::platform::NativeContextMenu> =
+        crate::platform::prepare_context_menu(window)
+    else {
+        return false;
+    };
+    let Some(build) = handle.items.borrow().clone() else {
+        return false;
+    };
+    let items = build(cx);
+    if items
+        .iter()
+        .any(|item| matches!(item, MenuItem::Custom { .. }))
+    {
+        return false;
+    }
+
+    let entries: Vec<crate::platform::NativeMenuItem> = items
+        .iter()
+        .map(|item| match item {
+            MenuItem::Entry {
+                label,
+                selected,
+                disabled,
+                ..
+            } => crate::platform::NativeMenuItem {
+                label: label.to_string(),
+                enabled: !disabled,
+                checked: *selected,
+                separator: false,
+            },
+            MenuItem::Header(label) => crate::platform::NativeMenuItem {
+                label: label.to_string(),
+                enabled: false,
+                checked: false,
+                separator: false,
+            },
+            MenuItem::Separator | MenuItem::Custom { .. } => crate::platform::NativeMenuItem {
+                label: String::new(),
+                enabled: false,
+                checked: false,
+                separator: true,
+            },
+        })
+        .collect();
+    let actions: Vec<Option<Rc<dyn Fn(&mut Window, &mut App)>>> =
+        items.into_iter().map(MenuItem::click_handler).collect();
+
+    handle.open_at(position, false, window, cx);
+    handle.state.borrow_mut().native = true;
+    window.refresh();
+
+    let handle = handle.clone();
+    let mut async_window = window.to_async(cx);
+    cx.foreground_executor()
+        .spawn(async move {
+            let chosen = native.show(position, &entries);
+            let _ = async_window.update(|window, cx| {
+                handle.close(window, cx);
+                if let Some(action) = chosen.and_then(|index| actions[index].clone()) {
+                    action(window, cx);
+                }
+                window.refresh();
+            });
+        })
+        .detach();
+    true
 }
 
 /// A zero-cost canvas that records its parent's bounds into the handle.
@@ -844,7 +945,12 @@ where
     E: ParentElement + Styled + InteractiveElement + IntoElement + 'static,
 {
     let id: ElementId = id.into();
-    let open_at = handle.state.borrow().open;
+    let items: Rc<dyn Fn(&mut App) -> Vec<MenuItem>> = Rc::new(items);
+    *handle.items.borrow_mut() = Some(items.clone());
+    let (open_at, native) = {
+        let state = handle.state.borrow();
+        (state.open, state.native)
+    };
     let handle_for_down = handle.clone();
 
     let element = element
@@ -853,20 +959,22 @@ where
         .on_mouse_down(
             MouseButton::Right,
             move |event: &MouseDownEvent, window, cx| {
-                open_menu(
-                    &handle_for_down,
-                    event.position,
-                    SurfaceFocus::Card,
-                    false,
-                    window,
-                    cx,
-                );
+                if !open_native_menu(&handle_for_down, event.position, window, cx) {
+                    open_menu(
+                        &handle_for_down,
+                        event.position,
+                        SurfaceFocus::Card,
+                        false,
+                        window,
+                        cx,
+                    );
+                }
                 cx.stop_propagation();
                 window.prevent_default();
             },
         );
 
-    let Some(position) = open_at else {
+    let Some(position) = open_at.filter(|_| !native) else {
         return element.into_any_element();
     };
 
@@ -879,7 +987,7 @@ where
                     .child(MenuCard {
                         id,
                         handle: handle.clone(),
-                        items: Rc::new(items),
+                        items,
                     }),
             )
             .with_priority(1),


### PR DESCRIPTION
This pull request introduces several user interface and localization enhancements, as well as improvements to session and agent management in the application. The main changes include adding support for subagent viewing in the right panel, improvements to theme customization and localization, and better handling of queued messages when stopping a running turn.

**Right Panel and Subagent Management:**

- Added a new "Agents" surface to the right panel, allowing users to view and monitor subagents associated with a task. This includes new UI elements, iconography, and localized strings for the agents panel and its descriptions. [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R475-R477) [[2]](diffhunk://#diff-ef5768e6d9ed5034440f0565b851f833dd359b2c119df922b57d7f50cf0d6ef6R720) [[3]](diffhunk://#diff-ef5768e6d9ed5034440f0565b851f833dd359b2c119df922b57d7f50cf0d6ef6R732) [[4]](diffhunk://#diff-ef5768e6d9ed5034440f0565b851f833dd359b2c119df922b57d7f50cf0d6ef6R1867-R1869) [[5]](diffhunk://#diff-ef5768e6d9ed5034440f0565b851f833dd359b2c119df922b57d7f50cf0d6ef6R2318-R2325) [[6]](diffhunk://#diff-681a487f00ab4a5ee6626370cd26e3cb6ccae10eb9bf06af92b2d75536427f04R1045-R1048) [[7]](diffhunk://#diff-681a487f00ab4a5ee6626370cd26e3cb6ccae10eb9bf06af92b2d75536427f04R1124-R1133)

**Theme Customization and Localization:**

- Enhanced theme settings by adding options for light/dark palettes and a theme preview. These changes are fully localized in English, Japanese, and Chinese, with new strings and descriptions for each language. [[1]](diffhunk://#diff-681a487f00ab4a5ee6626370cd26e3cb6ccae10eb9bf06af92b2d75536427f04R143-R165) [[2]](diffhunk://#diff-7ebd161d0d8b0036c403f0b4c82fcd9b4349f84fea80eca785c825b7423bb22bR75-R83) [[3]](diffhunk://#diff-bfd7909c5b5509cfbff6cd57efed3123ded57c31f09ea5fbf2e2ce2628dff6a3R71-R79)
- Updated the theme application logic to support selecting specific light and dark themes, not just the system default. [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L60-R60) [[2]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L1626-R1635) [[3]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L1818-R1833)

**Composer and Subagent Conversations:**

- Improved the composer UI to display a read-only note when viewing a subagent conversation, clarifying that users cannot interact with subagents directly.

**Session and Message Queue Handling:**

- Refined the behavior when stopping a running turn: after stopping, any queued messages are now automatically resumed, improving the user experience when managing session interactions. [[1]](diffhunk://#diff-a8ccc95a829792c69e472889e7a82395e27a7a5f7a5ed397c67751c23f079916L2057-R2099) [[2]](diffhunk://#diff-915cdac396dc3b9b92919a6d30b2e5269da9cd3444a442d9fa82814f81092a7cL562-R562) [[3]](diffhunk://#diff-915cdac396dc3b9b92919a6d30b2e5269da9cd3444a442d9fa82814f81092a7cR852-R876) [[4]](diffhunk://#diff-287674aa1aacbb6cc734707b3ebae3df3381cb99d9ad660c65f384ad9a3e02ebR2177-R2184)

**Miscellaneous:**

- Minor UI improvements, such as using theme-based backgrounds for certain elements and filtering sessions more accurately in the command palette. [[1]](diffhunk://#diff-a8ccc95a829792c69e472889e7a82395e27a7a5f7a5ed397c67751c23f079916L407-R407) [[2]](diffhunk://#diff-3c202dc8fb273f0b72c374ffb00e9e04010494c58bf030a9b8c114c258fe1401L685-R685)

These changes collectively improve the application's usability, clarity, and customization capabilities.

fixes #68 