### PR TITLE
Refresh DeepSeek agent presets when selector opens

### DIFF
--- a/src/app/composer.rs
+++ b/src/app/composer.rs
@@ -1303,13 +1303,20 @@ impl Waku {
         let selected_id = self.agent_preset_for_session(session)?;
         let selected_label = self.agent_preset_label_for_session(session)?;
         let theme = Theme::current(cx);
-        let handle = self.menu_handle("agent-preset", cx);
+        let weak = cx.entity().downgrade();
+        let refresh_weak = weak.clone();
+        let handle = self.menu_handle_with("agent-preset", cx, move |open, _, cx| {
+            if open {
+                let _ = refresh_weak.update(cx, |this, _| {
+                    this.refresh_provider_model_discovery(ProviderKind::DeepSeek);
+                });
+            }
+        });
         let trigger = MenuChip::new("agent-preset")
             .icon("icons/bot.svg", theme.text_tertiary)
             .label(selected_label)
             .selected(handle.is_open());
 
-        let weak = cx.entity().downgrade();
         Some(dropdown_menu(
             trigger,
             "agent-preset-menu",

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -775,6 +775,17 @@ impl Waku {
         }
     }
 
+    /// Re-run one provider's model-owned catalog discovery, for selectors whose
+    /// contents can change while Waku stays open (for example, DeepSeek's
+    /// user-authored agent presets).
+    pub(super) fn refresh_provider_model_discovery(&mut self, provider: ProviderKind) {
+        if self.provider_model_discoveries_pending.contains(&provider) {
+            return;
+        }
+        self.provider_model_discoveries.remove(&provider);
+        self.request_provider_model_discovery(provider);
+    }
+
     /// Ask every installed CLI for its version, one short-lived subprocess per
     /// provider on its own thread. Answers land in `provider_versions` through
     /// the drain loop; render reads only that map.


### PR DESCRIPTION
## Problem

Waku cached provider-owned catalogs for the lifetime of the process, so a newly created DeepSeek agent preset did not appear in the Agent preset selector until a provider refresh or restart.

## Solution

Re-run DeepSeek catalog discovery whenever the Agent preset selector opens. The refresh is scoped to DeepSeek, avoids duplicate work while a discovery is pending, and lets the existing menu re-render with the latest preset list.

## Checks

- `cargo fmt --package waku -- --check`
- `cargo check`
- `cargo test` — 572 Waku tests and 10 JS REPL tests passed; 18 ignored
- Debug app rebuilt and relaunched through `bun run dev`

## Notes

This keeps the existing provider discovery architecture and does not affect active sessions.