### PR TITLE
fix: prevent Markdown user bubbles from collapsing

### DIFF
--- a/src/app/components.rs
+++ b/src/app/components.rs
@@ -677,6 +677,8 @@ pub(super) fn render_message(params: MessageRender, cx: &mut App) -> AnyElement 
                     let body = render_markdown_message_body(&content, markdown, theme, ctx);
                     column = column.child(
                         div()
+                            // Give nested Markdown a definite width for measurement.
+                            .w_full()
                             .max_w(px(540.0))
                             .min_w_0()
                             .rounded(px(12.0))


### PR DESCRIPTION
## Summary

- Give user Markdown message bubbles a definite width before rendering nested Markdown.
- Preserve the existing 540 px maximum width.

<details>
<summary>Reproduction details</summary>

Screenshot:

<!-- Drag and drop the screenshot into this section. -->

Trigger text:

```text
1. this
2. is
3. A
4. real test of things, this shouldn't be collapsed
```

Expected: the message remains a normal-width bubble with readable list rows.

Observed before the fix: the bubble collapsed into a very tall, narrow column.

</details>

## Why

List messages could collapse to the Markdown tree's intrinsic minimum width, roughly the list marker plus one glyph. This caused each character to wrap vertically into a very tall, narrow bubble.

The fixed width lets Markdown content measure against the available space while preserving the existing width limit.

## Validation

- `cargo test --lib md::` passed, 69 tests
- `rustfmt --edition 2024 --check src/app/components.rs`
- `git diff --check`
