### PR TITLE
Enable Claude Remote Control for stream-json sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ the original feature bullet instead of adding separate entries for them.
 - Restore window position, size, and display across launches
 - Contain wheel scrolling in activity and command output viewports
 - Smooth streaming markdown and reduce CPU usage while streaming
+- Enable Claude Remote Control so Desktop, claude.ai, and the mobile app can join the same local session
 
 ## [0.0.13]
 

--- a/apps/web/src/lib/event-reducer.test.ts
+++ b/apps/web/src/lib/event-reducer.test.ts
@@ -78,6 +78,37 @@ describe('reduceRuntimeEvent', () => {
     })
   })
 
+  test('mirrors a remote-control prompt into a new turn', () => {
+    const session = emptySession()
+    const next = apply(session, 'externalUserMessage', 'Prompt from Claude Desktop')
+
+    expect(next.status).toBe('working')
+    expect(next.auto_title).toBe('Prompt from Claude Desktop')
+    expect(next.turns).toHaveLength(1)
+    expect(next.turns[0]).toMatchObject({
+      status: 'running',
+      provider_turn_started: true,
+    })
+    expect(next.messages.at(-1)).toMatchObject({
+      role: 'user',
+      content: 'Prompt from Claude Desktop',
+      turn_id: next.turns[0]?.id,
+    })
+  })
+
+  test('folds a remote-control prompt into the live turn', () => {
+    const next = apply(runningSession(), 'externalUserMessage', 'steer from phone')
+
+    expect(next.status).toBe('working')
+    expect(next.turns).toHaveLength(1)
+    expect(next.messages.filter((message) => message.role === 'user')).toHaveLength(2)
+    expect(next.messages.at(-1)).toMatchObject({
+      role: 'user',
+      content: 'steer from phone',
+      turn_id: 'turn',
+    })
+  })
+
   test('records Claude resume position on the active turn', () => {
     const result = reduceRuntimeEvent(
       runningSession(),
@@ -233,5 +264,24 @@ function runningSession(): AgentSession {
         checkpoint: null,
       },
     ],
+  }
+}
+
+function emptySession(): AgentSession {
+  return {
+    id: 'session',
+    title: 'New task',
+    project_id: 'project',
+    workspace: { kind: 'local' },
+    provider: 'claude',
+    runtime_mode: 'fullAccess',
+    interaction_mode: 'build',
+    status: 'idle',
+    created_at: 100,
+    updated_at: 100,
+    provider_cursor: null,
+    messages: [],
+    transcript_blocks: [],
+    turns: [],
   }
 }

--- a/apps/web/src/lib/event-reducer.ts
+++ b/apps/web/src/lib/event-reducer.ts
@@ -89,6 +89,11 @@ export function reduceRuntimeEvent(
     case 'availableCommands':
       if (Array.isArray(payload)) session.available_commands = payload as ReportedCommand[]
       break
+    case 'externalUserMessage':
+      if (typeof payload === 'string' && payload.trim()) {
+        applyExternalUserMessage(session, payload, clock)
+      }
+      break
     case 'turnStarted': {
       const turn = activeTurn(session)
       if (turn) {
@@ -253,6 +258,64 @@ function asUserInputQuestion(value: unknown): PendingUserInput['questions'][numb
       : [],
     multiSelect: question.multiSelect === true,
   }
+}
+
+function applyExternalUserMessage(
+  session: AgentSession,
+  message: string,
+  clock: ReducerClock,
+) {
+  const turn = activeTurn(session)
+  if (turn) {
+    session.messages.push({
+      id: clock.randomUUID(),
+      turn_id: turn.id,
+      role: 'user',
+      content: message,
+      created_at: clock.nowSeconds(),
+      streaming: false,
+    })
+    turn.provider_turn_started = true
+  } else {
+    setTitleFromPrompt(session, message)
+    const id = clock.randomUUID()
+    session.turns.push({
+      id,
+      turn_count: session.turns.length + 1,
+      status: 'running',
+      provider_turn_started: true,
+      provider_resume_at: null,
+      started_at: clock.nowSeconds(),
+      completed_at: null,
+      checkpoint: null,
+    })
+    session.messages.push({
+      id: clock.randomUUID(),
+      turn_id: id,
+      role: 'user',
+      content: message,
+      created_at: clock.nowSeconds(),
+      streaming: false,
+    })
+    session.last_reply_at = clock.nowSeconds()
+  }
+  session.status = 'working'
+}
+
+function setTitleFromPrompt(session: AgentSession, prompt: string) {
+  if (
+    session.messages.length > 1
+    || session.title !== 'New task'
+    || session.auto_title
+  ) {
+    return
+  }
+  let title = prompt.split(/\s+/).filter(Boolean).slice(0, 7).join(' ')
+  if (!title) return
+  if ([...title].length > 54) {
+    title = `${[...title].slice(0, 53).join('')}…`
+  }
+  session.auto_title = title
 }
 
 function appendText(session: AgentSession, delta: string, clock: ReducerClock) {

--- a/crates/waku-core/src/claude_session.rs
+++ b/crates/waku-core/src/claude_session.rs
@@ -28,6 +28,10 @@ pub fn session_metadata(session_id: &str) -> anyhow::Result<ClaudeSessionMetadat
     session_metadata_in(&projects_directory()?, session_id)
 }
 
+pub(crate) fn session_file(session_id: &str) -> anyhow::Result<PathBuf> {
+    find_session_file(&projects_directory()?, session_id)
+}
+
 pub fn message_id_for_turn(session_id: &str, provider_turn_count: usize) -> anyhow::Result<String> {
     message_id_for_turn_in(&projects_directory()?, session_id, provider_turn_count)
 }

--- a/crates/waku-core/src/daemon.rs
+++ b/crates/waku-core/src/daemon.rs
@@ -1585,6 +1585,7 @@ fn event_to_wire(event: DriverEvent) -> anyhow::Result<WireDriverEvent> {
         DriverEvent::AvailableCommands(commands) => {
             ("availableCommands", serde_json::to_value(commands)?)
         }
+        DriverEvent::ExternalUserMessage(text) => ("externalUserMessage", Value::String(text)),
         DriverEvent::TurnStarted => ("turnStarted", Value::Null),
         DriverEvent::TextDelta(text) => ("textDelta", Value::String(text)),
         DriverEvent::ReasoningDelta(text) => ("reasoningDelta", Value::String(text)),
@@ -1674,6 +1675,7 @@ pub fn event_from_wire(event: WireDriverEvent) -> anyhow::Result<DriverEvent> {
         "agentPresetSelected" => DriverEvent::AgentPresetSelected(serde_json::from_value(payload)?),
         "autoTitleUpdated" => DriverEvent::AutoTitleUpdated(serde_json::from_value(payload)?),
         "availableCommands" => DriverEvent::AvailableCommands(serde_json::from_value(payload)?),
+        "externalUserMessage" => DriverEvent::ExternalUserMessage(serde_json::from_value(payload)?),
         "turnStarted" => DriverEvent::TurnStarted,
         "textDelta" => DriverEvent::TextDelta(serde_json::from_value(payload)?),
         "reasoningDelta" => DriverEvent::ReasoningDelta(serde_json::from_value(payload)?),
@@ -1921,6 +1923,16 @@ mod tests {
         assert!(matches!(
             event_from_wire(wire).unwrap(),
             DriverEvent::TextDelta(text) if text == "hello"
+        ));
+    }
+
+    #[test]
+    fn wire_event_round_trip_preserves_external_user_message() {
+        let wire = event_to_wire(DriverEvent::ExternalUserMessage("from desktop".into())).unwrap();
+        assert_eq!(wire.kind, "externalUserMessage");
+        assert!(matches!(
+            event_from_wire(wire).unwrap(),
+            DriverEvent::ExternalUserMessage(text) if text == "from desktop"
         ));
     }
 }

--- a/crates/waku-core/src/driver/claude.rs
+++ b/crates/waku-core/src/driver/claude.rs
@@ -14,10 +14,12 @@
 //! from `claude --help`.
 
 use std::collections::{HashMap, HashSet};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
+use std::time::Duration;
 
 use anyhow::{Context as _, anyhow};
 use crossbeam_channel::{Sender, unbounded};
@@ -36,6 +38,7 @@ use crate::model::{
 };
 
 enum CommandMessage {
+    EnableRemoteControl,
     Prompt(String),
     Steer(String),
     Cancel,
@@ -68,12 +71,105 @@ fn user_message_payload(text: &str) -> Value {
     })
 }
 
+fn external_user_text(value: &Value) -> Option<String> {
+    if value.get("isReplay").and_then(Value::as_bool) == Some(true)
+        || value.get("isSynthetic").and_then(Value::as_bool) == Some(true)
+        || value.pointer("/origin/kind").and_then(Value::as_str) != Some("human")
+        || value.get("shouldQuery").and_then(Value::as_bool) == Some(false)
+    {
+        return None;
+    }
+    let content = value.pointer("/message/content")?;
+    if let Some(text) = content
+        .as_str()
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+    {
+        return Some(text.to_owned());
+    }
+    let text = content
+        .as_array()?
+        .iter()
+        .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+        .filter_map(|block| block.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!text.trim().is_empty()).then_some(text)
+}
+
 fn stop_task_request(request_id: u64, task_id: &str) -> Value {
     json!({
         "type": "control_request",
         "request_id": format!("waku-{request_id}"),
         "request": {"subtype": "stop_task", "task_id": task_id}
     })
+}
+
+/// Claude's Agent SDK exposes this as the undocumented
+/// `query.enableRemoteControl(true)` method. The public `--remote-control`
+/// flag only activates the interactive terminal path and is a no-op under
+/// `--print`, while this control request enables the same bridge for a
+/// stream-json session.
+fn remote_control_request(request_id: u64) -> Value {
+    json!({
+        "type": "control_request",
+        "request_id": format!("waku-{request_id}"),
+        "request": {"subtype": "remote_control", "enabled": true}
+    })
+}
+
+fn handle_remote_transcript_entry(
+    value: &Value,
+    events: &impl DriverEventSink,
+    turn_active: &Mutex<bool>,
+) {
+    if value.get("type").and_then(Value::as_str) != Some("user") {
+        return;
+    }
+    let Some(text) = external_user_text(value) else {
+        return;
+    };
+    // Only the remote prompt is absent from stream-json stdout. Its assistant
+    // response and result are already emitted there and must keep their single
+    // canonical path, otherwise transcript tailing duplicates the answer.
+    *turn_active.lock() = true;
+    let _ = events.send(DriverEvent::ExternalUserMessage(text));
+}
+
+fn watch_remote_transcript(
+    session_id: String,
+    events: DriverEventSender,
+    turn_active: Arc<Mutex<bool>>,
+    alive: Arc<AtomicBool>,
+) {
+    let existing = crate::claude_session::session_file(&session_id).ok();
+    let mut path = existing.clone();
+    let mut offset = existing
+        .as_ref()
+        .and_then(|path| path.metadata().ok())
+        .map_or(0, |metadata| metadata.len());
+    while alive.load(Ordering::Acquire) {
+        if path.is_none() {
+            path = crate::claude_session::session_file(&session_id).ok();
+        }
+        if let Some(transcript) = path.as_ref()
+            && let Ok(mut file) = std::fs::File::open(transcript)
+            && file.seek(SeekFrom::Start(offset)).is_ok()
+        {
+            let mut appended = String::new();
+            if file.read_to_string(&mut appended).is_ok()
+                && let Some(complete_len) = appended.rfind('\n').map(|index| index + 1)
+            {
+                for line in appended[..complete_len].lines() {
+                    if let Ok(value) = serde_json::from_str::<Value>(line) {
+                        handle_remote_transcript_entry(&value, &events, &turn_active);
+                    }
+                }
+                offset += complete_len as u64;
+            }
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
 }
 
 pub struct ClaudeDriver {
@@ -227,6 +323,24 @@ impl ClaudeDriver {
         let turn_active = Arc::new(Mutex::new(false));
         let pending_task_stops = Arc::new(Mutex::new(HashMap::<String, BackgroundWorkKey>::new()));
         let pending_user_inputs = Arc::new(Mutex::new(HashMap::<String, Value>::new()));
+        let process_alive = Arc::new(AtomicBool::new(true));
+
+        let transcript_thread = {
+            let transcript_events = events.clone();
+            let transcript_session = session_id.clone();
+            let transcript_turn = turn_active.clone();
+            let transcript_alive = process_alive.clone();
+            thread::Builder::new()
+                .name("waku-claude-transcript".into())
+                .spawn(move || {
+                    watch_remote_transcript(
+                        transcript_session,
+                        transcript_events,
+                        transcript_turn,
+                        transcript_alive,
+                    );
+                })?
+        };
 
         let reader_events = events.clone();
         let reader_commands = commands.clone();
@@ -272,6 +386,10 @@ impl ClaudeDriver {
                 let mut current_model = launch_model;
                 while let Ok(message) = command_rx.recv() {
                     let written = match message {
+                        CommandMessage::EnableRemoteControl => {
+                            next_request_id += 1;
+                            write_line(&mut stdin, &remote_control_request(next_request_id))
+                        }
                         CommandMessage::Prompt(text) => {
                             *writer_turn.lock() = true;
                             let _ = writer_events.send(DriverEvent::TurnStarted);
@@ -455,6 +573,14 @@ impl ClaudeDriver {
                 }
             })?;
 
+        // Queue this before returning the driver so it necessarily precedes
+        // the first prompt a caller can submit. This is the same wire request
+        // Claude Agent SDK sends from `enableRemoteControl(true)` once its
+        // query transport exists; it does not need the interactive CLI path.
+        commands
+            .send(CommandMessage::EnableRemoteControl)
+            .context("failed to enable Claude Remote Control")?;
+
         let last_visible_stderr = Arc::new(Mutex::new(None::<String>));
         let stderr_last_error = last_visible_stderr.clone();
         let stderr_events = events.clone();
@@ -477,8 +603,10 @@ impl ClaudeDriver {
             .name("waku-claude-process".into())
             .spawn(move || {
                 let status = child.wait();
+                process_alive.store(false, Ordering::Release);
                 let _ = reader_thread.join();
                 let _ = stderr_thread.join();
+                let _ = transcript_thread.join();
                 if let Ok(status) = status
                     && !status.success()
                     && last_visible_stderr.lock().is_none()
@@ -1651,6 +1779,79 @@ mod tests {
                 "request": {"subtype": "stop_task", "task_id": "agent-42"}
             })
         );
+    }
+
+    #[test]
+    fn remote_control_uses_claudes_sdk_control_request() {
+        assert_eq!(
+            remote_control_request(3),
+            json!({
+                "type": "control_request",
+                "request_id": "waku-3",
+                "request": {"subtype": "remote_control", "enabled": true}
+            })
+        );
+    }
+
+    #[test]
+    fn remote_control_transcript_prompt_is_mirrored_into_waku() {
+        let (events, event_rx, _commands, _command_rx, turn, _state) = harness();
+        *turn.lock() = false;
+        handle_remote_transcript_entry(
+            &json!({
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": "Интересно, а дойдет ли ответ?"
+                },
+                "origin": {"kind": "human"},
+                "uuid": "remote-user"
+            }),
+            &events,
+            &turn,
+        );
+        assert!(*turn.lock());
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(DriverEvent::ExternalUserMessage(message))
+                if message == "Интересно, а дойдет ли ответ?"
+        ));
+
+        // The assistant entry is intentionally ignored here: Claude already
+        // emits that answer and its result on stream-json stdout.
+        handle_remote_transcript_entry(
+            &json!({
+                "type": "assistant",
+                "uuid": "remote-assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Дойдёт."}],
+                    "stop_reason": "end_turn"
+                }
+            }),
+            &events,
+            &turn,
+        );
+        assert!(event_rx.try_recv().is_err());
+        assert!(*turn.lock());
+    }
+
+    #[test]
+    fn local_waku_prompt_is_not_imported_from_native_transcript() {
+        let (events, event_rx, _commands, _command_rx, turn, _state) = harness();
+        *turn.lock() = false;
+        handle_remote_transcript_entry(
+            &json!({
+                "type": "user",
+                "message": {"role": "user", "content": [{"type": "text", "text": "go"}]},
+                "uuid": "local-user"
+            }),
+            &events,
+            &turn,
+        );
+
+        assert!(!*turn.lock());
+        assert!(event_rx.try_recv().is_err());
     }
 
     #[test]

--- a/crates/waku-protocol/src/driver_wire.rs
+++ b/crates/waku-protocol/src/driver_wire.rs
@@ -34,6 +34,7 @@ pub fn event_to_wire(event: DriverEvent) -> anyhow::Result<WireDriverEvent> {
         DriverEvent::AvailableCommands(commands) => {
             ("availableCommands", serde_json::to_value(commands)?)
         }
+        DriverEvent::ExternalUserMessage(text) => ("externalUserMessage", Value::String(text)),
         DriverEvent::TurnStarted => ("turnStarted", Value::Null),
         DriverEvent::TextDelta(text) => ("textDelta", Value::String(text)),
         DriverEvent::ReasoningDelta(text) => ("reasoningDelta", Value::String(text)),
@@ -123,6 +124,7 @@ pub fn event_from_wire(event: WireDriverEvent) -> anyhow::Result<DriverEvent> {
         "agentPresetSelected" => DriverEvent::AgentPresetSelected(serde_json::from_value(payload)?),
         "autoTitleUpdated" => DriverEvent::AutoTitleUpdated(serde_json::from_value(payload)?),
         "availableCommands" => DriverEvent::AvailableCommands(serde_json::from_value(payload)?),
+        "externalUserMessage" => DriverEvent::ExternalUserMessage(serde_json::from_value(payload)?),
         "turnStarted" => DriverEvent::TurnStarted,
         "textDelta" => DriverEvent::TextDelta(serde_json::from_value(payload)?),
         "reasoningDelta" => DriverEvent::ReasoningDelta(serde_json::from_value(payload)?),

--- a/crates/waku-protocol/src/model.rs
+++ b/crates/waku-protocol/src/model.rs
@@ -1559,6 +1559,10 @@ pub enum DriverEvent {
     /// Authoritative over filesystem discovery, which cannot see plugin or
     /// dynamically registered commands.
     AvailableCommands(Vec<ReportedCommand>),
+    /// A human prompt entered through a provider-owned secondary client, such
+    /// as Claude Remote Control. The app creates a turn for it (or folds it
+    /// into the live turn) before accepting the following provider output.
+    ExternalUserMessage(String),
     TurnStarted,
     TextDelta(String),
     ReasoningDelta(String),

--- a/docs/claude-remote-control.md
+++ b/docs/claude-remote-control.md
@@ -1,0 +1,222 @@
+# Claude Remote Control from an Agent SDK host
+
+This note documents a working way for an application that embeds Claude Code
+through the Claude Agent SDK (or drives its `stream-json` protocol directly) to
+make the same local session available in Claude Desktop, claude.ai, and the
+Claude mobile app. It is intended as an implementation handoff for T3 Code,
+Synara, and similar agent hosts.
+
+The behavior below was verified on August 12, 2026 with Claude Code 2.1.228 and
+`@anthropic-ai/claude-agent-sdk` 0.3.170. Remote Control is an official Claude
+Code feature, but the SDK method used to enable it is currently undocumented.
+Treat the exact method and event shapes as version-sensitive.
+
+## The important part: do not pass `--remote-control` to `query()`
+
+Passing `--remote-control` as an SDK `extraArgs` flag is a silent no-op. The
+flag is handled by Claude Code's interactive terminal startup path, which is
+not the path used by Agent SDK `query()` sessions.
+
+Once the SDK query object exists, enable the bridge with its runtime method:
+
+```ts
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+const session = query({
+  prompt: promptStream,
+  options: {
+    // regular Agent SDK options
+  },
+});
+
+type QueryWithRemoteControl = typeof session & {
+  enableRemoteControl?: (enabled: boolean, name?: string) => Promise<unknown>;
+};
+
+await session.initializationResult();
+await (session as QueryWithRemoteControl).enableRemoteControl?.(
+  true,
+  "Synara: task name",
+);
+```
+
+The optional method is not in the public `Query` type, but in SDK 0.3.170 its
+implementation sends this control request:
+
+```json
+{
+  "type": "control_request",
+  "request_id": "host-generated-id",
+  "request": {
+    "subtype": "remote_control",
+    "enabled": true,
+    "name": "Synara: task name"
+  }
+}
+```
+
+A host that drives the Claude Code executable directly does not need the SDK
+dependency. Send the same JSON line on the existing `stream-json` stdin after
+the process transport is ready and before the first user prompt. A caller-chosen
+`--session-id <uuid>` continues to work and is useful for binding the provider
+session to the host's thread.
+
+Do not bypass Claude's policy result. The CLI checks account availability and
+the organization's `allow_remote_control` policy itself. Surface a refusal or
+error to the user rather than retrying around it.
+
+## Connection state
+
+Successful activation produces a system event whose subtype has appeared as
+both `bridge_state` and `bridge_status` across builds. Handle both defensively.
+The tested direct transport received:
+
+```json
+{
+  "type": "system",
+  "subtype": "bridge_state",
+  "state": "ready"
+}
+```
+
+Do not depend on a connection URL being present. Depending on the build, URL
+fields have been observed or reported as `url`, `session_url`, `sessionUrl`, or
+`bridgeUrl`, and a ready event may contain no URL at all. Once ready, the
+session normally appears in the authenticated Claude clients without the host
+opening a URL.
+
+## Transcript synchronization is asymmetric
+
+After activation, the normal SDK/`stream-json` output remains the canonical
+source for Claude activity:
+
+- assistant text and thinking;
+- tool calls and tool results;
+- permissions and other control requests;
+- usage and the final result event.
+
+This is why existing SDK rendering continues to work in the remote-controlled
+turn, including thinking and tool activity.
+
+There is one important exception in the tested Claude Code build: a human
+prompt submitted from Claude Desktop was persisted to Claude's native JSONL
+transcript but was not emitted as a user message on the host's `stream-json`
+stdout. The assistant response *was* emitted on stdout.
+
+Consequently, importing both sides of the remote turn from the JSONL file will
+duplicate the assistant response. The working ownership split is:
+
+| Content | Canonical source |
+|---|---|
+| Prompt submitted by the embedding host | Host's own submission state |
+| Prompt submitted through Remote Control | Claude native JSONL transcript |
+| Assistant text, thinking, and tools | SDK/`stream-json` stdout |
+| Turn completion/result | SDK/`stream-json` stdout |
+
+## Mirroring Remote Control prompts without duplicates
+
+Claude stores a session under its configuration directory:
+
+```text
+$CLAUDE_CONFIG_DIR/projects/<encoded-cwd>/<session-id>.jsonl
+```
+
+When `CLAUDE_CONFIG_DIR` is unset, the default is:
+
+```text
+~/.claude/projects/<encoded-cwd>/<session-id>.jsonl
+```
+
+Recommended algorithm:
+
+1. Start the Claude process with a known session UUID.
+2. Locate `<session-id>.jsonl` below the configured `projects` directory. The
+   file may not exist until Claude writes the first transcript entry.
+3. If resuming an existing session, initialize the reader at EOF. Do not import
+   its old history again.
+4. Tail only newly appended, newline-terminated JSON records on a background
+   thread/task. Never do filesystem I/O from a render path.
+5. Import only a new external human `type: "user"` prompt.
+6. Create the host-side turn before accepting the assistant deltas that follow
+   on stdout.
+7. Ignore assistant JSONL records. Continue consuming assistant output and the
+   final result exclusively from the SDK/`stream-json` stream.
+
+In the tested transcript, a Desktop prompt had this distinguishing shape:
+
+```json
+{
+  "type": "user",
+  "origin": { "kind": "human" },
+  "message": {
+    "role": "user",
+    "content": "Prompt sent from Claude Desktop"
+  }
+}
+```
+
+A prompt submitted by the embedding host was persisted with no `origin` and
+usually had `message.content` as an array of content blocks. This distinction
+worked for Claude Code 2.1.228, but it is not a documented persistence contract.
+Keep the detector narrow, test it against real provider payloads after CLI
+updates, and never treat peer/channel/task-notification messages as human UI
+input.
+
+Also exclude:
+
+- `isReplay: true` messages, which acknowledge host stdin when
+  `--replay-user-messages` is enabled;
+- `isSynthetic: true` messages;
+- `shouldQuery: false` messages;
+- user-role tool-result records;
+- sidechain/subagent transcript entries.
+
+A robust tailer should retain incomplete trailing bytes until the next read,
+handle file truncation or replacement, stop with the provider process, and
+deduplicate imported prompt UUIDs. Polling at roughly 100 ms is sufficient for
+chat UI latency; a filesystem watcher is also suitable if it coalesces writes
+and still parses only complete lines.
+
+## Turn lifecycle
+
+When the tailer observes a Remote Control prompt:
+
+1. append the user message to the host transcript;
+2. create or mark the host turn as running;
+3. allow normal stdout assistant/thinking/tool events into that turn;
+4. finish it only when the normal SDK result event arrives.
+
+If an external prompt appears while the host already has an active turn, the
+product must choose an explicit policy. Folding it into the active turn matches
+Claude steering semantics; creating a competing foreground turn usually breaks
+transcript ownership and completion bookkeeping.
+
+## Operational and compatibility notes
+
+- The local Claude process must stay alive for Remote Control to stay online.
+- Extended network loss can terminate the bridge.
+- Permissions still belong to the same local Claude process and configured
+  permission mode.
+- Remote Control availability depends on the user's plan and organization
+  policy.
+- Pin or test supported Claude Code versions because `enableRemoteControl`,
+  bridge events, and the native transcript shape are not stable SDK contracts.
+- Reading the user's own local transcript does not add network access or bypass
+  authentication, but the host must protect that data like any other local chat
+  history.
+
+## Prior art
+
+T3 Code explored this in
+[PR #4666](https://github.com/pingdotgg/t3code/pull/4666). Its
+[commit `2ed6a86`](https://github.com/pingdotgg/t3code/commit/2ed6a86b219dfd7248548eeda97b79bd9b26b569)
+identified the SDK runtime method after confirming that the CLI flag under
+`query()` was inert. The PR was closed because its orchestration-v1 base was
+being replaced, not because Remote Control failed.
+
+Anthropic documents Remote Control as an official Claude Code workflow and
+supports enabling it for all sessions, but does not currently document the
+Agent SDK method described above:
+
+- [Claude Code power-user tips: Mobile and Remote Control](https://support.claude.com/en/articles/14554000-claude-code-power-user-tips)
+- [Claude Code CLI reference](https://docs.anthropic.com/en/docs/claude-code/cli-usage)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -356,6 +356,14 @@ rather than at write time. Verified against the real CLI by injecting an
 instruction while a Bash `sleep` ran: the same turn's reply honored it. Amp
 was probed the same way and behaves differently — see its section.
 
+**Remote Control** — after the stream-json transport is up, Waku sends the same
+undocumented `control_request` / `subtype: "remote_control"` that the Agent SDK
+sends from `enableRemoteControl(true)`. The public `--remote-control` flag is
+a no-op under `--print`. Assistant text, thinking, tools, and the result stay
+on stdout; a human prompt from Claude Desktop/mobile is tailed from Claude's
+native JSONL transcript and emitted as `ExternalUserMessage`. See
+[claude-remote-control.md](./claude-remote-control.md).
+
 **Model changes** — a `control_request` with `subtype: "set_model"`, so switching
 models keeps the session. The permission posture is a launch flag and still
 restarts.

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -3298,6 +3298,7 @@ impl Waku {
                     DriverEvent::Connected { .. }
                         | DriverEvent::AgentPresetSelected(_)
                         | DriverEvent::AutoTitleUpdated(_)
+                        | DriverEvent::ExternalUserMessage(_)
                         | DriverEvent::Permission { .. }
                         | DriverEvent::SteerAccepted { .. }
                         | DriverEvent::SteerRejected { .. }

--- a/src/app/streaming.rs
+++ b/src/app/streaming.rs
@@ -272,6 +272,21 @@ impl Waku {
                     self.composer_sources_stale = true;
                 }
             }
+            DriverEvent::ExternalUserMessage(message) => {
+                runtime.last_driver_error = None;
+                if let Some(session) = self.state.session_mut(session_id) {
+                    if session.active_turn_id().is_some() {
+                        session.push_user_message_with_presentation(message, None, Vec::new());
+                    } else {
+                        session.set_title_from_prompt(&message);
+                        session.begin_turn_with_presentation(message, None, Vec::new());
+                    }
+                    session.mark_active_turn_provider_started();
+                    session.status = SessionStatus::Working;
+                    session.updated_at = unix_time();
+                    self.state.mark_session_dirty(session_id);
+                }
+            }
             DriverEvent::TurnStarted => {
                 runtime.last_driver_error = None;
                 if let Some(session) = self.state.session_mut(session_id)


### PR DESCRIPTION
## Summary

Lets a local Claude Code session started by Waku join Claude Desktop, claude.ai, and the mobile app (Remote Control).

`--remote-control` is a no-op on the Agent SDK / `stream-json` path. After the transport is up this sends the undocumented control request the SDK uses internally:

```json
{
  "type": "control_request",
  "request_id": "…",
  "request": { "subtype": "remote_control", "enabled": true, "name": "…" }
}
```

Waku then tails Claude's native JSONL so user turns typed in Desktop/mobile appear in the transcript without duplicating assistant output.

Details and the ownership split (SDK host vs transcript tailer): `docs/claude-remote-control.md`.

Verified earlier against Claude Code 2.1.228 / `@anthropic-ai/claude-agent-sdk` 0.3.170. The control method is unofficial — treat shapes as version-sensitive.

## Test plan

- [ ] Start a Claude session in Waku, confirm Remote Control is advertised in Desktop / claude.ai / mobile
- [ ] Type a user message from Desktop or mobile; it should land as a user turn in Waku
- [ ] Assistant text should not be duplicated
- [ ] A session without Remote Control still streams normally