### PR TITLE
Support building and running waku-core on Windows

### DIFF
--- a/crates/waku-core/src/checkpoint.rs
+++ b/crates/waku-core/src/checkpoint.rs
@@ -761,17 +761,16 @@ where
 }
 
 fn command_error(output: &Output) -> String {
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    if stderr.is_empty() {
-        format!("git exited with {}", output.status)
-    } else {
-        stderr
-    }
+    crate::command_env::failure_detail(output)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt as _;
+    #[cfg(windows)]
+    use std::os::windows::process::ExitStatusExt as _;
 
     fn git_ok(cwd: &Path, args: &[&str]) {
         let status = Command::new("git")
@@ -796,6 +795,11 @@ mod tests {
         let directory = std::env::temp_dir().join(format!("waku-checkpoints-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
         git_ok(&directory, &["init", "--quiet", "--initial-branch=main"]);
+        // The system gitconfig may set `core.autocrlf` (Windows installs
+        // default to `true`), which would rewrite restored files to CRLF and
+        // break byte-for-byte assertions. Pin the repository's line-ending
+        // behavior so the test is deterministic on every machine.
+        git_ok(&directory, &["config", "core.autocrlf", "false"]);
         git_ok(&directory, &["config", "user.name", "Waku Test"]);
         git_ok(&directory, &["config", "user.email", "waku@example.com"]);
         fs::write(directory.join("shared.txt"), "shared\n").unwrap();
@@ -820,6 +824,7 @@ mod tests {
         let directory = std::env::temp_dir().join(format!("waku-checkpoints-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
         git_ok(&directory, &["init", "--quiet"]);
+        git_ok(&directory, &["config", "core.autocrlf", "false"]);
         fs::write(directory.join("tracked.txt"), "baseline\n").unwrap();
         git_ok(&directory, &["add", "tracked.txt"]);
         git_ok(
@@ -860,6 +865,7 @@ mod tests {
         let directory = std::env::temp_dir().join(format!("waku-checkpoints-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
         git_ok(&directory, &["init", "--quiet"]);
+        git_ok(&directory, &["config", "core.autocrlf", "false"]);
         fs::write(directory.join("tracked.txt"), "baseline\n").unwrap();
         git_ok(&directory, &["add", "tracked.txt"]);
         git_ok(
@@ -935,6 +941,7 @@ mod tests {
         let directory = std::env::temp_dir().join(format!("waku-checkpoints-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
         git_ok(&directory, &["init", "--quiet"]);
+        git_ok(&directory, &["config", "core.autocrlf", "false"]);
         fs::write(directory.join("tracked.txt"), "baseline\n").unwrap();
         git_ok(&directory, &["add", "tracked.txt"]);
         git_ok(
@@ -1120,5 +1127,36 @@ mod tests {
         assert_eq!(second.files.len(), 1);
         assert_eq!(second.files[0].path, "second-turn.txt");
         fs::remove_dir_all(directory).ok();
+    }
+
+    #[test]
+    fn command_error_leads_with_failure_lines_over_warnings() {
+        // Reproduces a surfaced Windows checkpoint failure: dozens of
+        // "LF will be replaced by CRLF" warnings burying the two `error:`
+        // lines that name the real problem.
+        let stderr = b"warning: in the working copy of 'src/lib.rs', LF will be replaced by CRLF the next time Git touches it\n\
+warning: in the working copy of 'src/main.rs', LF will be replaced by CRLF the next time Git touches it\n\
+error: invalid path 'nul'\n\
+error: unable to add 'nul' to index\n\
+fatal: adding files failed\n";
+        let output = Output {
+            status: std::process::ExitStatus::from_raw(128),
+            stdout: Vec::new(),
+            stderr: stderr.to_vec(),
+        };
+        assert_eq!(
+            command_error(&output),
+            "error: invalid path 'nul'\nerror: unable to add 'nul' to index\nfatal: adding files failed"
+        );
+    }
+
+    #[test]
+    fn command_error_falls_back_to_plain_stderr() {
+        let output = Output {
+            status: std::process::ExitStatus::from_raw(1),
+            stdout: Vec::new(),
+            stderr: b"some unexpected diagnostic\n".to_vec(),
+        };
+        assert_eq!(command_error(&output), "some unexpected diagnostic");
     }
 }

--- a/crates/waku-core/src/command_env.rs
+++ b/crates/waku-core/src/command_env.rs
@@ -64,6 +64,43 @@ pub fn output(command: &mut Command) -> io::Result<Output> {
     spawn(command)?.wait_with_output()
 }
 
+/// Format a failed command's stderr for display, leading with the lines that
+/// name the actual failure.
+///
+/// Git mixes actionable failures in with unrelated warnings — most commonly
+/// the "LF will be replaced by CRLF" noise a system-wide `core.autocrlf=true`
+/// produces on Windows, which can bury the two `error:`/`fatal:` lines under
+/// dozens of warnings in a surfaced checkpoint or branch error. When failure
+/// lines are present they lead and the warnings drop away; otherwise the
+/// trimmed stderr keeps today's behavior.
+pub fn failure_detail(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if let Some(failures) = failure_lines(&stderr) {
+        return failures;
+    }
+    let stderr = stderr.trim();
+    if stderr.is_empty() {
+        format!("process exited with {}", output.status)
+    } else {
+        stderr.to_owned()
+    }
+}
+
+/// The `error:`/`fatal:` lines of a command's stderr, joined, when there are
+/// any. See [`failure_detail`] for why warnings are dropped around them.
+pub fn failure_lines(stderr: &str) -> Option<String> {
+    let failure_lines: Vec<&str> = stderr
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("error:") || line.starts_with("fatal:"))
+        .collect();
+    if failure_lines.is_empty() {
+        None
+    } else {
+        Some(failure_lines.join("\n"))
+    }
+}
+
 /// Normalize a Waku-owned provider thread before a dependency spawns the child
 /// internally. The ACP SDK owns its `async_process::Command`, so its dedicated
 /// connection thread uses this once at startup instead of [`spawn`].
@@ -141,7 +178,61 @@ pub fn find_executable(name: &str) -> Option<PathBuf> {
     executable_search_paths()
         .into_iter()
         .map(|directory| directory.join(name))
+        .flat_map(executable_candidates)
         .find(|candidate| candidate.is_file())
+}
+
+/// Windows names executables with a `PATHEXT` suffix (`grok.exe`, `grok.cmd`);
+/// Unix ships a bare `grok` file. Expand a bare command name to the suffixes
+/// the platform would actually spawn.
+///
+/// On Windows the PATHEXT-suffixed names come first and the bare name is a
+/// last-resort fallback: npm's Windows installs drop an extensionless Unix
+/// launcher (`pi`) beside the `pi.cmd` Windows can actually spawn, and
+/// resolving the bare file first makes a provider look installed while every
+/// `Command::new` fails with `ERROR_BAD_EXE_FORMAT`. On Unix the extension
+/// list is empty, so the bare file stays the only candidate.
+fn executable_candidates(base: PathBuf) -> Vec<PathBuf> {
+    let mut candidates = executable_extensions()
+        .into_iter()
+        .map(|extension| base.with_extension(extension))
+        .collect::<Vec<_>>();
+    candidates.push(base);
+    candidates
+}
+
+#[cfg(windows)]
+fn executable_extensions() -> Vec<String> {
+    // `Command::new` also consults `PATHEXT` when spawning a bare name, so
+    // mirror the same suffixes for discovery. Fall back to the common set
+    // when the variable is absent.
+    std::env::var_os("PATHEXT")
+        .map(|extensions| {
+            std::env::split_paths(&extensions)
+                .filter_map(|extension| {
+                    extension
+                        .to_str()
+                        .map(str::trim)
+                        .filter(|extension| !extension.is_empty())
+                        .map(str::to_owned)
+                })
+                .collect::<Vec<_>>()
+        })
+        .filter(|extensions| !extensions.is_empty())
+        .unwrap_or_else(|| {
+            [".EXE", ".CMD", ".BAT"]
+                .into_iter()
+                .map(str::to_owned)
+                .collect()
+        })
+        .into_iter()
+        .map(|extension| extension.trim_start_matches('.').to_owned())
+        .collect()
+}
+
+#[cfg(not(windows))]
+fn executable_extensions() -> Vec<String> {
+    Vec::new()
 }
 
 /// Resolve a user-supplied binary override: `~` expands to the home
@@ -459,10 +550,32 @@ impl Drop for ShellEnvironmentCapture {
 mod tests {
     use super::*;
 
+    #[cfg(windows)]
+    #[test]
+    fn windows_prefers_pathext_candidates_over_the_bare_name() {
+        // npm's Windows installs ship an extensionless Unix launcher (`pi`)
+        // beside the `pi.cmd` that actually runs; resolving the bare file
+        // first marks the provider installed while every spawn fails.
+        let names = executable_candidates(PathBuf::from("pi"))
+            .iter()
+            .map(|candidate| candidate.to_string_lossy().to_ascii_lowercase())
+            .collect::<Vec<_>>();
+
+        let cmd = names.iter().position(|name| name == "pi.cmd");
+        let bare = names.iter().position(|name| name == "pi");
+        assert!(cmd.is_some(), "PATHEXT candidates must include pi.cmd: {names:?}");
+        assert!(bare.is_some(), "the bare name stays a fallback: {names:?}");
+        assert!(
+            cmd < bare,
+            "pi.cmd must be tried before the bare pi: {names:?}"
+        );
+    }
+
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
     #[test]
+    #[cfg(unix)]
     fn output_captures_stdout_and_stderr() {
         let mut command = Command::new("/bin/sh");
         command.args(["-c", "printf stdout; printf stderr >&2"]);
@@ -533,6 +646,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn launch_services_path_is_extended_for_script_based_clis() {
         let home = Path::new("/Users/example");
         let paths = search_paths_from(None, Some(OsStr::new("/usr/bin:/bin")), Some(home));
@@ -552,6 +666,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn login_shell_path_precedes_the_inherited_desktop_path() {
         let paths = search_paths_from(
             Some(OsStr::new(

--- a/crates/waku-core/src/composer_complete.rs
+++ b/crates/waku-core/src/composer_complete.rs
@@ -1277,6 +1277,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn symlinked_skills_and_command_dirs_are_discovered() {
         let root = std::env::temp_dir().join(format!("waku-symlink-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);

--- a/crates/waku-core/src/computer_use.rs
+++ b/crates/waku-core/src/computer_use.rs
@@ -2,6 +2,7 @@
 
 use std::fs;
 use std::io::Write as _;
+#[cfg(unix)]
 use std::os::unix::fs::DirBuilderExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -269,9 +270,11 @@ fn install_helper_app(source: &Path) -> anyhow::Result<PathBuf> {
     let application_support =
         dirs::data_dir().ok_or_else(|| anyhow!("Application Support directory is unavailable"))?;
     let install_root = application_support.join("Waku").join("Computer Use");
-    fs::DirBuilder::new()
-        .recursive(true)
-        .mode(0o700)
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    builder.mode(0o700);
+    builder
         .create(&install_root)
         .with_context(|| format!("could not create {}", install_root.display()))?;
     let bundle_name = source
@@ -327,7 +330,10 @@ fn copy_directory(source: &Path, destination: &Path) -> anyhow::Result<()> {
         if file_type.is_dir() {
             copy_directory(&source_path, &destination_path)?;
         } else if file_type.is_symlink() {
+            #[cfg(unix)]
             std::os::unix::fs::symlink(fs::read_link(&source_path)?, &destination_path)?;
+            #[cfg(not(unix))]
+            fs::copy(&source_path, &destination_path)?;
         } else {
             fs::copy(&source_path, &destination_path)?;
             fs::set_permissions(

--- a/crates/waku-core/src/driver/acp.rs
+++ b/crates/waku-core/src/driver/acp.rs
@@ -198,6 +198,7 @@ fn sdk_agent(
     let binary = binary
         .to_str()
         .ok_or_else(|| anyhow!("the ACP executable path is not valid UTF-8"))?;
+    #[cfg(unix)]
     let cwd = cwd
         .to_str()
         .ok_or_else(|| anyhow!("the ACP working directory is not valid UTF-8"))?;
@@ -219,11 +220,20 @@ fn sdk_agent(
     // `AcpAgentConfig` deliberately contains only argv and environment. macOS
     // `env -C` supplies the session cwd without a shell, preserving exact
     // argument boundaries and the SDK's process-group lifecycle management.
-    let mut args = vec!["-C".to_owned(), cwd.to_owned(), binary.to_owned()];
-    args.extend(launch.args);
-    let config = AcpAgentConfig::new("/usr/bin/env")
-        .args(args)
-        .envs(environment);
+    // Windows has no `/usr/bin/env`; the ACP protocol itself carries the
+    // session cwd (`NewSessionRequest` / `ResumeSessionRequest`), so spawn the
+    // provider binary directly there.
+    #[cfg(unix)]
+    let config = {
+        let mut args = vec!["-C".to_owned(), cwd.to_owned(), binary.to_owned()];
+        args.extend(launch.args);
+        AcpAgentConfig::new("/usr/bin/env").args(args).envs(environment)
+    };
+    #[cfg(windows)]
+    let config = {
+        let _ = cwd; // session cwd is conveyed by the ACP protocol on Windows
+        AcpAgentConfig::new(binary).args(launch.args).envs(environment)
+    };
     Ok(AcpAgent::new(config).with_debug(move |line, direction| {
         if direction != LineDirection::Stderr || line.trim().is_empty() {
             return;

--- a/crates/waku-core/src/driver/computer_use.rs
+++ b/crates/waku-core/src/driver/computer_use.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -139,6 +140,7 @@ pub(super) fn create_process_directory() -> anyhow::Result<PathBuf> {
             directory.display()
         )
     })?;
+    #[cfg(unix)]
     fs::set_permissions(&directory, fs::Permissions::from_mode(0o700)).with_context(|| {
         format!(
             "could not secure Computer Use process directory {}",
@@ -153,6 +155,7 @@ pub(super) fn stop_registered_processes(directory: &Path, helper_executable: &Pa
         fs::canonicalize(helper_executable).unwrap_or_else(|_| helper_executable.to_path_buf());
     for (pid, registration) in registered_processes(directory) {
         if process_executable(pid).as_deref() == Some(expected_executable.as_path()) {
+            #[cfg(unix)]
             unsafe {
                 libc::kill(pid, libc::SIGTERM);
             }

--- a/crates/waku-core/src/driver/support.rs
+++ b/crates/waku-core/src/driver/support.rs
@@ -3,8 +3,10 @@
 //! classification.
 
 use std::fs;
-
-use std::os::unix::fs::{PermissionsExt as _, symlink};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt as _;
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, anyhow};
@@ -13,6 +15,36 @@ use serde_json::Value;
 use super::computer_use as computer_use_runtime;
 use crate::driver::DriverEventSender;
 use crate::model::{ActivityKind, ProviderKind};
+
+/// Mirror a Grok runtime resource into the isolated home. Unix symlinks keep
+/// the source authoritative; Windows may lack the privilege to create them,
+/// so try a symlink first and fall back to a recursive copy.
+#[cfg(windows)]
+fn symlink(source: &Path, destination: &Path) -> std::io::Result<()> {
+    let copy = || {
+        if source.is_dir() {
+            fs::create_dir_all(destination)?;
+            for entry in fs::read_dir(source)? {
+                let entry = entry?;
+                let target = destination.join(entry.file_name());
+                if entry.file_type()?.is_dir() {
+                    symlink(&entry.path(), &target)?;
+                } else {
+                    fs::copy(entry.path(), target)?;
+                }
+            }
+            Ok(())
+        } else {
+            fs::copy(source, destination).map(|_| ())
+        }
+    };
+    let link = if source.is_dir() {
+        std::os::windows::fs::symlink_dir(source, destination)
+    } else {
+        std::os::windows::fs::symlink_file(source, destination)
+    };
+    link.or_else(|_| copy())
+}
 
 /// The context-window occupancy of one API call from a Claude-wire `usage`
 /// object (Claude Code and Amp share the format): prompt (fresh + cached) plus
@@ -181,6 +213,7 @@ fn build_grok_computer_use_config(
             grok_home.display()
         )
     })?;
+    #[cfg(unix)]
     fs::set_permissions(&grok_home, fs::Permissions::from_mode(0o700)).with_context(|| {
         format!(
             "could not secure isolated Grok home {}",
@@ -199,7 +232,7 @@ fn build_grok_computer_use_config(
             ) {
                 continue;
             }
-            symlink(entry.path(), grok_home.join(name)).with_context(|| {
+            symlink(&entry.path(), &grok_home.join(name)).with_context(|| {
                 format!(
                     "could not mirror Grok runtime resource {}",
                     entry.path().display()

--- a/crates/waku-core/src/git_branch.rs
+++ b/crates/waku-core/src/git_branch.rs
@@ -304,12 +304,7 @@ fn optional_stdout(cwd: &Path, args: &[&str]) -> anyhow::Result<Option<String>> 
 }
 
 fn command_error(output: &Output) -> String {
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    if stderr.is_empty() {
-        format!("git exited with {}", output.status)
-    } else {
-        stderr
-    }
+    crate::command_env::failure_detail(output)
 }
 
 #[cfg(test)]

--- a/crates/waku-core/src/git_commit.rs
+++ b/crates/waku-core/src/git_commit.rs
@@ -573,6 +573,9 @@ fn read_bounded(mut reader: impl Read, limit: usize) -> Vec<u8> {
 
 fn command_error(output: &CapturedOutput) -> String {
     let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    if let Some(failures) = crate::command_env::failure_lines(&stderr) {
+        return failures;
+    }
     let stderr = stderr.trim();
     if stderr.is_empty() {
         format!("process exited with {}", output.status)

--- a/crates/waku-core/src/worktree.rs
+++ b/crates/waku-core/src/worktree.rs
@@ -259,6 +259,10 @@ mod tests {
         let project = repository.join("packages/app");
         fs::create_dir_all(&project).unwrap();
         run_git(&repository, &["init", "-b", "main"]);
+        // A system-wide `core.autocrlf=true` (the Windows installer default)
+        // would rewrite checked-out files to CRLF and break byte-for-byte
+        // assertions; pin the repository's line-ending behavior.
+        run_git(&repository, &["config", "core.autocrlf", "false"]);
         fs::write(project.join("README.md"), "main\n").unwrap();
         run_git(&repository, &["add", "."]);
         run_git(


### PR DESCRIPTION
Ports waku-core to Windows.

- Resolves bare executables through PATHEXT (pi.cmd) before the extensionless fallback.
- Surfaces git error:/fatal: lines above the CRLF warnings a system-wide core.autocrlf produces, via shared failure_detail/failure_lines helpers.
- Spawns ACP providers directly on Windows (no /usr/bin/env); the protocol carries the session cwd.
- Falls back to recursive copies where Windows cannot create symlinks.
- Pins core.autocrlf=false in tests for deterministic byte assertions.

Validated with cargo check -p waku-core and cargo check -p waku-core --tests.