### PR TITLE
Restore macOS Cmd+H hide via the application menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unreleased]
 
+- Hide the app with Cmd+H on macOS
+
 ## [0.1.2]
 
 - Fix regression: user bubble should fit its content width

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -6,6 +6,12 @@ menu.check_for_updates:
   en: Check for Updates…
 menu.settings:
   en: Settings…
+menu.hide:
+  en: Hide %{app}
+menu.hide_others:
+  en: Hide Others
+menu.show_all:
+  en: Show All
 menu.quit:
   en: Quit %{app}
 menu.file:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -3,6 +3,9 @@ _version: 1
 menu.about: "%{app} について"
 menu.check_for_updates: アップデートを確認…
 menu.settings: 設定…
+menu.hide: "%{app} を隠す"
+menu.hide_others: ほかを隠す
+menu.show_all: すべてを表示
 menu.quit: "%{app} を終了"
 menu.file: ファイル
 menu.new_task: 新規タスク

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -3,6 +3,9 @@ _version: 1
 menu.about: 关于 %{app}
 menu.check_for_updates: 检查更新…
 menu.settings: 设置…
+menu.hide: 隐藏 %{app}
+menu.hide_others: 隐藏其他
+menu.show_all: 全部显示
 menu.quit: 退出 %{app}
 menu.file: 文件
 menu.new_task: 新建任务

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,9 @@ actions!(
     [
         Quit,
         About,
+        Hide,
+        HideOthers,
+        ShowAll,
         CloseWindow,
         NewSession,
         NewProject,
@@ -220,6 +223,11 @@ pub fn run() {
                 }
             });
             cx.on_action(|_: &About, _| crate::platform::show_about_panel());
+            // AppKit's default Hide items live on the application menu. Replacing
+            // that menu without these actions leaves ⌘H / ⌥⌘H unbound.
+            cx.on_action(|_: &Hide, cx| cx.hide());
+            cx.on_action(|_: &HideOthers, cx| cx.hide_other_apps());
+            cx.on_action(|_: &ShowAll, cx| cx.unhide_other_apps());
 
             cx.bind_keys([
                 // `secondary` is Command on macOS and Control elsewhere.
@@ -281,6 +289,12 @@ pub fn run() {
                 KeyBinding::new("secondary-v", WebviewPaste, Some("Browser")),
                 KeyBinding::new("secondary-a", WebviewSelectAll, Some("Browser")),
                 KeyBinding::new("escape", BrowserAddressCancel, Some("BrowserAddress")),
+            ]);
+
+            #[cfg(target_os = "macos")]
+            cx.bind_keys([
+                KeyBinding::new("cmd-h", Hide, None),
+                KeyBinding::new("alt-cmd-h", HideOthers, None),
             ]);
 
             cx.on_action(|_: &Quit, cx| cx.quit());
@@ -389,11 +403,18 @@ pub(crate) fn set_app_menus(cx: &mut App, updater_available: bool) {
                     ));
                 }
                 items.push(MenuItem::separator());
-                items.extend([
-                    MenuItem::action(tr!("menu.settings"), OpenSettings),
-                    MenuItem::separator(),
-                    MenuItem::action(tr!("menu.quit", app = APP_NAME), Quit),
-                ]);
+                items.push(MenuItem::action(tr!("menu.settings"), OpenSettings));
+                items.push(MenuItem::separator());
+                #[cfg(target_os = "macos")]
+                {
+                    items.extend([
+                        MenuItem::action(tr!("menu.hide", app = APP_NAME), Hide),
+                        MenuItem::action(tr!("menu.hide_others"), HideOthers),
+                        MenuItem::action(tr!("menu.show_all"), ShowAll),
+                        MenuItem::separator(),
+                    ]);
+                }
+                items.push(MenuItem::action(tr!("menu.quit", app = APP_NAME), Quit));
                 items
             },
         },


### PR DESCRIPTION
## Summary

- Restore the standard macOS application-menu items **Hide Waku** (`⌘H`), **Hide Others** (`⌥⌘H`), and **Show All**.
- Bind those items to GPUI's `hide` / `hide_other_apps` / `unhide_other_apps` APIs so AppKit has a real Hide command again.

Fixes #94.

## Why

Waku replaces the native menu bar with `set_app_menus`. The Waku menu went from Settings straight to Quit, so AppKit never received a Hide item and `⌘H` did nothing.

This is the same approach Zed uses: keep Hide on the application menu and bind `cmd-h` / `alt-cmd-h` so GPUI can set the menu key equivalents. The red close button still only hides the window with `orderOut`; `⌘H` hides the whole app.

## Validation

- Compared against Zed's macOS hide menu and keybindings (`zed::Hide`, `zed::HideOthers`).
- `git diff --check`
- Did not run `cargo test` or rebuild `Waku Debug.app` in this clone; first-time deps were fetched, but the debug watcher was not running.

## Follow-up

None. Linux is unchanged: GPUI's hide APIs are no-ops there, so the items stay macOS-only.
