### PR TITLE
Add a conversation text size setting

### DIFF
--- a/crates/waku-client/src/persistence.rs
+++ b/crates/waku-client/src/persistence.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{Command, DaemonExposureSettings, DaemonSettings, DaemonSupervisor, ResponsePayload};
+pub use waku_protocol::ConversationTextSize;
 use waku_protocol::computer_use::ComputerAppGrant;
 use waku_protocol::i18n::AppLanguage;
 use waku_protocol::identity::DATA_DIRECTORY_NAME;
@@ -215,6 +216,7 @@ pub struct AppSettings {
     pub favorite_models: Vec<FavoriteModel>,
     pub theme: ThemePreference,
     pub language: AppLanguage,
+    pub conversation_text_size: ConversationTextSize,
     pub daemon_exposure: DaemonExposureSettings,
 }
 
@@ -225,6 +227,7 @@ impl Default for AppSettings {
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
             language: AppLanguage::default(),
+            conversation_text_size: ConversationTextSize::default(),
             daemon_exposure: DaemonExposureSettings::default(),
         }
     }
@@ -292,6 +295,8 @@ pub struct PersistedState {
     #[serde(default)]
     pub language: AppLanguage,
     #[serde(default)]
+    pub conversation_text_size: ConversationTextSize,
+    #[serde(default)]
     pub daemon_exposure: DaemonExposureSettings,
     #[serde(default = "default_sidebar_visibility")]
     pub sidebar_visible: bool,
@@ -351,6 +356,7 @@ impl PersistedState {
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
             language: AppLanguage::default(),
+            conversation_text_size: ConversationTextSize::default(),
             daemon_exposure: DaemonExposureSettings::default(),
             sidebar_visible: true,
             right_panel_visible: false,
@@ -469,6 +475,7 @@ impl PersistedState {
             favorite_models: self.favorite_models.clone(),
             theme: self.theme,
             language: self.language,
+            conversation_text_size: self.conversation_text_size,
             daemon_exposure: self.daemon_exposure.clone(),
         }
     }
@@ -498,6 +505,7 @@ impl PersistedState {
         self.favorite_models = settings.favorite_models;
         self.theme = settings.theme;
         self.language = settings.language;
+        self.conversation_text_size = settings.conversation_text_size;
         self.daemon_exposure = settings.daemon_exposure;
     }
 
@@ -993,6 +1001,17 @@ mod tests {
                 [configuration_directory().join("settings.json")]
             );
         }
+    }
+
+    #[test]
+    fn conversation_text_size_defaults_in_partial_settings() {
+        let settings: AppSettings = serde_json::from_str(r#"{"theme":"dark"}"#).unwrap();
+
+        assert_eq!(settings.theme, ThemePreference::Dark);
+        assert_eq!(
+            settings.conversation_text_size,
+            ConversationTextSize::Default
+        );
     }
 
     #[test]

--- a/crates/waku-core/src/persistence.rs
+++ b/crates/waku-core/src/persistence.rs
@@ -34,6 +34,7 @@ use crate::model::{
     ProviderKind, RuntimeMode, SessionWorkspace,
 };
 use crate::theme::ThemePreference;
+use waku_protocol::ConversationTextSize;
 pub use waku_protocol::persistence::{
     ComposerDraft, ComposerDraftAttachment, ComposerDraftChange, ComposerDraftKey,
     ComposerDraftTarget, ComposerDrafts, SessionMessageMatch,
@@ -191,6 +192,7 @@ pub struct AppSettings {
     pub favorite_models: Vec<FavoriteModel>,
     pub theme: ThemePreference,
     pub language: AppLanguage,
+    pub conversation_text_size: ConversationTextSize,
 }
 
 impl Default for AppSettings {
@@ -200,6 +202,7 @@ impl Default for AppSettings {
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
             language: AppLanguage::default(),
+            conversation_text_size: ConversationTextSize::default(),
         }
     }
 }
@@ -268,6 +271,8 @@ pub struct PersistedState {
     pub theme: ThemePreference,
     #[serde(default)]
     pub language: AppLanguage,
+    #[serde(default)]
+    pub conversation_text_size: ConversationTextSize,
     #[serde(default = "default_sidebar_visibility")]
     pub sidebar_visible: bool,
     #[serde(default = "default_right_panel_visibility")]
@@ -338,6 +343,7 @@ impl PersistedState {
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
             language: AppLanguage::default(),
+            conversation_text_size: ConversationTextSize::default(),
             sidebar_visible: true,
             right_panel_visible: false,
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
@@ -436,6 +442,7 @@ impl PersistedState {
             favorite_models: self.favorite_models.clone(),
             theme: self.theme,
             language: self.language,
+            conversation_text_size: self.conversation_text_size,
         }
     }
 
@@ -473,6 +480,7 @@ impl PersistedState {
         self.favorite_models = settings.favorite_models;
         self.theme = settings.theme;
         self.language = settings.language;
+        self.conversation_text_size = settings.conversation_text_size;
     }
 
     pub fn apply_daemon_settings(&mut self, settings: crate::DaemonSettings) {
@@ -1919,6 +1927,10 @@ mod tests {
         assert_eq!(settings.theme, ThemePreference::Dark);
         assert_eq!(settings.language, AppLanguage::System);
         assert!(settings.analytics_enabled);
+        assert_eq!(
+            settings.conversation_text_size,
+            ConversationTextSize::Default
+        );
     }
 
     #[test]
@@ -2684,6 +2696,7 @@ mod tests {
         let mut state = PersistedState::fresh(PathBuf::from("/tmp/project"));
         state.theme = ThemePreference::Light;
         state.language = AppLanguage::SimplifiedChinese;
+        state.conversation_text_size = ConversationTextSize::Large;
         state.sidebar_width = 301.0;
         store.save(&mut state).unwrap();
 
@@ -2696,6 +2709,7 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(value["theme"], "light");
         assert_eq!(value["language"], "simplified-chinese");
+        assert_eq!(value["conversation_text_size"], "large");
         for daemon_key in [
             "computer_use_enabled",
             "computer_use_allowed_apps",
@@ -2739,6 +2753,7 @@ mod tests {
             "favorite_models",
             "theme",
             "language",
+            "conversation_text_size",
             "computer_use_enabled",
             "computer_use_allowed_apps",
             "disabled_providers",

--- a/crates/waku-protocol/src/lib.rs
+++ b/crates/waku-protocol/src/lib.rs
@@ -42,6 +42,7 @@ pub mod projectless;
 pub mod provider_session;
 pub mod settings;
 pub mod skills;
+pub mod text_size;
 pub mod theme;
 pub mod usage;
 pub mod usage_history;
@@ -57,4 +58,5 @@ pub use protocol::{
     WireDriverEvent, WireDriverStartOptions, WireSessionOptions,
 };
 pub use settings::DaemonSettings;
+pub use text_size::ConversationTextSize;
 pub use workspace::{WorkspaceOperation, WorkspaceResult};

--- a/crates/waku-protocol/src/settings.rs
+++ b/crates/waku-protocol/src/settings.rs
@@ -41,7 +41,13 @@ impl DaemonSettings {
     }
 
     pub fn discard_legacy_app_keys(&mut self) {
-        for key in ["analytics_enabled", "favorite_models", "theme", "language"] {
+        for key in [
+            "analytics_enabled",
+            "favorite_models",
+            "theme",
+            "language",
+            "conversation_text_size",
+        ] {
             self.extra.remove(key);
         }
     }

--- a/crates/waku-protocol/src/text_size.rs
+++ b/crates/waku-protocol/src/text_size.rs
@@ -1,0 +1,32 @@
+//! Conversation typography preference persisted by desktop clients.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConversationTextSize {
+    Small,
+    #[default]
+    Default,
+    Large,
+}
+
+impl ConversationTextSize {
+    pub const ALL: [Self; 3] = [Self::Small, Self::Default, Self::Large];
+
+    pub fn label(self) -> String {
+        match self {
+            Self::Small => crate::i18n::translate("settings.text_size_small"),
+            Self::Default => crate::i18n::translate("settings.text_size_default"),
+            Self::Large => crate::i18n::translate("settings.text_size_large"),
+        }
+    }
+
+    pub const fn scale(self) -> f32 {
+        match self {
+            Self::Small => 0.92,
+            Self::Default => 1.0,
+            Self::Large => 1.12,
+        }
+    }
+}

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -123,7 +123,7 @@ settings.computer_use:
 settings.general_keywords:
   en: general local projects conversations privacy analytics telemetry anonymous sharing updates automatic sparkle version
 settings.appearance_keywords:
-  en: appearance theme system light dark language english chinese simplified
+  en: appearance theme system light dark language english chinese simplified text font size small large
 settings.providers_keywords:
   en: providers agents models cli version install detect claude codex cursor opencode amp grok pi
 settings.skills:
@@ -274,6 +274,16 @@ settings.theme:
   en: Theme
 settings.theme_description:
   en: Choose between system, light, or dark themes
+settings.conversation_text_size:
+  en: Conversation text size
+settings.conversation_text_size_description:
+  en: Adjust message text without changing the rest of the interface
+settings.text_size_small:
+  en: Small
+settings.text_size_default:
+  en: Default
+settings.text_size_large:
+  en: Large
 settings.theme_system:
   en: System
 settings.theme_light:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -63,7 +63,7 @@ settings.usage: 使用状況
 settings.daemon: デーモン
 settings.computer_use: コンピュータ操作
 settings.general_keywords: 一般 ローカル プロジェクト 会話 プライバシー 分析 テレメトリ 匿名 共有 アップデート 自動 バージョン
-settings.appearance_keywords: 外観 テーマ システム ライト ダーク 言語 英語 中国語 簡体字 日本語
+settings.appearance_keywords: 外観 テーマ システム ライト ダーク 言語 英語 中国語 簡体字 日本語 テキスト フォント サイズ 小 大
 settings.providers_keywords: プロバイダー エージェント モデル CLI バージョン インストール 検出 claude codex cursor opencode amp grok pi
 settings.skills: スキル
 settings.skills_keywords: スキル ライブラリ エージェント 無効 有効 削除 claude codex cursor opencode pi amp 共有
@@ -139,6 +139,11 @@ web.error_secure_websocket_required: 安全な Waku Web ページからは wss:/
 web.error_daemon_token_required: デーモントークンを入力してください
 settings.theme: テーマ
 settings.theme_description: システム、ライト、ダークのいずれかのテーマを選択します
+settings.conversation_text_size: 会話の文字サイズ
+settings.conversation_text_size_description: インターフェースの他の部分を変えずにメッセージの文字サイズを調整します
+settings.text_size_small: 小
+settings.text_size_default: 標準
+settings.text_size_large: 大
 settings.theme_system: システム
 settings.theme_light: ライト
 settings.theme_dark: ダーク

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -59,7 +59,7 @@ settings.usage: 用量
 settings.daemon: 守护进程
 settings.computer_use: 电脑操作
 settings.general_keywords: 通用 本地 项目 对话 隐私 匿名 使用数据 分析 分享 更新 自动 版本
-settings.appearance_keywords: 外观 主题 系统 浅色 深色 语言 英语 中文 简体
+settings.appearance_keywords: 外观 主题 系统 浅色 深色 语言 英语 中文 简体 文本 字体 大小 小 大
 settings.providers_keywords: 服务商 智能体 模型 命令行 版本 安装 检测 claude codex cursor opencode amp grok pi
 settings.skills: 技能
 settings.skills_keywords: 技能 技能库 智能体 禁用 启用 删除 claude codex cursor opencode pi amp 共享
@@ -135,6 +135,11 @@ web.error_secure_websocket_required: 安全的 Waku Web 页面只能通过 wss:/
 web.error_daemon_token_required: 请输入守护进程令牌
 settings.theme: 主题
 settings.theme_description: 选择跟随系统、浅色或深色主题
+settings.conversation_text_size: 对话文字大小
+settings.conversation_text_size_description: 调整消息文字大小，不影响界面的其他部分
+settings.text_size_small: 小
+settings.text_size_default: 默认
+settings.text_size_large: 大
 settings.theme_system: 跟随系统
 settings.theme_light: 浅色
 settings.theme_dark: 深色

--- a/src/app.rs
+++ b/src/app.rs
@@ -53,8 +53,8 @@ use crate::ui::tooltip::Tooltip;
 
 use crate::browser::BrowserView;
 use crate::persistence::{
-    ComposerDraftStore, ComposerDrafts, DEFAULT_RIGHT_PANEL_WIDTH, DEFAULT_SIDEBAR_WIDTH,
-    PersistedState, PersistedWindowState, StateStore,
+    ComposerDraftStore, ComposerDrafts, ConversationTextSize, DEFAULT_RIGHT_PANEL_WIDTH,
+    DEFAULT_SIDEBAR_WIDTH, PersistedState, PersistedWindowState, StateStore,
 };
 use crate::query::{Query, QueryCache};
 use crate::review_diff::{Snapshot as ReviewDiffSnapshot, Source as ReviewDiffSource};

--- a/src/app/components.rs
+++ b/src/app/components.rs
@@ -675,6 +675,7 @@ pub(super) fn render_message(params: MessageRender, cx: &mut App) -> AnyElement 
             } else {
                 if !content.trim().is_empty() {
                     let body = render_markdown_message_body(&content, markdown, theme, ctx);
+                    let metrics = ctx.metrics();
                     column = column.child(
                         div()
                             .max_w(px(540.0))
@@ -683,8 +684,8 @@ pub(super) fn render_message(params: MessageRender, cx: &mut App) -> AnyElement 
                             .bg(theme.raised)
                             .px(px(12.0))
                             .py(px(8.0))
-                            .text_size(px(14.0))
-                            .line_height(px(20.0))
+                            .text_size(px(metrics.text_size))
+                            .line_height(px(metrics.line_height))
                             .child(body),
                     );
                 }

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -1346,6 +1346,7 @@ impl Waku {
         let theme = Theme::current(cx);
         let selected_theme = self.state.theme;
         let selected_language = self.state.language;
+        let selected_text_size = self.state.conversation_text_size;
         let weak = cx.entity().downgrade();
         let theme_handle = self.menu_handle("theme-selector", cx);
         let theme_selector = dropdown_menu(
@@ -1397,6 +1398,34 @@ impl Waku {
                             });
                         })
                         .selected(language == selected_language)
+                    })
+                    .collect()
+            },
+        );
+
+        let weak = cx.entity().downgrade();
+        let text_size_handle = self.menu_handle("conversation-text-size-selector", cx);
+        let text_size_selector = dropdown_menu(
+            MenuChip::new("conversation-text-size-selector")
+                .label(selected_text_size.label())
+                .outlined()
+                .selected(text_size_handle.is_open())
+                .w(px(116.0))
+                .justify_between(),
+            "conversation-text-size-selector-menu",
+            &text_size_handle,
+            MenuAlign::BelowRight,
+            move |_| {
+                ConversationTextSize::ALL
+                    .into_iter()
+                    .map(|text_size| {
+                        let weak = weak.clone();
+                        MenuItem::new(text_size.label(), move |_, cx| {
+                            let _ = weak.update(cx, |this, cx| {
+                                this.set_conversation_text_size(text_size, cx);
+                            });
+                        })
+                        .selected(text_size == selected_text_size)
                     })
                     .collect()
             },
@@ -1472,6 +1501,38 @@ impl Waku {
                             ),
                     )
                     .child(language_selector),
+            )
+            .child(div().mx(px(20.0)).h(px(1.0)).bg(theme.border))
+            .child(
+                div()
+                    .w_full()
+                    .min_h(px(60.0))
+                    .px(px(20.0))
+                    .py(px(12.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(24.0))
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .child(
+                                div()
+                                    .text_size(px(13.5))
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .text_color(theme.text)
+                                    .child(tr!("settings.conversation_text_size")),
+                            )
+                            .child(
+                                div()
+                                    .mt(px(5.0))
+                                    .text_size(px(12.5))
+                                    .line_height(px(18.0))
+                                    .text_color(theme.text_secondary)
+                                    .child(tr!("settings.conversation_text_size_description")),
+                            ),
+                    )
+                    .child(text_size_selector),
             )
             .into_any_element()
     }
@@ -2341,6 +2402,20 @@ impl Waku {
         }
         self.state.theme = preference;
         crate::theme::apply_theme_preference(preference, window, cx);
+        self.save();
+        cx.notify();
+    }
+
+    fn set_conversation_text_size(
+        &mut self,
+        text_size: ConversationTextSize,
+        cx: &mut Context<Self>,
+    ) {
+        if self.state.conversation_text_size == text_size {
+            return;
+        }
+        self.state.conversation_text_size = text_size;
+        self.reset_transcript_rows(self.transcript_row_count());
         self.save();
         cx.notify();
     }

--- a/src/app/transcript_view.rs
+++ b/src/app/transcript_view.rs
@@ -1210,7 +1210,8 @@ impl Waku {
                         MarkdownMetrics::USER_MESSAGE
                     } else {
                         MarkdownMetrics::BODY
-                    };
+                    }
+                    .scaled(self.state.conversation_text_size.scale());
                     let animate_streaming = message.streaming && !cx.reduce_motion();
                     let ctx = self.markdown_ctx(
                         format!("message-{}", message.id),

--- a/src/md/render.rs
+++ b/src/md/render.rs
@@ -97,6 +97,19 @@ impl Metrics {
         code_line_height: 16.0,
         block_gap: 6.0,
     };
+
+    /// Scale conversation typography while keeping half-pixel layout values.
+    /// Tool chrome uses `COMPACT` directly and is intentionally unaffected.
+    pub fn scaled(self, scale: f32) -> Self {
+        let scale_half_pixel = |value: f32| (value * scale * 2.0).round() / 2.0;
+        Self {
+            text_size: scale_half_pixel(self.text_size),
+            line_height: scale_half_pixel(self.line_height),
+            code_text_size: scale_half_pixel(self.code_text_size),
+            code_line_height: scale_half_pixel(self.code_line_height),
+            block_gap: scale_half_pixel(self.block_gap),
+        }
+    }
 }
 
 pub const SANS_FAMILY: &str = ".SystemUIFont";
@@ -506,6 +519,10 @@ impl<'a> Ctx<'a> {
 
     pub fn selection(&self) -> &TranscriptSelection {
         &self.selection
+    }
+
+    pub fn metrics(&self) -> Metrics {
+        self.metrics
     }
 
     pub fn with_link_handler(mut self, handler: LinkHandler) -> Self {


### PR DESCRIPTION
This PR was produces exclusively with codex, imagines and QA'd by me.

The idea is that it can serve a a discussion ground on the feature.

## Problem

Conversation text is too small for some readers, and Waku currently offers no way to adjust it without changing system-wide display settings.

## Solution

- add Small, Default, and Large conversation text-size presets under Appearance
- scale message prose and code without changing the composer, sidebar, tool calls, or other UI
- reset virtualized transcript measurements when the preference changes
- persist the preference with a backward-compatible default

## Checks

- `cargo +1.96.0 check --locked`
- `cargo +1.96.0 test --locked -- --skip websocket_terminal_round_trip_streams_input_and_output`
- `bun run --filter @waku/client check`
- `bun run --filter @waku/client test`
- successful rebuild through the existing development watcher

## Known limitations / baseline notes

- visual QA completed in Waku Debug
- this intentionally changes conversation message typography only, not global application chrome
- the full Rust suite reaches an unrelated intermittent timeout in `websocket_terminal_round_trip_streams_input_and_output`; every other test passes
- the documented format command currently reports rustfmt differences in unchanged `main` files
- `bun run protocol:check` currently reports stale `ActivityFileChange` bindings already present on `main`

Closes #96


## Screenshot

Conversation text size options in Appearance:

![Conversation text size selector](https://raw.githubusercontent.com/olup/waku/pr-assets/pr-assets/pr-103-conversation-text-size.png)