### PR TITLE
Group sidebar conversations by project

### DIFF
--- a/crates/waku-client/src/persistence.rs
+++ b/crates/waku-client/src/persistence.rs
@@ -215,6 +215,7 @@ pub struct AppSettings {
     pub favorite_models: Vec<FavoriteModel>,
     pub theme: ThemePreference,
     pub language: AppLanguage,
+    pub group_conversations_by_project: bool,
     pub daemon_exposure: DaemonExposureSettings,
 }
 
@@ -225,6 +226,7 @@ impl Default for AppSettings {
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
             language: AppLanguage::default(),
+            group_conversations_by_project: false,
             daemon_exposure: DaemonExposureSettings::default(),
         }
     }
@@ -292,6 +294,8 @@ pub struct PersistedState {
     #[serde(default)]
     pub language: AppLanguage,
     #[serde(default)]
+    pub group_conversations_by_project: bool,
+    #[serde(default)]
     pub daemon_exposure: DaemonExposureSettings,
     #[serde(default = "default_sidebar_visibility")]
     pub sidebar_visible: bool,
@@ -351,6 +355,7 @@ impl PersistedState {
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
             language: AppLanguage::default(),
+            group_conversations_by_project: false,
             daemon_exposure: DaemonExposureSettings::default(),
             sidebar_visible: true,
             right_panel_visible: false,
@@ -469,6 +474,7 @@ impl PersistedState {
             favorite_models: self.favorite_models.clone(),
             theme: self.theme,
             language: self.language,
+            group_conversations_by_project: self.group_conversations_by_project,
             daemon_exposure: self.daemon_exposure.clone(),
         }
     }
@@ -498,6 +504,7 @@ impl PersistedState {
         self.favorite_models = settings.favorite_models;
         self.theme = settings.theme;
         self.language = settings.language;
+        self.group_conversations_by_project = settings.group_conversations_by_project;
         self.daemon_exposure = settings.daemon_exposure;
     }
 
@@ -993,6 +1000,14 @@ mod tests {
                 [configuration_directory().join("settings.json")]
             );
         }
+    }
+
+    #[test]
+    fn project_grouping_defaults_off_in_partial_settings() {
+        let settings: AppSettings = serde_json::from_str(r#"{"theme":"dark"}"#).unwrap();
+
+        assert_eq!(settings.theme, ThemePreference::Dark);
+        assert!(!settings.group_conversations_by_project);
     }
 
     #[test]

--- a/crates/waku-core/src/persistence.rs
+++ b/crates/waku-core/src/persistence.rs
@@ -191,6 +191,7 @@ pub struct AppSettings {
     pub favorite_models: Vec<FavoriteModel>,
     pub theme: ThemePreference,
     pub language: AppLanguage,
+    pub group_conversations_by_project: bool,
 }
 
 impl Default for AppSettings {
@@ -200,6 +201,7 @@ impl Default for AppSettings {
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
             language: AppLanguage::default(),
+            group_conversations_by_project: false,
         }
     }
 }
@@ -268,6 +270,8 @@ pub struct PersistedState {
     pub theme: ThemePreference,
     #[serde(default)]
     pub language: AppLanguage,
+    #[serde(default)]
+    pub group_conversations_by_project: bool,
     #[serde(default = "default_sidebar_visibility")]
     pub sidebar_visible: bool,
     #[serde(default = "default_right_panel_visibility")]
@@ -338,6 +342,7 @@ impl PersistedState {
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
             language: AppLanguage::default(),
+            group_conversations_by_project: false,
             sidebar_visible: true,
             right_panel_visible: false,
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
@@ -436,6 +441,7 @@ impl PersistedState {
             favorite_models: self.favorite_models.clone(),
             theme: self.theme,
             language: self.language,
+            group_conversations_by_project: self.group_conversations_by_project,
         }
     }
 
@@ -473,6 +479,7 @@ impl PersistedState {
         self.favorite_models = settings.favorite_models;
         self.theme = settings.theme;
         self.language = settings.language;
+        self.group_conversations_by_project = settings.group_conversations_by_project;
     }
 
     pub fn apply_daemon_settings(&mut self, settings: crate::DaemonSettings) {
@@ -1919,6 +1926,7 @@ mod tests {
         assert_eq!(settings.theme, ThemePreference::Dark);
         assert_eq!(settings.language, AppLanguage::System);
         assert!(settings.analytics_enabled);
+        assert!(!settings.group_conversations_by_project);
     }
 
     #[test]
@@ -2684,6 +2692,7 @@ mod tests {
         let mut state = PersistedState::fresh(PathBuf::from("/tmp/project"));
         state.theme = ThemePreference::Light;
         state.language = AppLanguage::SimplifiedChinese;
+        state.group_conversations_by_project = true;
         state.sidebar_width = 301.0;
         store.save(&mut state).unwrap();
 
@@ -2696,6 +2705,7 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(value["theme"], "light");
         assert_eq!(value["language"], "simplified-chinese");
+        assert_eq!(value["group_conversations_by_project"], true);
         for daemon_key in [
             "computer_use_enabled",
             "computer_use_allowed_apps",
@@ -2739,6 +2749,7 @@ mod tests {
             "favorite_models",
             "theme",
             "language",
+            "group_conversations_by_project",
             "computer_use_enabled",
             "computer_use_allowed_apps",
             "disabled_providers",

--- a/crates/waku-protocol/src/settings.rs
+++ b/crates/waku-protocol/src/settings.rs
@@ -41,7 +41,13 @@ impl DaemonSettings {
     }
 
     pub fn discard_legacy_app_keys(&mut self) {
-        for key in ["analytics_enabled", "favorite_models", "theme", "language"] {
+        for key in [
+            "analytics_enabled",
+            "favorite_models",
+            "theme",
+            "language",
+            "group_conversations_by_project",
+        ] {
             self.extra.remove(key);
         }
     }

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -123,7 +123,7 @@ settings.computer_use:
 settings.general_keywords:
   en: general local projects conversations privacy analytics telemetry anonymous sharing updates automatic sparkle version
 settings.appearance_keywords:
-  en: appearance theme system light dark language english chinese simplified
+  en: appearance theme system light dark language english chinese simplified sidebar conversations projects group
 settings.providers_keywords:
   en: providers agents models cli version install detect claude codex cursor opencode amp grok pi
 settings.skills:
@@ -274,6 +274,10 @@ settings.theme:
   en: Theme
 settings.theme_description:
   en: Choose between system, light, or dark themes
+settings.group_conversations_by_project:
+  en: Group conversations by project
+settings.group_conversations_by_project_description:
+  en: Replace date sections in the sidebar with collapsible project sections
 settings.theme_system:
   en: System
 settings.theme_light:
@@ -430,6 +434,10 @@ sidebar.this_year:
   en: This Year
 sidebar.more:
   en: More
+sidebar.show_more:
+  en: Show %{count} more
+sidebar.show_less:
+  en: Show less
 sidebar.working:
   en: Working for %{elapsed}
 sidebar.just_now:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -63,7 +63,7 @@ settings.usage: 使用状況
 settings.daemon: デーモン
 settings.computer_use: コンピュータ操作
 settings.general_keywords: 一般 ローカル プロジェクト 会話 プライバシー 分析 テレメトリ 匿名 共有 アップデート 自動 バージョン
-settings.appearance_keywords: 外観 テーマ システム ライト ダーク 言語 英語 中国語 簡体字 日本語
+settings.appearance_keywords: 外観 テーマ システム ライト ダーク 言語 英語 中国語 簡体字 日本語 サイドバー 会話 プロジェクト グループ
 settings.providers_keywords: プロバイダー エージェント モデル CLI バージョン インストール 検出 claude codex cursor opencode amp grok pi
 settings.skills: スキル
 settings.skills_keywords: スキル ライブラリ エージェント 無効 有効 削除 claude codex cursor opencode pi amp 共有
@@ -139,6 +139,8 @@ web.error_secure_websocket_required: 安全な Waku Web ページからは wss:/
 web.error_daemon_token_required: デーモントークンを入力してください
 settings.theme: テーマ
 settings.theme_description: システム、ライト、ダークのいずれかのテーマを選択します
+settings.group_conversations_by_project: プロジェクトごとに会話をグループ化
+settings.group_conversations_by_project_description: サイドバーの日付セクションを折りたたみ可能なプロジェクトセクションに置き換えます
 settings.theme_system: システム
 settings.theme_light: ライト
 settings.theme_dark: ダーク
@@ -221,6 +223,8 @@ sidebar.this_week: 今週
 sidebar.this_month: 今月
 sidebar.this_year: 今年
 sidebar.more: さらに前
+sidebar.show_more: "さらに %{count} 件を表示"
+sidebar.show_less: 表示を減らす
 sidebar.working: 作業中 · %{elapsed}
 sidebar.just_now: たった今
 sidebar.minutes_ago: "%{count} 分前"

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -59,7 +59,7 @@ settings.usage: 用量
 settings.daemon: 守护进程
 settings.computer_use: 电脑操作
 settings.general_keywords: 通用 本地 项目 对话 隐私 匿名 使用数据 分析 分享 更新 自动 版本
-settings.appearance_keywords: 外观 主题 系统 浅色 深色 语言 英语 中文 简体
+settings.appearance_keywords: 外观 主题 系统 浅色 深色 语言 英语 中文 简体 侧边栏 对话 项目 分组
 settings.providers_keywords: 服务商 智能体 模型 命令行 版本 安装 检测 claude codex cursor opencode amp grok pi
 settings.skills: 技能
 settings.skills_keywords: 技能 技能库 智能体 禁用 启用 删除 claude codex cursor opencode pi amp 共享
@@ -135,6 +135,8 @@ web.error_secure_websocket_required: 安全的 Waku Web 页面只能通过 wss:/
 web.error_daemon_token_required: 请输入守护进程令牌
 settings.theme: 主题
 settings.theme_description: 选择跟随系统、浅色或深色主题
+settings.group_conversations_by_project: 按项目分组对话
+settings.group_conversations_by_project_description: 将侧边栏中的日期分组替换为可折叠的项目分组
 settings.theme_system: 跟随系统
 settings.theme_light: 浅色
 settings.theme_dark: 深色
@@ -209,6 +211,8 @@ sidebar.this_week: 本周
 sidebar.this_month: 本月
 sidebar.this_year: 今年
 sidebar.more: 更早
+sidebar.show_more: "再显示 %{count} 个"
+sidebar.show_less: 收起
 sidebar.working: 工作中 · %{elapsed}
 sidebar.just_now: 刚刚
 sidebar.minutes_ago: "%{count} 分钟前"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1258,6 +1258,10 @@ pub struct Waku {
     /// Date groups the user has folded in the sidebar. This is intentionally
     /// runtime-only, like transcript disclosure state.
     sidebar_collapsed_groups: HashSet<SessionDateGroup>,
+    /// Project groups folded while project grouping is active.
+    sidebar_collapsed_project_groups: HashSet<SidebarProjectGroup>,
+    /// Project groups expanded beyond the five-conversation preview.
+    sidebar_expanded_project_groups: HashSet<SidebarProjectGroup>,
     sidebar_visible: bool,
     sidebar_width: f32,
     right_panel_visible: bool,
@@ -1527,7 +1531,7 @@ use components::*;
 pub use image_preview::init as init_image_preview_keys;
 pub use settings::init as init_settings_keys;
 pub use sidebar::init as init_sidebar_keys;
-use sidebar::{SessionDateGroup, SidebarRow};
+use sidebar::{SessionDateGroup, SidebarProjectGroup, SidebarRow};
 pub use skills_page::init as init_skills_keys;
 use streaming::*;
 use transcript::*;
@@ -2685,6 +2689,8 @@ impl Waku {
                 session_rename: None,
                 session_rename_input,
                 sidebar_collapsed_groups: HashSet::new(),
+                sidebar_collapsed_project_groups: HashSet::new(),
+                sidebar_expanded_project_groups: HashSet::new(),
                 sidebar_visible,
                 sidebar_width,
                 right_panel_visible,

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -1402,6 +1402,54 @@ impl Waku {
             },
         );
 
+        let group_by_project = self.state.group_conversations_by_project;
+        let project_grouping_toggle = div()
+            .id("group-conversations-by-project-toggle")
+            .tab_index(0)
+            .focus_visible(|style| style.border_color(theme.accent))
+            .w(px(36.0))
+            .h(px(20.0))
+            .p(px(2.0))
+            .flex_none()
+            .rounded_full()
+            .cursor_default()
+            .bg(if group_by_project {
+                theme.inverse
+            } else {
+                theme.inset
+            })
+            .border_1()
+            .border_color(if group_by_project {
+                theme.inverse
+            } else {
+                theme.border_strong
+            })
+            .flex()
+            .items_center()
+            .when(group_by_project, |element| element.justify_end())
+            .child(
+                div()
+                    .w(px(14.0))
+                    .h(px(14.0))
+                    .rounded_full()
+                    .bg(if group_by_project {
+                        theme.on_inverse
+                    } else {
+                        theme.text_tertiary
+                    }),
+            )
+            .on_click(cx.listener(move |this, _, _, cx| {
+                this.set_group_conversations_by_project(!group_by_project, cx);
+            }))
+            .on_key_down(cx.listener(move |this, event: &KeyDownEvent, _, cx| {
+                if !event.keystroke.modifiers.modified()
+                    && matches!(event.keystroke.key.as_str(), "enter" | "space")
+                {
+                    this.set_group_conversations_by_project(!group_by_project, cx);
+                    cx.stop_propagation();
+                }
+            }));
+
         div()
             .mt(px(15.0))
             .w_full()
@@ -1472,6 +1520,40 @@ impl Waku {
                             ),
                     )
                     .child(language_selector),
+            )
+            .child(div().mx(px(20.0)).h(px(1.0)).bg(theme.border))
+            .child(
+                div()
+                    .w_full()
+                    .min_h(px(60.0))
+                    .px(px(20.0))
+                    .py(px(12.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(24.0))
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .child(
+                                div()
+                                    .text_size(px(13.5))
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .text_color(theme.text)
+                                    .child(tr!("settings.group_conversations_by_project")),
+                            )
+                            .child(
+                                div()
+                                    .mt(px(5.0))
+                                    .text_size(px(12.5))
+                                    .line_height(px(18.0))
+                                    .text_color(theme.text_secondary)
+                                    .child(tr!(
+                                        "settings.group_conversations_by_project_description"
+                                    )),
+                            ),
+                    )
+                    .child(project_grouping_toggle),
             )
             .into_any_element()
     }
@@ -2341,6 +2423,15 @@ impl Waku {
         }
         self.state.theme = preference;
         crate::theme::apply_theme_preference(preference, window, cx);
+        self.save();
+        cx.notify();
+    }
+
+    fn set_group_conversations_by_project(&mut self, enabled: bool, cx: &mut Context<Self>) {
+        if self.state.group_conversations_by_project == enabled {
+            return;
+        }
+        self.state.group_conversations_by_project = enabled;
         self.save();
         cx.notify();
     }

--- a/src/app/sidebar.rs
+++ b/src/app/sidebar.rs
@@ -7,6 +7,7 @@ actions!(waku_sidebar, [CancelSessionRename]);
 
 const SESSION_RENAME_PARENT_CONTEXT: &str = "SessionRename";
 const SESSION_RENAME_FIELD_CONTEXT: &str = "SessionRename > ComposerInput";
+const PROJECT_SESSION_PREVIEW_LIMIT: usize = 5;
 
 /// Keep Escape inside the focused inline editor so it cancels the rename,
 /// rather than falling through to the window-wide Stop action.
@@ -26,6 +27,21 @@ pub(super) enum SessionDateGroup {
     ThisMonth,
     ThisYear,
     More,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(super) enum SidebarProjectGroup {
+    Project(Uuid),
+    NoProject,
+}
+
+impl SidebarProjectGroup {
+    fn fingerprint(self) -> u64 {
+        match self {
+            Self::Project(id) => mix_uuid(0x70a1_ec7, id),
+            Self::NoProject => 0x70a1_ec7,
+        }
+    }
 }
 
 impl SessionDateGroup {
@@ -118,9 +134,35 @@ fn append_sidebar_group_rows(
         return;
     }
 
-    rows.push(SidebarRow::Header(group));
+    rows.push(SidebarRow::DateHeader(group));
     if !collapsed {
         rows.extend(sessions.iter().copied().map(SidebarRow::Session));
+    }
+    rows.push(SidebarRow::GroupSpacer);
+}
+
+fn append_sidebar_project_rows(
+    rows: &mut Vec<SidebarRow>,
+    group: SidebarProjectGroup,
+    sessions: &[Uuid],
+    collapsed: bool,
+    expanded: bool,
+) {
+    rows.push(SidebarRow::ProjectHeader(group));
+    if !collapsed {
+        let visible = if expanded {
+            sessions.len()
+        } else {
+            sessions.len().min(PROJECT_SESSION_PREVIEW_LIMIT)
+        };
+        rows.extend(sessions[..visible].iter().copied().map(SidebarRow::Session));
+        if sessions.len() > PROJECT_SESSION_PREVIEW_LIMIT {
+            rows.push(SidebarRow::ProjectLimit {
+                group,
+                remaining: sessions.len() - PROJECT_SESSION_PREVIEW_LIMIT,
+                expanded,
+            });
+        }
     }
     rows.push(SidebarRow::GroupSpacer);
 }
@@ -210,9 +252,17 @@ pub(super) enum SidebarRow {
     /// Opens the window-wide command palette and scrolls with history.
     Search,
     /// Date-group header; the first row also carries the project action.
-    Header(SessionDateGroup),
+    DateHeader(SessionDateGroup),
+    /// Project header used when project grouping is enabled.
+    ProjectHeader(SidebarProjectGroup),
     /// A started session.
     Session(Uuid),
+    /// Reveals all sessions in a project, or restores its five-item preview.
+    ProjectLimit {
+        group: SidebarProjectGroup,
+        remaining: usize,
+        expanded: bool,
+    },
     /// Spacing between date groups.
     GroupSpacer,
 }
@@ -747,14 +797,20 @@ impl Waku {
     /// tick for values that move at most once per stream commit. The
     /// fingerprint is an allocation-free scan of exactly what
     /// [`Self::sidebar_rows`] reads: started sessions in order with their
-    /// recency timestamps, the collapsed-group set, and today's date.
+    /// project and recency timestamps, disclosure state, grouping preference,
+    /// and today's date.
     fn sidebar_rows_cached(&self, today: NaiveDate) -> Rc<Vec<SidebarRow>> {
         let mut fingerprint = mix(0x51de_ba5e_5eed_c0de, today.num_days_from_ce() as u64);
+        fingerprint = mix(
+            fingerprint,
+            u64::from(self.state.group_conversations_by_project),
+        );
         for session in &self.state.sessions {
             if !session.has_started() {
                 continue;
             }
             fingerprint = mix_uuid(fingerprint, session.id);
+            fingerprint = mix_uuid(fingerprint, session.project_id);
             fingerprint = mix(fingerprint, sidebar_session_timestamp(session));
         }
         // A set has no stable iteration order; combine order-independently.
@@ -768,6 +824,32 @@ impl Waku {
             mix(fingerprint, self.sidebar_collapsed_groups.len() as u64),
             collapsed,
         );
+        let collapsed_projects = self
+            .sidebar_collapsed_project_groups
+            .iter()
+            .fold(0u64, |combined, group| {
+                combined.wrapping_add(group.fingerprint())
+            });
+        fingerprint = mix(
+            mix(
+                fingerprint,
+                self.sidebar_collapsed_project_groups.len() as u64,
+            ),
+            collapsed_projects,
+        );
+        let expanded_projects = self
+            .sidebar_expanded_project_groups
+            .iter()
+            .fold(0u64, |combined, group| {
+                combined.wrapping_add(group.fingerprint())
+            });
+        fingerprint = mix(
+            mix(
+                fingerprint,
+                self.sidebar_expanded_project_groups.len() as u64,
+            ),
+            expanded_projects,
+        );
         if self.sidebar_rows_fingerprint.get() != Some(fingerprint) {
             *self.sidebar_rows_snapshot.borrow_mut() = Rc::new(self.sidebar_rows(today));
             self.sidebar_rows_fingerprint.set(Some(fingerprint));
@@ -776,9 +858,8 @@ impl Waku {
     }
 
     /// Snapshot the session history as a flat list of lightweight rows, newest
-    /// first, grouped by calendar period like the previous eager render.
+    /// first, grouped by either calendar period or project.
     fn sidebar_rows(&self, today: NaiveDate) -> Vec<SidebarRow> {
-        let mut grouped_sessions: [Vec<Uuid>; 6] = std::array::from_fn(|_| Vec::new());
         let mut sorted_sessions = self
             .state
             .sessions
@@ -787,6 +868,46 @@ impl Waku {
             .collect::<Vec<_>>();
         sorted_sessions
             .sort_by_key(|session| std::cmp::Reverse(sidebar_session_timestamp(session)));
+
+        if self.state.group_conversations_by_project {
+            let mut groups: Vec<(SidebarProjectGroup, Vec<Uuid>)> = Vec::new();
+            let mut group_indexes = HashMap::new();
+            for session in sorted_sessions {
+                let group = self.sidebar_project_group(session.project_id);
+                let index = *group_indexes.entry(group).or_insert_with(|| {
+                    groups.push((group, Vec::new()));
+                    groups.len() - 1
+                });
+                groups[index].1.push(session.id);
+            }
+            // Named projects keep the order of their newest conversation;
+            // projectless work stays in one predictable section at the end.
+            if let Some(index) = groups
+                .iter()
+                .position(|(group, _)| *group == SidebarProjectGroup::NoProject)
+            {
+                let no_project = groups.remove(index);
+                groups.push(no_project);
+            }
+
+            let mut rows = vec![SidebarRow::Search];
+            for (group, sessions) in groups {
+                append_sidebar_project_rows(
+                    &mut rows,
+                    group,
+                    &sessions,
+                    self.sidebar_collapsed_project_groups.contains(&group),
+                    self.sidebar_expanded_project_groups.contains(&group),
+                );
+            }
+            if rows.len() == 1 {
+                // Keep the project action visible while there is no history.
+                rows.push(SidebarRow::ProjectHeader(SidebarProjectGroup::NoProject));
+            }
+            return rows;
+        }
+
+        let mut grouped_sessions: [Vec<Uuid>; 6] = std::array::from_fn(|_| Vec::new());
         for session in sorted_sessions {
             grouped_sessions[session_date_group(sidebar_session_timestamp(session), today).index()]
                 .push(session.id);
@@ -804,9 +925,19 @@ impl Waku {
         }
         if rows.len() == 1 {
             // Keep the project action visible while there is no history.
-            rows.push(SidebarRow::Header(SessionDateGroup::Today));
+            rows.push(SidebarRow::DateHeader(SessionDateGroup::Today));
         }
         rows
+    }
+
+    fn sidebar_project_group(&self, project_id: Uuid) -> SidebarProjectGroup {
+        self.state
+            .projects
+            .iter()
+            .find(|project| project.id == project_id)
+            .filter(|project| !project.is_projectless())
+            .map(|project| SidebarProjectGroup::Project(project.id))
+            .unwrap_or(SidebarProjectGroup::NoProject)
     }
 
     /// Keep the virtualized list in sync with the current row snapshot.
@@ -845,11 +976,21 @@ impl Waku {
         };
         match *row {
             SidebarRow::Search => self.render_sidebar_search(cx).into_any_element(),
-            SidebarRow::Header(group) => self
+            SidebarRow::DateHeader(group) => self
                 .render_sidebar_group_header(group, index == 1, cx)
+                .into_any_element(),
+            SidebarRow::ProjectHeader(group) => self
+                .render_sidebar_project_header(group, index == 1, cx)
                 .into_any_element(),
             SidebarRow::Session(session_id) => self
                 .render_sidebar_session_item(session_id, cx)
+                .into_any_element(),
+            SidebarRow::ProjectLimit {
+                group,
+                remaining,
+                expanded,
+            } => self
+                .render_sidebar_project_limit(group, remaining, expanded, cx)
                 .into_any_element(),
             SidebarRow::GroupSpacer => div().w_full().h(px(10.0)).into_any_element(),
         }
@@ -933,6 +1074,167 @@ impl Waku {
             self.sidebar_collapsed_groups.insert(group)
         } else {
             self.sidebar_collapsed_groups.remove(&group)
+        };
+        if changed {
+            cx.notify();
+        }
+    }
+
+    fn sidebar_project_group_label(&self, group: SidebarProjectGroup) -> String {
+        match group {
+            SidebarProjectGroup::Project(project_id) => self
+                .state
+                .projects
+                .iter()
+                .find(|project| project.id == project_id)
+                .map(Project::display_name)
+                .unwrap_or_else(|| tr!("sidebar.unknown_project")),
+            SidebarProjectGroup::NoProject => tr!("project.no_project_name"),
+        }
+    }
+
+    fn render_sidebar_project_header(
+        &self,
+        group: SidebarProjectGroup,
+        first: bool,
+        cx: &mut Context<Self>,
+    ) -> Div {
+        let theme = Theme::current(cx);
+        let collapsed = self.sidebar_collapsed_project_groups.contains(&group);
+        let chevron = icon("icons/chevron-down.svg", 11.0, theme.text_ghost)
+            .when(collapsed, |icon| {
+                icon.with_transformation(gpui::Transformation::rotate(gpui::percentage(0.75)))
+            });
+
+        session_group_header(&theme)
+            .w_full()
+            .child(
+                div()
+                    .id(SharedString::from(format!(
+                        "sidebar-project-group-toggle-{}",
+                        group.fingerprint()
+                    )))
+                    .tab_index(0)
+                    .h(px(22.0))
+                    .min_w_0()
+                    .rounded(px(4.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(5.0))
+                    .cursor_default()
+                    .focus_visible(|style| style.border_1().border_color(theme.accent))
+                    .child(chevron)
+                    .child(
+                        div()
+                            .min_w_0()
+                            .line_clamp(1)
+                            .text_overflow(gpui::TextOverflow::Truncate("...".into()))
+                            .child(self.sidebar_project_group_label(group)),
+                    )
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.toggle_sidebar_project_group(group, cx);
+                    }))
+                    .on_key_down(cx.listener(move |this, event: &KeyDownEvent, _, cx| {
+                        match event.keystroke.key.as_str() {
+                            "enter" | "space" => {
+                                this.toggle_sidebar_project_group(group, cx);
+                                cx.stop_propagation();
+                            }
+                            "left" if !collapsed => {
+                                this.set_sidebar_project_group_collapsed(group, true, cx);
+                                cx.stop_propagation();
+                            }
+                            "right" if collapsed => {
+                                this.set_sidebar_project_group_collapsed(group, false, cx);
+                                cx.stop_propagation();
+                            }
+                            _ => {}
+                        }
+                    })),
+            )
+            .when(first, |element| {
+                element
+                    .justify_between()
+                    .child(self.render_sidebar_project_action(cx))
+            })
+    }
+
+    fn render_sidebar_project_limit(
+        &self,
+        group: SidebarProjectGroup,
+        remaining: usize,
+        expanded: bool,
+        cx: &mut Context<Self>,
+    ) -> Div {
+        let theme = Theme::current(cx);
+        let label = if expanded {
+            tr!("sidebar.show_less")
+        } else {
+            tr!("sidebar.show_more", count = remaining)
+        };
+        div().w_full().h(px(30.0)).px(px(8.0)).child(
+            div()
+                .id(SharedString::from(format!(
+                    "sidebar-project-limit-{}",
+                    group.fingerprint()
+                )))
+                .tab_index(0)
+                .h_full()
+                .px(px(5.0))
+                .rounded(px(5.0))
+                .flex()
+                .items_center()
+                .cursor_default()
+                .text_size(px(11.5))
+                .text_color(theme.text_tertiary)
+                .focus_visible(|style| style.border_1().border_color(theme.accent))
+                .hover(|element| element.bg(theme.overlay).text_color(theme.text_secondary))
+                .child(label)
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.set_sidebar_project_group_expanded(group, !expanded, cx);
+                }))
+                .on_key_down(cx.listener(move |this, event: &KeyDownEvent, _, cx| {
+                    if !event.keystroke.modifiers.modified()
+                        && matches!(event.keystroke.key.as_str(), "enter" | "space")
+                    {
+                        this.set_sidebar_project_group_expanded(group, !expanded, cx);
+                        cx.stop_propagation();
+                    }
+                })),
+        )
+    }
+
+    fn toggle_sidebar_project_group(&mut self, group: SidebarProjectGroup, cx: &mut Context<Self>) {
+        let collapsed = !self.sidebar_collapsed_project_groups.contains(&group);
+        self.set_sidebar_project_group_collapsed(group, collapsed, cx);
+    }
+
+    fn set_sidebar_project_group_collapsed(
+        &mut self,
+        group: SidebarProjectGroup,
+        collapsed: bool,
+        cx: &mut Context<Self>,
+    ) {
+        let changed = if collapsed {
+            self.sidebar_collapsed_project_groups.insert(group)
+        } else {
+            self.sidebar_collapsed_project_groups.remove(&group)
+        };
+        if changed {
+            cx.notify();
+        }
+    }
+
+    fn set_sidebar_project_group_expanded(
+        &mut self,
+        group: SidebarProjectGroup,
+        expanded: bool,
+        cx: &mut Context<Self>,
+    ) {
+        let changed = if expanded {
+            self.sidebar_expanded_project_groups.insert(group)
+        } else {
+            self.sidebar_expanded_project_groups.remove(&group)
         };
         if changed {
             cx.notify();
@@ -1029,6 +1331,7 @@ impl Waku {
             .find(|project| project.id == session.project_id)
             .map(Project::display_name)
             .unwrap_or_else(|| tr!("sidebar.unknown_project"));
+        let grouped_by_project = self.state.group_conversations_by_project;
         let rename_input =
             (self.session_rename == Some(session_id)).then(|| self.session_rename_input.clone());
         let renaming = rename_input.is_some();
@@ -1124,15 +1427,19 @@ impl Waku {
                     .gap(px(5.0))
                     .text_size(px(11.5))
                     .line_height(px(15.0))
-                    .child(icon("icons/folder.svg", 11.0, theme.text_tertiary))
-                    .child(
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .truncate()
-                            .text_color(theme.text_tertiary)
-                            .child(SharedString::from(project_name)),
-                    )
+                    .when(!grouped_by_project, |element| {
+                        element
+                            .child(icon("icons/folder.svg", 11.0, theme.text_tertiary))
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .truncate()
+                                    .text_color(theme.text_tertiary)
+                                    .child(SharedString::from(project_name)),
+                            )
+                    })
+                    .when(grouped_by_project, |element| element.child(div().flex_1()))
                     .when_some(
                         session_time_label(session, unix_time()),
                         |element, label| {
@@ -1621,7 +1928,7 @@ mod tests {
         assert_eq!(
             expanded,
             vec![
-                SidebarRow::Header(SessionDateGroup::Today),
+                SidebarRow::DateHeader(SessionDateGroup::Today),
                 SidebarRow::Session(sessions[0]),
                 SidebarRow::Session(sessions[1]),
                 SidebarRow::GroupSpacer,
@@ -1633,7 +1940,61 @@ mod tests {
         assert_eq!(
             collapsed,
             vec![
-                SidebarRow::Header(SessionDateGroup::Today),
+                SidebarRow::DateHeader(SessionDateGroup::Today),
+                SidebarRow::GroupSpacer,
+            ]
+        );
+    }
+
+    #[test]
+    fn project_group_previews_five_sessions_before_show_more() {
+        let group = SidebarProjectGroup::Project(Uuid::from_u128(99));
+        let sessions = (1..=7).map(Uuid::from_u128).collect::<Vec<_>>();
+        let mut rows = Vec::new();
+
+        append_sidebar_project_rows(&mut rows, group, &sessions, false, false);
+
+        assert_eq!(rows[0], SidebarRow::ProjectHeader(group));
+        assert_eq!(
+            &rows[1..=5],
+            &sessions[..5]
+                .iter()
+                .copied()
+                .map(SidebarRow::Session)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            rows[6],
+            SidebarRow::ProjectLimit {
+                group,
+                remaining: 2,
+                expanded: false,
+            }
+        );
+        assert_eq!(rows[7], SidebarRow::GroupSpacer);
+    }
+
+    #[test]
+    fn expanded_and_collapsed_project_groups_keep_their_controls() {
+        let group = SidebarProjectGroup::NoProject;
+        let sessions = (1..=6).map(Uuid::from_u128).collect::<Vec<_>>();
+        let mut expanded = Vec::new();
+        append_sidebar_project_rows(&mut expanded, group, &sessions, false, true);
+        assert_eq!(
+            expanded[7],
+            SidebarRow::ProjectLimit {
+                group,
+                remaining: 1,
+                expanded: true,
+            }
+        );
+
+        let mut collapsed = Vec::new();
+        append_sidebar_project_rows(&mut collapsed, group, &sessions, true, false);
+        assert_eq!(
+            collapsed,
+            vec![
+                SidebarRow::ProjectHeader(group),
                 SidebarRow::GroupSpacer,
             ]
         );


### PR DESCRIPTION
This PR was produces exclusively with codex via waku, imagines and QA'd by me.
The idea is that it can serve a a discussion ground on the feature.

## Problem

The sidebar groups conversations by date even though conversations already belong to projects, making related work harder to scan together.

## Solution

- add an Appearance setting that replaces date sections with project sections
- make project sections collapsible and keep `No Project` as a separate section
- show the five most recent conversations per project with show-more/show-less controls
- preserve sidebar virtualization and keyboard operation

## Checks

- `cargo +1.96.0 check --locked`
- `cargo +1.96.0 test --locked -- --skip websocket_terminal_round_trip_streams_input_and_output`
- `bun run --filter @waku/client check`
- `bun run --filter @waku/client test`
- successful rebuild through the existing development watcher

## Known limitations / baseline notes

- visual QA completed in Waku Debug
- project grouping replaces date grouping while enabled; it does not combine both hierarchies
- the full Rust suite reaches an unrelated intermittent timeout in `websocket_terminal_round_trip_streams_input_and_output`; every other test passes
- the documented format command currently reports rustfmt differences in unchanged `main` files
- `bun run protocol:check` currently reports stale `ActivityFileChange` bindings already present on `main`

Closes #31


## Screenshots

Collapsible `No project` section replacing date grouping in the sidebar:

![Project-grouped conversation sidebar](https://raw.githubusercontent.com/olup/waku/pr-assets/pr-assets/pr-104-project-groups.png)

Appearance preference:

![Project grouping appearance setting](https://raw.githubusercontent.com/olup/waku/pr-assets/pr-assets/pr-103-104-105-appearance-settings.png)