### PR TITLE
Add a setting to collapse activity lists by default

### DIFF
--- a/crates/waku-client/src/persistence.rs
+++ b/crates/waku-client/src/persistence.rs
@@ -48,6 +48,10 @@ fn default_analytics_enabled() -> bool {
     true
 }
 
+fn default_collapse_activity_groups() -> bool {
+    true
+}
+
 fn default_provider() -> ProviderKind {
     ProviderKind::Codex
 }
@@ -215,6 +219,7 @@ pub struct AppSettings {
     pub favorite_models: Vec<FavoriteModel>,
     pub theme: ThemePreference,
     pub language: AppLanguage,
+    pub collapse_activity_groups_by_default: bool,
     pub daemon_exposure: DaemonExposureSettings,
 }
 
@@ -225,6 +230,7 @@ impl Default for AppSettings {
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
             language: AppLanguage::default(),
+            collapse_activity_groups_by_default: true,
             daemon_exposure: DaemonExposureSettings::default(),
         }
     }
@@ -291,6 +297,8 @@ pub struct PersistedState {
     pub theme: ThemePreference,
     #[serde(default)]
     pub language: AppLanguage,
+    #[serde(default = "default_collapse_activity_groups")]
+    pub collapse_activity_groups_by_default: bool,
     #[serde(default)]
     pub daemon_exposure: DaemonExposureSettings,
     #[serde(default = "default_sidebar_visibility")]
@@ -351,6 +359,7 @@ impl PersistedState {
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
             language: AppLanguage::default(),
+            collapse_activity_groups_by_default: true,
             daemon_exposure: DaemonExposureSettings::default(),
             sidebar_visible: true,
             right_panel_visible: false,
@@ -469,6 +478,7 @@ impl PersistedState {
             favorite_models: self.favorite_models.clone(),
             theme: self.theme,
             language: self.language,
+            collapse_activity_groups_by_default: self.collapse_activity_groups_by_default,
             daemon_exposure: self.daemon_exposure.clone(),
         }
     }
@@ -498,6 +508,7 @@ impl PersistedState {
         self.favorite_models = settings.favorite_models;
         self.theme = settings.theme;
         self.language = settings.language;
+        self.collapse_activity_groups_by_default = settings.collapse_activity_groups_by_default;
         self.daemon_exposure = settings.daemon_exposure;
     }
 
@@ -993,6 +1004,14 @@ mod tests {
                 [configuration_directory().join("settings.json")]
             );
         }
+    }
+
+    #[test]
+    fn activity_groups_default_to_collapsed_in_partial_settings() {
+        let settings: AppSettings = serde_json::from_str(r#"{"theme":"dark"}"#).unwrap();
+
+        assert_eq!(settings.theme, ThemePreference::Dark);
+        assert!(settings.collapse_activity_groups_by_default);
     }
 
     #[test]

--- a/crates/waku-core/src/persistence.rs
+++ b/crates/waku-core/src/persistence.rs
@@ -66,6 +66,10 @@ fn default_analytics_enabled() -> bool {
     true
 }
 
+fn default_collapse_activity_groups() -> bool {
+    true
+}
+
 fn default_provider() -> ProviderKind {
     ProviderKind::Codex
 }
@@ -191,6 +195,7 @@ pub struct AppSettings {
     pub favorite_models: Vec<FavoriteModel>,
     pub theme: ThemePreference,
     pub language: AppLanguage,
+    pub collapse_activity_groups_by_default: bool,
 }
 
 impl Default for AppSettings {
@@ -200,6 +205,7 @@ impl Default for AppSettings {
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
             language: AppLanguage::default(),
+            collapse_activity_groups_by_default: true,
         }
     }
 }
@@ -268,6 +274,8 @@ pub struct PersistedState {
     pub theme: ThemePreference,
     #[serde(default)]
     pub language: AppLanguage,
+    #[serde(default = "default_collapse_activity_groups")]
+    pub collapse_activity_groups_by_default: bool,
     #[serde(default = "default_sidebar_visibility")]
     pub sidebar_visible: bool,
     #[serde(default = "default_right_panel_visibility")]
@@ -338,6 +346,7 @@ impl PersistedState {
             favorite_models: Vec::new(),
             theme: ThemePreference::System,
             language: AppLanguage::default(),
+            collapse_activity_groups_by_default: true,
             sidebar_visible: true,
             right_panel_visible: false,
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
@@ -436,6 +445,7 @@ impl PersistedState {
             favorite_models: self.favorite_models.clone(),
             theme: self.theme,
             language: self.language,
+            collapse_activity_groups_by_default: self.collapse_activity_groups_by_default,
         }
     }
 
@@ -473,6 +483,7 @@ impl PersistedState {
         self.favorite_models = settings.favorite_models;
         self.theme = settings.theme;
         self.language = settings.language;
+        self.collapse_activity_groups_by_default = settings.collapse_activity_groups_by_default;
     }
 
     pub fn apply_daemon_settings(&mut self, settings: crate::DaemonSettings) {
@@ -1919,6 +1930,7 @@ mod tests {
         assert_eq!(settings.theme, ThemePreference::Dark);
         assert_eq!(settings.language, AppLanguage::System);
         assert!(settings.analytics_enabled);
+        assert!(settings.collapse_activity_groups_by_default);
     }
 
     #[test]
@@ -2684,6 +2696,7 @@ mod tests {
         let mut state = PersistedState::fresh(PathBuf::from("/tmp/project"));
         state.theme = ThemePreference::Light;
         state.language = AppLanguage::SimplifiedChinese;
+        state.collapse_activity_groups_by_default = false;
         state.sidebar_width = 301.0;
         store.save(&mut state).unwrap();
 
@@ -2696,6 +2709,7 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(value["theme"], "light");
         assert_eq!(value["language"], "simplified-chinese");
+        assert_eq!(value["collapse_activity_groups_by_default"], false);
         for daemon_key in [
             "computer_use_enabled",
             "computer_use_allowed_apps",
@@ -2739,6 +2753,7 @@ mod tests {
             "favorite_models",
             "theme",
             "language",
+            "collapse_activity_groups_by_default",
             "computer_use_enabled",
             "computer_use_allowed_apps",
             "disabled_providers",

--- a/crates/waku-protocol/src/settings.rs
+++ b/crates/waku-protocol/src/settings.rs
@@ -41,7 +41,13 @@ impl DaemonSettings {
     }
 
     pub fn discard_legacy_app_keys(&mut self) {
-        for key in ["analytics_enabled", "favorite_models", "theme", "language"] {
+        for key in [
+            "analytics_enabled",
+            "favorite_models",
+            "theme",
+            "language",
+            "collapse_activity_groups_by_default",
+        ] {
             self.extra.remove(key);
         }
     }

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -123,7 +123,7 @@ settings.computer_use:
 settings.general_keywords:
   en: general local projects conversations privacy analytics telemetry anonymous sharing updates automatic sparkle version
 settings.appearance_keywords:
-  en: appearance theme system light dark language english chinese simplified
+  en: appearance theme system light dark language english chinese simplified activities tools calls collapse expand
 settings.providers_keywords:
   en: providers agents models cli version install detect claude codex cursor opencode amp grok pi
 settings.skills:
@@ -274,6 +274,10 @@ settings.theme:
   en: Theme
 settings.theme_description:
   en: Choose between system, light, or dark themes
+settings.collapse_activity_groups:
+  en: Collapse activity lists by default
+settings.collapse_activity_groups_description:
+  en: Keep agent actions compact until you choose to expand them
 settings.theme_system:
   en: System
 settings.theme_light:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -63,7 +63,7 @@ settings.usage: 使用状況
 settings.daemon: デーモン
 settings.computer_use: コンピュータ操作
 settings.general_keywords: 一般 ローカル プロジェクト 会話 プライバシー 分析 テレメトリ 匿名 共有 アップデート 自動 バージョン
-settings.appearance_keywords: 外観 テーマ システム ライト ダーク 言語 英語 中国語 簡体字 日本語
+settings.appearance_keywords: 外観 テーマ システム ライト ダーク 言語 英語 中国語 簡体字 日本語 アクティビティ ツール 折りたたむ
 settings.providers_keywords: プロバイダー エージェント モデル CLI バージョン インストール 検出 claude codex cursor opencode amp grok pi
 settings.skills: スキル
 settings.skills_keywords: スキル ライブラリ エージェント 無効 有効 削除 claude codex cursor opencode pi amp 共有
@@ -139,6 +139,8 @@ web.error_secure_websocket_required: 安全な Waku Web ページからは wss:/
 web.error_daemon_token_required: デーモントークンを入力してください
 settings.theme: テーマ
 settings.theme_description: システム、ライト、ダークのいずれかのテーマを選択します
+settings.collapse_activity_groups: アクティビティリストをデフォルトで折りたたむ
+settings.collapse_activity_groups_description: 展開するまでエージェントの操作をコンパクトに表示します
 settings.theme_system: システム
 settings.theme_light: ライト
 settings.theme_dark: ダーク

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -59,7 +59,7 @@ settings.usage: 用量
 settings.daemon: 守护进程
 settings.computer_use: 电脑操作
 settings.general_keywords: 通用 本地 项目 对话 隐私 匿名 使用数据 分析 分享 更新 自动 版本
-settings.appearance_keywords: 外观 主题 系统 浅色 深色 语言 英语 中文 简体
+settings.appearance_keywords: 外观 主题 系统 浅色 深色 语言 英语 中文 简体 活动 工具 折叠
 settings.providers_keywords: 服务商 智能体 模型 命令行 版本 安装 检测 claude codex cursor opencode amp grok pi
 settings.skills: 技能
 settings.skills_keywords: 技能 技能库 智能体 禁用 启用 删除 claude codex cursor opencode pi amp 共享
@@ -135,6 +135,8 @@ web.error_secure_websocket_required: 安全的 Waku Web 页面只能通过 wss:/
 web.error_daemon_token_required: 请输入守护进程令牌
 settings.theme: 主题
 settings.theme_description: 选择跟随系统、浅色或深色主题
+settings.collapse_activity_groups: 默认折叠活动列表
+settings.collapse_activity_groups_description: 在手动展开前保持智能体操作列表紧凑
 settings.theme_system: 跟随系统
 settings.theme_light: 浅色
 settings.theme_dark: 深色

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -1402,6 +1402,54 @@ impl Waku {
             },
         );
 
+        let collapse_activities = self.state.collapse_activity_groups_by_default;
+        let collapse_activities_toggle = div()
+            .id("collapse-activity-groups-toggle")
+            .tab_index(0)
+            .focus_visible(|style| style.border_color(theme.accent))
+            .w(px(36.0))
+            .h(px(20.0))
+            .p(px(2.0))
+            .flex_none()
+            .rounded_full()
+            .cursor_default()
+            .bg(if collapse_activities {
+                theme.inverse
+            } else {
+                theme.inset
+            })
+            .border_1()
+            .border_color(if collapse_activities {
+                theme.inverse
+            } else {
+                theme.border_strong
+            })
+            .flex()
+            .items_center()
+            .when(collapse_activities, |element| element.justify_end())
+            .child(
+                div()
+                    .w(px(14.0))
+                    .h(px(14.0))
+                    .rounded_full()
+                    .bg(if collapse_activities {
+                        theme.on_inverse
+                    } else {
+                        theme.text_tertiary
+                    }),
+            )
+            .on_click(cx.listener(move |this, _, _, cx| {
+                this.set_collapse_activity_groups_by_default(!collapse_activities, cx);
+            }))
+            .on_key_down(cx.listener(move |this, event: &KeyDownEvent, _, cx| {
+                if !event.keystroke.modifiers.modified()
+                    && matches!(event.keystroke.key.as_str(), "enter" | "space")
+                {
+                    this.set_collapse_activity_groups_by_default(!collapse_activities, cx);
+                    cx.stop_propagation();
+                }
+            }));
+
         div()
             .mt(px(15.0))
             .w_full()
@@ -1472,6 +1520,38 @@ impl Waku {
                             ),
                     )
                     .child(language_selector),
+            )
+            .child(div().mx(px(20.0)).h(px(1.0)).bg(theme.border))
+            .child(
+                div()
+                    .w_full()
+                    .min_h(px(60.0))
+                    .px(px(20.0))
+                    .py(px(12.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(24.0))
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .child(
+                                div()
+                                    .text_size(px(13.5))
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .text_color(theme.text)
+                                    .child(tr!("settings.collapse_activity_groups")),
+                            )
+                            .child(
+                                div()
+                                    .mt(px(5.0))
+                                    .text_size(px(12.5))
+                                    .line_height(px(18.0))
+                                    .text_color(theme.text_secondary)
+                                    .child(tr!("settings.collapse_activity_groups_description")),
+                            ),
+                    )
+                    .child(collapse_activities_toggle),
             )
             .into_any_element()
     }
@@ -2341,6 +2421,20 @@ impl Waku {
         }
         self.state.theme = preference;
         crate::theme::apply_theme_preference(preference, window, cx);
+        self.save();
+        cx.notify();
+    }
+
+    fn set_collapse_activity_groups_by_default(
+        &mut self,
+        enabled: bool,
+        cx: &mut Context<Self>,
+    ) {
+        if self.state.collapse_activity_groups_by_default == enabled {
+            return;
+        }
+        self.state.collapse_activity_groups_by_default = enabled;
+        self.activities_expanded.clear();
         self.save();
         cx.notify();
     }

--- a/src/app/transcript_view.rs
+++ b/src/app/transcript_view.rs
@@ -1704,7 +1704,7 @@ impl Waku {
             .activities_expanded
             .get(&block_index)
             .copied()
-            .unwrap_or(live_turn);
+            .unwrap_or(!self.state.collapse_activity_groups_by_default && live_turn);
         let live_reasoning_id = (self
             .selected_runtime()
             .is_some_and(|runtime| runtime.stream_phase == Some(StreamPhase::Reasoning))


### PR DESCRIPTION
## Problem

Expanded agent activity lists consume a large part of the transcript even when the reader only needs the current action summary.

## Solution

- collapse grouped agent activity by default while preserving manual disclosure state
- add an Appearance setting that restores the existing live-turn expansion behavior
- persist the preference with a backward-compatible default

## Checks

- `cargo +1.96.0 check --locked`
- `cargo +1.96.0 test --locked`
- `bun run --filter @waku/client check`
- `bun run --filter @waku/client test`
- successful rebuild through the existing development watcher

## Known limitations / baseline notes

- visual QA completed in Waku Debug
- the preference applies to grouped activity disclosure; readers can still expand individual groups manually
- the documented format command currently reports rustfmt differences in unchanged `main` files
- `bun run protocol:check` currently reports stale `ActivityFileChange` bindings already present on `main`

Closes #99


## Screenshot

Default activity-list disclosure preference in Appearance:

![Collapse activity lists setting](https://raw.githubusercontent.com/olup/waku/pr-assets/pr-assets/pr-103-104-105-appearance-settings.png)