### PR TITLE
Add reasoning effort selection for Grok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ the original feature bullet instead of adding separate entries for them.
 ## [unreleased]
 
 - Codex thread goals: type /goal to set a persistent objective the task keeps pursuing — before or after the first message — with its autonomous pursuit streaming into the transcript, a status chip showing live budget or elapsed time, and a dialog to edit, pause, resume, or clear the goal (also in Waku Web)
-- Add reasoning effort selection for Grok, offered on the built-in grok-4.5 and grok-4.6 models; custom models from the Grok CLI config are listed without an effort menu
-- Stop offering the stale Grok Build fallback model when the Grok CLI's model discovery is unavailable; the current CLI rejects that model id
+- Add reasoning effort selection for Grok
 
 ## [0.1.14]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ the original feature bullet instead of adding separate entries for them.
 ## [unreleased]
 
 - Codex thread goals: type /goal to set a persistent objective the task keeps pursuing — before or after the first message — with its autonomous pursuit streaming into the transcript, a status chip showing live budget or elapsed time, and a dialog to edit, pause, resume, or clear the goal (also in Waku Web)
-- Add reasoning effort selection for Grok
+- Add reasoning effort selection for Grok, offered on the built-in grok-4.5 and grok-4.6 models; custom models from the Grok CLI config are listed without an effort menu
+- Stop offering the stale Grok Build fallback model when the Grok CLI's model discovery is unavailable; the current CLI rejects that model id
 
 ## [0.1.14]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ the original feature bullet instead of adding separate entries for them.
 ## [unreleased]
 
 - Codex thread goals: type /goal to set a persistent objective the task keeps pursuing — before or after the first message — with its autonomous pursuit streaming into the transcript, a status chip showing live budget or elapsed time, and a dialog to edit, pause, resume, or clear the goal (also in Waku Web)
+- Add reasoning effort selection for Grok
 
 ## [0.1.14]
 
@@ -53,7 +54,6 @@ the original feature bullet instead of adding separate entries for them.
 - macOS: Add "Open in.." button to open project folder in selected application
 
 ## [0.1.10]
-
 - Add Kimi Code support
 - Add Oh My Pi support
 - Fix markdown table rendering

--- a/crates/waku-core/src/driver/acp.rs
+++ b/crates/waku-core/src/driver/acp.rs
@@ -68,16 +68,24 @@ struct AcpLaunch {
     env: Vec<(String, String)>,
 }
 
-fn launch_for(provider: ProviderKind) -> anyhow::Result<AcpLaunch> {
+fn launch_for(provider: ProviderKind, reasoning_effort: Option<&str>) -> anyhow::Result<AcpLaunch> {
     match provider {
         ProviderKind::Cursor => Ok(AcpLaunch {
             args: vec!["acp".into()],
             env: Vec::new(),
         }),
-        ProviderKind::Grok => Ok(AcpLaunch {
-            args: vec!["agent".into(), "stdio".into()],
-            env: vec![("GROK_OAUTH2_REFERRER".into(), "waku".into())],
-        }),
+        ProviderKind::Grok => {
+            let mut args = vec!["agent".into()];
+            if let Some(effort) = reasoning_effort.filter(|effort| !effort.is_empty()) {
+                args.push("--reasoning-effort".into());
+                args.push(effort.to_owned());
+            }
+            args.push("stdio".into());
+            Ok(AcpLaunch {
+                args,
+                env: vec![("GROK_OAUTH2_REFERRER".into(), "waku".into())],
+            })
+        }
         ProviderKind::Fx => Ok(AcpLaunch {
             args: vec!["acp".into()],
             env: Vec::new(),
@@ -135,7 +143,7 @@ impl AcpDriver {
             None => None,
         };
 
-        let launch = launch_for(provider)?;
+        let launch = launch_for(provider, reasoning_effort.as_deref())?;
         let computer_use = (provider == ProviderKind::Grok && computer_use_enabled)
             .then(|| super::support::HeadlessComputerUseRuntime::start(provider, events.clone()))
             .transpose()?;
@@ -502,13 +510,14 @@ async fn run_sdk_connection(
             });
 
             let mut current_model = model;
+            let mut current_effort = reasoning_effort;
             apply_model(
                 &connection,
                 provider,
                 &session_id,
                 config_options.as_deref(),
                 current_model.as_deref(),
-                reasoning_effort.as_deref(),
+                current_effort.as_deref(),
                 &events,
             )
             .await;
@@ -612,15 +621,19 @@ async fn run_sdk_connection(
                         }
                     }
                     CommandMessage::Options(options) => {
-                        if options.model != current_model {
+                        if options.model != current_model
+                            || (provider == ProviderKind::Grok
+                                && options.reasoning_effort != current_effort)
+                        {
                             current_model = options.model;
+                            current_effort = options.reasoning_effort;
                             apply_model(
                                 &connection,
                                 provider,
                                 &session_id,
                                 config_options.as_deref(),
                                 current_model.as_deref(),
-                                options.reasoning_effort.as_deref(),
+                                current_effort.as_deref(),
                                 &events,
                             )
                             .await;
@@ -719,7 +732,8 @@ fn desired_mode(
 
 /// Which session config option carries reasoning effort. ACP leaves the id to
 /// the agent: Kimi Code exposes it as its `thinking` level, while the other
-/// agents Waku drives keep it on `mode`.
+/// agents Waku drives keep it on `mode`. Grok does not use this path: its
+/// effort rides on `session/set_model` as `_meta.reasoningEffort`.
 fn reasoning_effort_config_id(provider: ProviderKind) -> &'static str {
     match provider {
         ProviderKind::Kimi => "thinking",
@@ -953,6 +967,21 @@ fn fx_model_provider_switch<'a>(
     .then_some((provider, "gateway"))
 }
 
+fn set_model_params(
+    session_id: &SessionId,
+    model: &str,
+    reasoning_effort: Option<&str>,
+    provider: ProviderKind,
+) -> serde_json::Value {
+    let mut params = json!({"sessionId": session_id, "modelId": model});
+    if provider == ProviderKind::Grok
+        && let Some(effort) = reasoning_effort.filter(|effort| !effort.is_empty())
+    {
+        params["_meta"] = json!({"reasoningEffort": effort});
+    }
+    params
+}
+
 async fn apply_model(
     connection: &ConnectionTo<Agent>,
     provider: ProviderKind,
@@ -1066,7 +1095,7 @@ async fn apply_model(
     // stays on session/set_config_option, its documented model API.
     let request = match UntypedMessage::new(
         "session/set_model",
-        json!({"sessionId": session_id, "modelId": model}),
+        set_model_params(session_id, model, reasoning_effort, provider),
     ) {
         Ok(request) => request,
         Err(error) => {
@@ -1084,7 +1113,9 @@ async fn apply_model(
         )));
         return;
     }
-    if let Some(effort) = reasoning_effort {
+    if provider != ProviderKind::Grok
+        && let Some(effort) = reasoning_effort
+    {
         // Reasoning effort is an optional config extension and is deliberately
         // non-fatal when an agent does not expose it.
         let _ = connection
@@ -2081,7 +2112,7 @@ mod tests {
 
     #[test]
     fn fx_launches_its_documented_acp_subcommand() {
-        let launch = launch_for(ProviderKind::Fx).unwrap();
+        let launch = launch_for(ProviderKind::Fx, None).unwrap();
         assert_eq!(launch.args, ["acp"]);
         assert!(launch.env.is_empty());
     }
@@ -2379,6 +2410,29 @@ mod tests {
         assert!(matches!(&seen[0], DriverEvent::TextDelta(text) if text == "Hi! How can I help?"));
         assert!(matches!(&seen[1], DriverEvent::TextDelta(text) if text.starts_with("[context]")));
         assert!(state.produced_content);
+    }
+
+    #[test]
+    fn grok_launch_passes_reasoning_effort_before_stdio() {
+        let launch = launch_for(ProviderKind::Grok, Some("xhigh")).unwrap();
+        assert_eq!(
+            launch.args,
+            ["agent", "--reasoning-effort", "xhigh", "stdio"]
+        );
+        let bare = launch_for(ProviderKind::Grok, None).unwrap();
+        assert_eq!(bare.args, ["agent", "stdio"]);
+    }
+
+    #[test]
+    fn grok_set_model_includes_reasoning_effort_meta() {
+        let params = set_model_params(
+            &SessionId::new("sess"),
+            "grok-4.6",
+            Some("xhigh"),
+            ProviderKind::Grok,
+        );
+        assert_eq!(params["modelId"], "grok-4.6");
+        assert_eq!(params["_meta"]["reasoningEffort"], "xhigh");
     }
 
     #[test]

--- a/crates/waku-core/src/git_commit.rs
+++ b/crates/waku-core/src/git_commit.rs
@@ -783,6 +783,7 @@ mod tests {
                     assert!(has_pair(&args, "--tools", ""));
                     assert!(has(&args, "--no-memory"));
                     assert!(has(&args, "--no-subagents"));
+                    assert!(has_pair(&args, "--reasoning-effort", "low"));
                 }
                 ProviderKind::Pi => {
                     assert!(has(&args, "--print"));

--- a/crates/waku-core/src/model_catalog.rs
+++ b/crates/waku-core/src/model_catalog.rs
@@ -81,7 +81,9 @@ pub fn fallback_models(provider: ProviderKind) -> Vec<ProviderModel> {
         ProviderKind::Fx => Vec::new(),
         ProviderKind::OpenCode => Vec::new(),
         ProviderKind::Grok => {
-            vec![ProviderModel::new("grok-build", "Grok Build").default()]
+            vec![grok_reasoning_model(
+                ProviderModel::new("grok-build", "Grok Build").default(),
+            )]
         }
         // Pi, Oh My Pi, and Kimi Code all take their catalog from the user's
         // configured LLM providers. A fabricated fallback would make
@@ -505,7 +507,7 @@ fn parse_grok_models(output: &str) -> Vec<ProviderModel> {
             }
             let mut model = ProviderModel::new(id, display_name_from_slug(id));
             model.is_default = default_model.as_deref() == Some(id);
-            Some(model)
+            Some(grok_reasoning_model(model))
         })
         .collect()
 }
@@ -991,6 +993,19 @@ fn reasoning_options<const N: usize>(efforts: [&str; N]) -> Vec<ProviderModelOpt
         .collect()
 }
 
+/// Grok 4.6 and the `grok-build` alias advertise low/medium/high/xhigh.
+/// Grok 4.5's live catalog stops at high; offering xhigh would be ignored.
+fn grok_reasoning_model(model: ProviderModel) -> ProviderModel {
+    if waku_protocol::model_catalog::grok_model_supports_xhigh(&model.id) {
+        model.reasoning(
+            reasoning_options(["low", "medium", "high", "xhigh"]),
+            "high",
+        )
+    } else {
+        model.reasoning(reasoning_options(["low", "medium", "high"]), "high")
+    }
+}
+
 fn claude_reasoning_model(id: &str, name: &str) -> ProviderModel {
     ProviderModel::new(id, name).reasoning(
         reasoning_options(["low", "medium", "high", "xhigh", "max"]),
@@ -1397,8 +1412,42 @@ mod tests {
         assert_eq!(models.len(), 2);
         assert_eq!(models[0].id, "grok-4.6");
         assert!(models[0].is_default);
+        assert_eq!(
+            models[0]
+                .reasoning_efforts
+                .iter()
+                .map(|option| option.id.as_str())
+                .collect::<Vec<_>>(),
+            ["low", "medium", "high", "xhigh"]
+        );
+        assert_eq!(models[0].default_reasoning_effort.as_deref(), Some("high"));
         assert_eq!(models[1].id, "grok-4.5");
         assert!(!models[1].is_default);
+        assert_eq!(
+            models[1]
+                .reasoning_efforts
+                .iter()
+                .map(|option| option.id.as_str())
+                .collect::<Vec<_>>(),
+            ["low", "medium", "high"]
+        );
+        assert_eq!(models[1].default_reasoning_effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn grok_fallback_offers_xhigh_on_the_build_alias() {
+        let models = fallback_models(ProviderKind::Grok);
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "grok-build");
+        assert_eq!(
+            models[0]
+                .reasoning_efforts
+                .iter()
+                .map(|option| option.id.as_str())
+                .collect::<Vec<_>>(),
+            ["low", "medium", "high", "xhigh"]
+        );
+        assert_eq!(models[0].default_reasoning_effort.as_deref(), Some("high"));
     }
 
     #[test]

--- a/crates/waku-core/src/model_catalog.rs
+++ b/crates/waku-core/src/model_catalog.rs
@@ -80,11 +80,10 @@ pub fn fallback_models(provider: ProviderKind) -> Vec<ProviderModel> {
         // route, so discovery is authoritative.
         ProviderKind::Fx => Vec::new(),
         ProviderKind::OpenCode => Vec::new(),
-        ProviderKind::Grok => {
-            vec![grok_reasoning_model(
-                ProviderModel::new("grok-build", "Grok Build").default(),
-            )]
-        }
+        // Grok's catalog comes from `grok models`, which includes any custom
+        // model the user configured. An invented fallback would offer a model
+        // the CLI rejects, so discovery is authoritative.
+        ProviderKind::Grok => Vec::new(),
         // Pi, Oh My Pi, and Kimi Code all take their catalog from the user's
         // configured LLM providers. A fabricated fallback would make
         // unavailable models look selectable.
@@ -993,16 +992,19 @@ fn reasoning_options<const N: usize>(efforts: [&str; N]) -> Vec<ProviderModelOpt
         .collect()
 }
 
-/// Grok 4.6 and the `grok-build` alias advertise low/medium/high/xhigh.
-/// Grok 4.5's live catalog stops at high; offering xhigh would be ignored.
+/// The hardcoded reasoning menu is limited to the exact built-in models it
+/// was verified against. `grok models` also lists user-defined custom models,
+/// whose effort support is not knowable from the ID, so they get no menu.
 fn grok_reasoning_model(model: ProviderModel) -> ProviderModel {
-    if waku_protocol::model_catalog::grok_model_supports_xhigh(&model.id) {
-        model.reasoning(
-            reasoning_options(["low", "medium", "high", "xhigh"]),
+    match waku_protocol::model_catalog::grok_model_reasoning_efforts(&model.id) {
+        Some(efforts) => model.reasoning(
+            efforts
+                .iter()
+                .copied()
+                .map(|effort| ProviderModelOption::new(effort, reasoning_effort_label(effort))),
             "high",
-        )
-    } else {
-        model.reasoning(reasoning_options(["low", "medium", "high"]), "high")
+        ),
+        None => model,
     }
 }
 
@@ -1407,9 +1409,9 @@ mod tests {
     #[test]
     fn parses_grok_default_and_available_models() {
         let models = parse_grok_models(
-            "You are logged in with grok.com.\n\nDefault model: grok-4.6\n\nAvailable models:\n  * grok-4.6 (default)\n  - grok-4.5\n",
+            "You are logged in with grok.com.\n\nDefault model: grok-4.6\n\nAvailable models:\n  * grok-4.6 (default)\n  - grok-4.5\n  - my-custom-test\n",
         );
-        assert_eq!(models.len(), 2);
+        assert_eq!(models.len(), 3);
         assert_eq!(models[0].id, "grok-4.6");
         assert!(models[0].is_default);
         assert_eq!(
@@ -1432,22 +1434,19 @@ mod tests {
             ["low", "medium", "high"]
         );
         assert_eq!(models[1].default_reasoning_effort.as_deref(), Some("high"));
+        // A user-defined custom model keeps the picker entry but gets no
+        // hardcoded reasoning menu; its effort support is not knowable from
+        // the listing.
+        assert_eq!(models[2].id, "my-custom-test");
+        assert!(models[2].reasoning_efforts.is_empty());
+        assert_eq!(models[2].default_reasoning_effort, None);
     }
 
     #[test]
-    fn grok_fallback_offers_xhigh_on_the_build_alias() {
-        let models = fallback_models(ProviderKind::Grok);
-        assert_eq!(models.len(), 1);
-        assert_eq!(models[0].id, "grok-build");
-        assert_eq!(
-            models[0]
-                .reasoning_efforts
-                .iter()
-                .map(|option| option.id.as_str())
-                .collect::<Vec<_>>(),
-            ["low", "medium", "high", "xhigh"]
-        );
-        assert_eq!(models[0].default_reasoning_effort.as_deref(), Some("high"));
+    fn grok_fallback_catalog_is_empty() {
+        // A fabricated fallback would offer a model the CLI rejects, so
+        // discovery is authoritative and the pre-discovery picker is empty.
+        assert!(fallback_models(ProviderKind::Grok).is_empty());
     }
 
     #[test]

--- a/crates/waku-protocol/src/model_catalog.rs
+++ b/crates/waku-protocol/src/model_catalog.rs
@@ -64,7 +64,9 @@ pub fn fallback_models(provider: ProviderKind) -> Vec<ProviderModel> {
         | ProviderKind::OpenCode
         | ProviderKind::OhMyPi
         | ProviderKind::Pi => Vec::new(),
-        ProviderKind::Grok => vec![ProviderModel::new("grok-build", "Grok Build").default()],
+        ProviderKind::Grok => vec![grok_reasoning_model(
+            ProviderModel::new("grok-build", "Grok Build").default(),
+        )],
     }
 }
 
@@ -107,6 +109,26 @@ fn reasoning_options<const N: usize>(efforts: [&str; N]) -> Vec<ProviderModelOpt
         .collect()
 }
 
+/// Grok 4.6 and the `grok-build` alias advertise xhigh.
+/// Grok 4.5's live catalog stops at high; offering xhigh would be ignored.
+pub fn grok_model_supports_xhigh(id: &str) -> bool {
+    let slug = id.to_ascii_lowercase();
+    !slug.contains("4.5") && !slug.contains("4-5")
+}
+
+/// Mirrors the daemon catalog: Grok 4.5 stops at high; later models
+/// and the `grok-build` alias advertise xhigh.
+fn grok_reasoning_model(model: ProviderModel) -> ProviderModel {
+    if grok_model_supports_xhigh(&model.id) {
+        model.reasoning(
+            reasoning_options(["low", "medium", "high", "xhigh"]),
+            "high",
+        )
+    } else {
+        model.reasoning(reasoning_options(["low", "medium", "high"]), "high")
+    }
+}
+
 fn claude_reasoning_model(id: &str, name: &str) -> ProviderModel {
     ProviderModel::new(id, name).reasoning(
         reasoning_options(["low", "medium", "high", "xhigh", "max"]),
@@ -134,4 +156,33 @@ fn claude_long_context(model: ProviderModel) -> ProviderModel {
         ],
         "200k",
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grok_xhigh_gate_matches_live_catalog() {
+        assert!(grok_model_supports_xhigh("grok-4.6"));
+        assert!(grok_model_supports_xhigh("grok-build"));
+        assert!(!grok_model_supports_xhigh("grok-4.5"));
+        assert!(!grok_model_supports_xhigh("grok-4-5"));
+    }
+
+    #[test]
+    fn grok_fallback_offers_xhigh_on_the_build_alias() {
+        let models = fallback_models(ProviderKind::Grok);
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "grok-build");
+        assert_eq!(
+            models[0]
+                .reasoning_efforts
+                .iter()
+                .map(|option| option.id.as_str())
+                .collect::<Vec<_>>(),
+            ["low", "medium", "high", "xhigh"]
+        );
+        assert_eq!(models[0].default_reasoning_effort.as_deref(), Some("high"));
+    }
 }

--- a/crates/waku-protocol/src/model_catalog.rs
+++ b/crates/waku-protocol/src/model_catalog.rs
@@ -60,13 +60,11 @@ pub fn fallback_models(provider: ProviderKind) -> Vec<ProviderModel> {
         }
         ProviderKind::DeepSeek
         | ProviderKind::Fx
+        | ProviderKind::Grok
         | ProviderKind::Kimi
         | ProviderKind::OpenCode
         | ProviderKind::OhMyPi
         | ProviderKind::Pi => Vec::new(),
-        ProviderKind::Grok => vec![grok_reasoning_model(
-            ProviderModel::new("grok-build", "Grok Build").default(),
-        )],
     }
 }
 
@@ -109,23 +107,14 @@ fn reasoning_options<const N: usize>(efforts: [&str; N]) -> Vec<ProviderModelOpt
         .collect()
 }
 
-/// Grok 4.6 and the `grok-build` alias advertise xhigh.
-/// Grok 4.5's live catalog stops at high; offering xhigh would be ignored.
-pub fn grok_model_supports_xhigh(id: &str) -> bool {
-    let slug = id.to_ascii_lowercase();
-    !slug.contains("4.5") && !slug.contains("4-5")
-}
-
-/// Mirrors the daemon catalog: Grok 4.5 stops at high; later models
-/// and the `grok-build` alias advertise xhigh.
-fn grok_reasoning_model(model: ProviderModel) -> ProviderModel {
-    if grok_model_supports_xhigh(&model.id) {
-        model.reasoning(
-            reasoning_options(["low", "medium", "high", "xhigh"]),
-            "high",
-        )
-    } else {
-        model.reasoning(reasoning_options(["low", "medium", "high"]), "high")
+/// The exact Grok models the hardcoded reasoning menu is known to cover.
+/// `grok models` also lists user-defined custom models, whose effort support
+/// is not knowable from the ID, so they get no menu.
+pub fn grok_model_reasoning_efforts(id: &str) -> Option<&'static [&'static str]> {
+    match id.to_ascii_lowercase().as_str() {
+        "grok-4.5" => Some(&["low", "medium", "high"]),
+        "grok-4.6" => Some(&["low", "medium", "high", "xhigh"]),
+        _ => None,
     }
 }
 
@@ -163,26 +152,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn grok_xhigh_gate_matches_live_catalog() {
-        assert!(grok_model_supports_xhigh("grok-4.6"));
-        assert!(grok_model_supports_xhigh("grok-build"));
-        assert!(!grok_model_supports_xhigh("grok-4.5"));
-        assert!(!grok_model_supports_xhigh("grok-4-5"));
+    fn grok_reasoning_menu_covers_only_exact_builtins() {
+        assert_eq!(
+            grok_model_reasoning_efforts("grok-4.5"),
+            Some(&["low", "medium", "high"][..])
+        );
+        assert_eq!(
+            grok_model_reasoning_efforts("grok-4.6"),
+            Some(&["low", "medium", "high", "xhigh"][..])
+        );
+        // Custom models and unknown spellings get no menu.
+        assert_eq!(grok_model_reasoning_efforts("grok-build"), None);
+        assert_eq!(grok_model_reasoning_efforts("my-custom-test"), None);
+        assert_eq!(grok_model_reasoning_efforts("grok-4-6"), None);
     }
 
     #[test]
-    fn grok_fallback_offers_xhigh_on_the_build_alias() {
-        let models = fallback_models(ProviderKind::Grok);
-        assert_eq!(models.len(), 1);
-        assert_eq!(models[0].id, "grok-build");
-        assert_eq!(
-            models[0]
-                .reasoning_efforts
-                .iter()
-                .map(|option| option.id.as_str())
-                .collect::<Vec<_>>(),
-            ["low", "medium", "high", "xhigh"]
-        );
-        assert_eq!(models[0].default_reasoning_effort.as_deref(), Some("high"));
+    fn grok_fallback_catalog_is_empty() {
+        // A fabricated fallback would offer a model the CLI rejects, so
+        // discovery is authoritative and the pre-discovery picker is empty.
+        assert!(fallback_models(ProviderKind::Grok).is_empty());
     }
 }

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -572,7 +572,7 @@ received them.
 
 ## Agent Client Protocol
 
-**Launch** — `cursor-agent acp`, `fx acp`, `grok agent stdio`, `kimi acp`
+**Launch** — `cursor-agent acp`, `fx acp`, `grok agent [--reasoning-effort E] stdio`, `kimi acp`
 ([driver/acp.rs](../crates/waku-core/src/driver/acp.rs)).
 
 **Protocol** — newline-delimited JSON-RPC over stdio, bidirectional. One agent
@@ -716,7 +716,9 @@ its permission mode (`default`/`plan`/`auto`/`yolo`) and its effort lives on
 `thinking`. `reasoning_effort_config_id` resolves that per provider — sending
 the default id to Kimi would silently set nothing, or worse, move the permission
 mode. The call is non-fatal either way, since an agent may expose no effort at
-all.
+all. Grok is the exception: effort rides on `session/set_model` as
+`_meta.reasoningEffort` (and as `--reasoning-effort` at launch), not as a
+session config option.
 
 Kimi's catalog comes from `kimi provider list --json`, which covers both the
 managed plan and any registry the user imported with `kimi provider add`. Only

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -720,6 +720,13 @@ all. Grok is the exception: effort rides on `session/set_model` as
 `_meta.reasoningEffort` (and as `--reasoning-effort` at launch), not as a
 session config option.
 
+Grok's catalog comes from the plain-text `grok models` listing, which reports
+ids but no effort metadata. The hardcoded menu therefore covers only the exact
+built-ins (`grok-4.5` stops at high, `grok-4.6` offers xhigh): the listing also
+includes custom models from the user's config, whose effort support the id
+alone cannot establish, so they are offered without an effort menu. Discovery
+is authoritative — a stale fallback would name a model the CLI rejects.
+
 Kimi's catalog comes from `kimi provider list --json`, which covers both the
 managed plan and any registry the user imported with `kimi provider add`. Only
 the K3 family reports `supportEfforts`; the rest expose a single always-on


### PR DESCRIPTION
## Summary

- Add reasoning effort selection for Grok, matching Claude/Codex.
- Pass `--reasoning-effort` on `grok agent … stdio` launch.
- Apply mid-session effort changes with `session/set_model` `_meta.reasoningEffort`.
- Offer `xhigh` on grok-4.6; grok-4.5 stops at `high`. The hardcoded menu covers only the exact built-in ids — `grok models` also lists user-defined custom models, which keep their picker entry but no effort menu.
- Drop the stale `grok-build` fallback entry: the current CLI rejects that model id (`session/set_model` → `unknown model id`), so discovery is authoritative and the pre-discovery picker is empty.

Fixes #123.

## Why

Grok already accepts `--reasoning-effort` and `_meta.reasoningEffort`, but Waku never exposed the picker.

## Validation

- `cargo test -p waku-core --lib grok`
- `cargo test -p waku-protocol --lib model_catalog::tests`
- `cargo test -p waku-core --lib every_provider_uses_a_noninteractive_generation_mode`
- `cargo test -p waku-protocol --lib` (56 passed), `cargo test -p waku-core --lib` (342 passed), `cargo check -p waku-daemon -p waku-client`