### PR TITLE
Round client-decorated window corners on the surfaces that reach them

### DIFF
--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1,3 +1,4 @@
+use super::window_chrome::{ClientCorners, ClientCornersExt};
 use super::*;
 
 fn should_render_empty_state(session: Option<&AgentSession>) -> bool {
@@ -325,6 +326,14 @@ impl Render for Waku {
                     .flex()
                     .flex_col()
                     .bg(theme.surface)
+                    // Whichever edge no panel covers is an edge this column
+                    // reaches, so it has to round those window corners itself.
+                    .when(panels.sidebar <= 0.0, |element| {
+                        element.rounded_client_corners(ClientCorners::Left, window)
+                    })
+                    .when(panels.right_panel <= 0.0, |element| {
+                        element.rounded_client_corners(ClientCorners::Right, window)
+                    })
                     .when(panels.sidebar > 0.0, |element| {
                         element.border_l_1().border_color(theme.sidebar_border)
                     })

--- a/src/app/right_panel.rs
+++ b/src/app/right_panel.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use super::window_chrome::{ClientCorners, ClientCornersExt};
 use super::*;
 
 const TAB_SCROLL_FADE_WIDTH: f32 = 24.0;
@@ -2177,6 +2178,9 @@ impl Waku {
             .border_l_1()
             .border_color(theme.border_strong)
             .bg(theme.surface)
+            // Pinned to the window's right edge, so both right corners of a
+            // client-drawn frame are this panel's to round.
+            .rounded_client_corners(ClientCorners::Right, window)
             .relative()
             .child(self.render_right_panel_header(window, cx))
             .child(body)

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -1,6 +1,7 @@
 use gpui::actions;
 
 use super::composer::next_picker_highlight;
+use super::window_chrome::{ClientCorners, ClientCornersExt};
 use super::*;
 
 actions!(waku_settings, [ClearSearch]);
@@ -119,6 +120,7 @@ impl Waku {
             .size_full()
             .flex()
             .bg(theme.canvas)
+            .rounded_client_corners(ClientCorners::Both, window)
             .text_color(theme.text)
             .font_family(".SystemUIFont")
             .child(self.render_settings_sidebar(window, cx))
@@ -197,6 +199,7 @@ impl Waku {
             .flex()
             .flex_col()
             .bg(theme.sidebar)
+            .rounded_client_corners(ClientCorners::Left, window)
             .child(self.render_settings_sidebar_titlebar(window, cx))
             .child(
                 div().px(px(12.0)).child(
@@ -327,6 +330,7 @@ impl Waku {
                 .border_l_1()
                 .border_color(theme.sidebar_border)
                 .bg(theme.surface)
+                .rounded_client_corners(ClientCorners::Right, window)
                 .children(right_window_controls.map(|controls| {
                     self.render_settings_drag_region("settings-skills-titlebar", cx)
                         .flex()
@@ -400,6 +404,7 @@ impl Waku {
             .border_l_1()
             .border_color(theme.sidebar_border)
             .bg(theme.surface)
+            .rounded_client_corners(ClientCorners::Right, window)
             .child(
                 self.render_settings_drag_region("settings-content-titlebar", cx)
                     .flex()

--- a/src/app/sidebar.rs
+++ b/src/app/sidebar.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Datelike, Days, Local, NaiveDate, Utc};
 use gpui::{KeyBinding, actions};
 
+use super::window_chrome::{ClientCorners, ClientCornersExt};
 use super::*;
 
 actions!(waku_sidebar, [CancelSessionRename]);
@@ -689,6 +690,9 @@ impl Waku {
             } else {
                 theme.sidebar
             })
+            // The sidebar is pinned to the window's left edge, so it owns both
+            // left corners of a client-drawn frame whenever it is on screen.
+            .rounded_client_corners(ClientCorners::Left, window)
             .child(self.render_sidebar_titlebar(window, cx))
             .child(
                 div()

--- a/src/app/window_chrome.rs
+++ b/src/app/window_chrome.rs
@@ -16,6 +16,56 @@ use crate::ui::{icon, tooltip::Tooltip};
 
 const CLIENT_FRAME_INSET: f32 = 10.0;
 const CLIENT_FRAME_ROUNDING: f32 = 10.0;
+const CLIENT_FRAME_BORDER: f32 = 1.0;
+/// The frame's border sits outside the content it wraps, so a surface that
+/// reaches a window corner has to round one border tighter to stay concentric
+/// with the arc the frame draws.
+const CLIENT_CONTENT_ROUNDING: f32 = CLIENT_FRAME_ROUNDING - CLIENT_FRAME_BORDER;
+
+/// The pair of window corners a surface is responsible for rounding.
+#[derive(Clone, Copy)]
+pub(super) enum ClientCorners {
+    Left,
+    Right,
+    Both,
+}
+
+/// Round whichever window corners this surface covers.
+///
+/// GPUI masks content with a rectangle, so the `overflow_hidden` on the client
+/// frame clips its children to the frame's box and not to its radius. A child
+/// that paints an opaque background into a corner therefore has to round
+/// itself, or its square fill shows through outside the frame's border arc.
+/// Server-decorated windows round nothing, because the compositor owns the
+/// corners there.
+pub(super) trait ClientCornersExt: Styled + Sized {
+    fn rounded_client_corners(mut self, corners: ClientCorners, window: &Window) -> Self {
+        let Decorations::Client { tiling } = window.window_decorations() else {
+            return self;
+        };
+        let radius = px(CLIENT_CONTENT_ROUNDING);
+        let (left, right) = match corners {
+            ClientCorners::Left => (true, false),
+            ClientCorners::Right => (false, true),
+            ClientCorners::Both => (true, true),
+        };
+        if left && !(tiling.top || tiling.left) {
+            self = self.rounded_tl(radius);
+        }
+        if right && !(tiling.top || tiling.right) {
+            self = self.rounded_tr(radius);
+        }
+        if left && !(tiling.bottom || tiling.left) {
+            self = self.rounded_bl(radius);
+        }
+        if right && !(tiling.bottom || tiling.right) {
+            self = self.rounded_br(radius);
+        }
+        self
+    }
+}
+
+impl<T: Styled + Sized> ClientCornersExt for T {}
 
 #[derive(Clone, Copy)]
 pub(super) enum WindowControlSide {
@@ -40,7 +90,7 @@ impl Waku {
 
         let inset = px(CLIENT_FRAME_INSET);
         let rounding = px(CLIENT_FRAME_ROUNDING);
-        let border = px(1.0);
+        let border = px(CLIENT_FRAME_BORDER);
         let theme = Theme::current(cx);
         window.set_client_inset(inset);
 


### PR DESCRIPTION
Fixes #124.

### Problem

On a client-decorated window, the corner fill runs past the rounded border, leaving a square wedge of colour outside the arc.

`render_window_frame` sets `.overflow_hidden()` on the client frame, which reads as though it clips children to the frame's rounded shape. GPUI's `ContentMask` is a plain rectangle with no radius field, so children are clipped to the frame's box but not to its curve. The frame's own background rounds correctly; a child painting an opaque background into a corner still paints a square one underneath.

### Solution

Add a `ClientCornersExt::rounded_client_corners` helper and apply it to each surface that can reach a window edge, rather than relying on clipping — the same approach Zed takes for this GPUI limitation with its `rounded_client_corners` theme helper.

The radius is `CLIENT_FRAME_ROUNDING - CLIENT_FRAME_BORDER`, one pixel tighter than the frame, so the content arc sits concentric inside the border arc.

Which surface owns a corner depends on what is open, so the helper is applied in seven places: the sidebar and right panel own their side's corners whenever they are on screen, the main column takes over whichever side is uncovered, and the settings view covers its own three surfaces.

### Scope

No effect off Linux. The helper returns early unless `window.window_decorations()` reports `Decorations::Client`; only the X11 and Wayland window backends override the default, which is `Decorations::Server`, so macOS and Windows are unchanged. It also honours `tiling`, so a tiled or maximised edge stays square.

### Checks

- `cargo fmt` — clean on the changed files
- `cargo check --workspace` — clean
- `cargo test --workspace` — one failure, `waku-core` `websocket_terminal_round_trip_streams_input_and_output`, which fails identically on a clean tree here and is in a crate this change does not touch
- `bun run --filter @waku/client check` and `test` — clean
- Validated in the debug app on GNOME 50.4 / Wayland: all four corners, sidebar collapsed and open, right panel open, and the settings view

`bun run protocol:check` reports stale generated bindings, but it does so on a clean `main` here too, and no wire type changes in this PR.

### Limitations

Verified on Wayland only. Untested on X11 and on a tiling window manager, though the tiling state is honoured in code. The radius is derived rather than measured, so it may want adjusting if the frame constants change.