### PR TITLE
Bind the Insert-key clipboard chords outside macOS

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -133,6 +133,12 @@ pub fn init(cx: &mut App) {
             Some("ComposerInput"),
         ),
         KeyBinding::new("ctrl-shift-right", SelectToNextWord, Some("ComposerInput")),
+        // The older clipboard chords, still the default on X11 and still what
+        // dictation and terminal tools send when they inject a paste rather
+        // than typing the text out character by character.
+        KeyBinding::new("shift-insert", Paste, Some("ComposerInput")),
+        KeyBinding::new("ctrl-insert", Copy, Some("ComposerInput")),
+        KeyBinding::new("shift-delete", Cut, Some("ComposerInput")),
     ]);
 }
 


### PR DESCRIPTION
Fixes #125.

### Problem

Paste is bound only to `secondary-v`, which is Ctrl+V away from macOS. The Insert-key family is never bound, so Shift+Insert, Ctrl+Insert and Shift+Delete do nothing in the composer on Linux and Windows.

Shift+Insert matters more than it first appears. It is the paste chord that works in both GUI text fields and terminals on Linux, since terminals use Ctrl+Shift+V and readline treats Ctrl+V as quoted-insert. That makes it the default chord for dictation and other text-injection tools, which put text on the clipboard and synthesise a paste rather than typing it out character by character. Those tools send one chord globally and cannot pick a different one per focused window, so an unbound Shift+Insert makes dictation into Waku look like it silently fails.

### Solution

Bind Shift+Insert to `Paste`, Ctrl+Insert to `Copy`, and Shift+Delete to `Cut` in the existing `#[cfg(not(target_os = "macos"))]` block, alongside the word-motion chords already there.

### Scope

macOS is unaffected — the block is compiled out there. Windows picks the chords up, which I believe is correct, as these are the long-standing Windows clipboard chords. No existing binding is displaced: `ctrl-delete` stays `DeleteToNextWord`, and the Insert chords were unbound.

### Checks

- `cargo fmt` — clean on the changed file
- `cargo check --workspace` — clean
- `cargo test --workspace` — one failure, `waku-core` `websocket_terminal_round_trip_streams_input_and_output`, which fails identically on a clean tree here and is in a crate this change does not touch
- `bun run --filter @waku/client check` and `test` — clean
- Validated in the debug app on GNOME 50.4 / Wayland: Shift+Insert pastes into the composer, including from a dictation tool driving it over libei

`bun run protocol:check` reports stale generated bindings, but it does so on a clean `main` here too, and there are no wire type changes in this PR.

### Limitations

Untested on Windows and on X11. Only the composer context is bound, matching the surrounding bindings; other text inputs are not in scope here.