### PR TITLE
perf(waku-core): parse session.history as message-level typed events

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -29,7 +29,7 @@ rustflags = ["-C", "target-feature=+crt-static"]
 rustflags = ["-C", "link-arg=-arm64hazardfree"]
 
 [build]
-jobs = 4
+jobs = 8
 
 [profile.dev]
 debug = "line-tables-only"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8376,7 +8376,6 @@ dependencies = [
  "rusqlite",
  "rust-i18n",
  "serde",
- "serde-saphyr",
  "serde_json",
  "smol",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,8 +180,8 @@ windows-sys = { version = "0.61", features = [
 ed25519-dalek = "2"
 
 [profile.release]
-lto = "thin"
-codegen-units = 1
+lto = "off"
+codegen-units = 16
 strip = true
 
 # Keep debug assertions and incremental builds for app code, but do not run

--- a/crates/waku-core/Cargo.toml
+++ b/crates/waku-core/Cargo.toml
@@ -19,8 +19,7 @@ parking_lot = "0.12"
 rust-i18n = "4"
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
-serde-saphyr = { version = "0.0.29", default-features = false, features = ["deserialize"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["raw_value"] }
 smol = "2"
 subtle = "2"
 toml = "0.8"

--- a/crates/waku-core/src/deepseek_history.rs
+++ b/crates/waku-core/src/deepseek_history.rs
@@ -1,0 +1,671 @@
+//! Typed, allocation-lean parsing of DeepSeek Harness `session.history`
+//! responses.
+//!
+//! The HTTP body of a history response is one RPC envelope
+//! (`{type, rpcId, result: {ok, value}}`) whose `value` is a history page
+//! (`{events: [{event, view?}], hasMore, projections?}`). Parsing that whole
+//! envelope into `serde_json::Value` — what the driver did before — builds a
+//! full value tree (millions of allocations for a large page) even though the
+//! driver reads only a handful of fields per event.
+//!
+//! Instead the page is deserialized into typed structs mirroring the wire
+//! contract in deepseek-harness:
+//! `packages/host/apiproxy/src/api/sessions.schema.ts` (envelope/page/entry),
+//! `packages/core/session/src/types.ts` (the `SessionEvent` map), and
+//! `packages/llm/llm/src/types.ts` + `message.ts` (chunks and content blocks).
+//! The wire contract marks event `data` as wide (`unknown`), so the typed
+//! `data` struct here is a tolerant union of exactly the fields the driver
+//! reads; unknown fields and unknown event types are ignored.
+//!
+//! Escaped-string fields (`chunk.text`, `arguments`, `title`, ...) are
+//! captured as borrowed `&RawValue`. serde.rs cannot hand out a borrowed
+//! decoded `&str` for an escaped string (the escape work needs an owned
+//! buffer, so such fields can only deserialize into `String`), but
+//! `&RawValue` is zero-copy: it borrows the raw escaped slice straight out of
+//! the input bytes, with no per-field allocation during the parse. Text
+//! fields are decoded individually when events are converted — at message
+//! level a page carries only a few hundred texts, so there is no need for a
+//! deduplicated decode pool.
+
+
+use anyhow::{anyhow, Context as _};
+use serde::Deserialize;
+use serde_json::value::RawValue;
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Wire schema (borrowed: `&RawValue` text fields are zero-copy)
+// ---------------------------------------------------------------------------
+
+/// Full HTTP body of one RPC response: `{type, rpcId, result: {ok, value}}`.
+#[derive(Deserialize)]
+#[serde(bound(deserialize = "'de: 'a"))]
+struct Envelope<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    #[serde(rename = "rpcId")]
+    rpc_id: &'a str,
+    result: EnvelopeResult<'a>,
+}
+
+#[derive(Deserialize)]
+#[serde(bound(deserialize = "'de: 'a"))]
+struct EnvelopeResult<'a> {
+    ok: bool,
+    value: &'a RawValue,
+}
+
+/// `session.history` response value: `{events, hasMore, projections?}`.
+#[derive(Deserialize)]
+#[serde(bound(deserialize = "'de: 'a"))]
+pub(crate) struct HistoryPage<'a> {
+    pub(crate) events: Vec<HistoryEntry<'a>>,
+    #[serde(rename = "hasMore")]
+    pub(crate) has_more: bool,
+    #[serde(default)]
+    pub(crate) projections: Option<ProjectionsBlock<'a>>,
+}
+
+#[derive(Deserialize)]
+#[serde(bound(deserialize = "'de: 'a"))]
+pub(crate) struct ProjectionsBlock<'a> {
+    pub(crate) values: &'a RawValue,
+}
+
+/// One history item: `{event, view?}`. The host-computed tool `view` stays
+/// raw; it is parsed to `Value` only for tool events that present it.
+#[derive(Deserialize)]
+#[serde(bound(deserialize = "'de: 'a"))]
+pub(crate) struct HistoryEntry<'a> {
+    #[serde(default)]
+    pub(crate) event: Option<HistoryEventWire<'a>>,
+    #[serde(default)]
+    pub(crate) view: Option<&'a RawValue>,
+}
+
+/// SessionEvent envelope: `{type, seq, time, data, ...}`. Only the fields the
+/// driver reads are captured; `time`, `sourceEventSeqs`, `surfaceOp` and
+/// `ignorable` are skipped.
+#[derive(Deserialize)]
+#[serde(bound(deserialize = "'de: 'a"))]
+pub(crate) struct HistoryEventWire<'a> {
+    #[serde(rename = "type")]
+    pub(crate) kind: &'a str,
+    pub(crate) seq: u64,
+    pub(crate) data: EventDataWire<'a>,
+}
+
+/// Tolerant union of the `data` fields the driver reads, per the event map in
+/// `packages/core/session/src/types.ts` (SessionEventMap). Unknown fields and
+/// unknown event types are ignored by construction. Text-bearing fields are
+/// `&RawValue` so they stay undecoded (and unallocated) until the batch pass.
+#[derive(Deserialize, Default)]
+#[serde(bound(deserialize = "'de: 'a"))]
+pub(crate) struct EventDataWire<'a> {
+    pub(crate) turn: Option<u64>,
+    pub(crate) step: Option<u64>,
+    /// Only the delta-bearing fields are kept: they feed orphan-step text
+    /// aggregation for aborted turns.
+    pub(crate) chunk: Option<StreamChunkWire<'a>>,
+    /// `data.message` — raw, because its shape differs per event type: a
+    /// content-block list for `assistant/message`/`user/message`, a nested
+    /// tool-result block for `tool/result`.
+    #[serde(default)]
+    pub(crate) message: Option<&'a RawValue>,
+    #[serde(rename = "callId")]
+    pub(crate) call_id: Option<&'a str>,
+    pub(crate) name: Option<&'a str>,
+    /// `data.arguments` — raw JSON string as produced by the model.
+    #[serde(default)]
+    pub(crate) arguments: Option<&'a RawValue>,
+    /// `turn/end` carries `{kind, error?}`; `request/header` carries a plain
+    /// string (`'initial' | 'resume' | 'change'`). Accept both.
+    #[serde(default)]
+    pub(crate) reason: Option<ReasonWire<'a>>,
+    #[serde(default)]
+    pub(crate) todos: Option<&'a RawValue>,
+    #[serde(rename = "contextWindow")]
+    pub(crate) context_window: Option<u64>,
+    #[serde(default)]
+    pub(crate) title: Option<&'a RawValue>,
+    /// `data.usage` on `assistant/message` events.
+    #[serde(default)]
+    pub(crate) usage: Option<&'a RawValue>,
+    /// `data.error` on `tool/result` events (internal failure identity).
+    #[serde(default)]
+    pub(crate) error: Option<&'a RawValue>,
+}
+
+/// StreamChunk: only the delta fields needed to aggregate aborted-step text.
+#[derive(Deserialize, Default)]
+#[serde(bound(deserialize = "'de: 'a"))]
+pub(crate) struct StreamChunkWire<'a> {
+    #[serde(rename = "type")]
+    pub(crate) kind: &'a str,
+    #[serde(default)]
+    pub(crate) text: Option<&'a RawValue>,
+}
+
+/// `data.reason`: the `turn/end` object or the `request/header` string.
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub(crate) enum ReasonWire<'a> {
+    Obj(TurnEndReasonWire<'a>),
+    /// `request/header` events carry a plain string reason; the untagged
+    /// fallback keeps them from failing the whole page parse. Never read.
+    #[allow(dead_code)]
+    Str(&'a str),
+}
+
+#[derive(Deserialize, Default)]
+#[serde(bound(deserialize = "'de: 'a"))]
+pub(crate) struct TurnEndReasonWire<'a> {
+    #[serde(default)]
+    pub(crate) kind: Option<&'a str>,
+    #[serde(default)]
+    pub(crate) error: Option<LlmFailureWire<'a>>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(bound(deserialize = "'de: 'a"))]
+pub(crate) struct LlmFailureWire<'a> {
+    #[serde(default)]
+    pub(crate) message: Option<&'a RawValue>,
+}
+
+// ---------------------------------------------------------------------------
+// Owned, pool-referencing event model consumed by the driver
+// ---------------------------------------------------------------------------
+
+/// Why a `turn/end` event ended (mirrors `TurnEndReason`).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TurnEndKind {
+    Completed,
+    Aborted,
+    Blocked,
+    Error,
+    MaxTokens,
+    Interrupted,
+    Other,
+}
+
+/// Token accounting for one model call (mirrors `TokenUsage`).
+#[derive(Clone, Copy, Default)]
+pub(crate) struct TokenUsage {
+    pub(crate) input_tokens: u64,
+    pub(crate) output_tokens: u64,
+    pub(crate) cache_read_tokens: u64,
+    pub(crate) cache_write_tokens: u64,
+}
+
+/// One history event the driver replays. Text fields are `usize` indices into
+/// the snapshot's shared text pool (`HistorySnapshot.texts`), so decoding a
+/// repeated string costs one decode, not one decode per event.
+#[derive(Clone)]
+pub(crate) struct HistoryEvent {
+    pub(crate) seq: u64,
+    pub(crate) kind: HistoryEventKind,
+}
+
+#[derive(Clone)]
+pub(crate) enum HistoryEventKind {
+    TurnStart,
+    TurnEnd {
+        kind: TurnEndKind,
+        error_message: Option<String>,
+    },
+    Message {
+        turn: u64,
+        step: u64,
+        texts: Vec<String>,
+        reasoning_texts: Vec<String>,
+        usage: Option<TokenUsage>,
+    },
+    /// A step that streamed text/reasoning deltas but never produced an
+    /// `assistant/message` (an aborted or interrupted turn). Its deltas are
+    /// aggregated into one assembled text so history replay does not lose the
+    /// partial reasoning/answer.
+    StepDelta { reasoning: bool, text: String },
+    ToolCall {
+        call_id: String,
+        name: String,
+        /// Decoded `arguments` JSON string as produced by the model.
+        arguments: Option<String>,
+        view: Option<Value>,
+    },
+    ToolResult {
+        call_id: Option<String>,
+        content: Option<Value>,
+        failed: bool,
+        view: Option<Value>,
+    },
+    TodoWrite {
+        todos: Value,
+    },
+    RequestContext {
+        context_window: Option<u64>,
+    },
+    SessionTitle {
+        title: Option<String>,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Page parsing and event conversion
+// ---------------------------------------------------------------------------
+
+/// Parse one raw HTTP history response body and validate the RPC envelope.
+/// The returned page borrows `bytes`; it stays valid for as long as the byte
+/// buffer does, which lets the caller collect raw text slices and convert to
+/// owned events before dropping the buffer.
+pub(crate) fn parse_history_response<'a>(
+    bytes: &'a [u8],
+    expected_rpc_id: &str,
+) -> anyhow::Result<HistoryPage<'a>> {
+    let envelope: Envelope = serde_json::from_slice(bytes)
+        .context("DeepSeek Harness returned invalid session.history JSON")?;
+    if envelope.kind != "server-response" || envelope.rpc_id != expected_rpc_id {
+        return Err(anyhow!(
+            "DeepSeek Harness returned an invalid session.history envelope"
+        ));
+    }
+    if !envelope.result.ok {
+        return Err(anyhow!(
+            "DeepSeek Harness session.history failed (result.ok was false)"
+        ));
+    }
+    let page: HistoryPage = serde_json::from_str(envelope.result.value.get())
+        .context("DeepSeek Harness returned an invalid session.history value")?;
+    Ok(page)
+}
+
+/// Collect every raw text slice the driver will read, in event order
+/// (duplicates included). This is the input to the batch decode pass.
+/// Convert one borrowed page into owned events. Text-bearing fields are
+/// decoded directly from their raw slices — at message level there are only
+/// a few hundred texts per page, so a deduplicated pool would save little.
+pub(crate) fn convert_page<'a>(entries: &[HistoryEntry<'a>]) -> Vec<HistoryEvent> {
+    entries.iter().filter_map(convert_entry).collect()
+}
+
+/// One text/reasoning delta of an orphaned step, addressed by its position
+/// inside the page's raw bytes. The caller holds the page bytes alive until
+/// the replay phase, so the delta payloads can be re-read (and aggregated
+/// with a single decode) without keeping borrowed `&RawValue`s across the
+/// fetch boundary.
+pub(crate) struct DeltaRef {
+    pub(crate) offset: usize,
+    pub(crate) len: usize,
+    pub(crate) reasoning: bool,
+}
+
+/// A step that streamed deltas but produced no `assistant/message` in its
+/// own page: either truly aborted, or completed on a neighbour page (the
+/// caller drops those after merging all pages).
+pub(crate) struct OrphanCandidate {
+    pub(crate) turn: u64,
+    pub(crate) step: u64,
+    pub(crate) reasoning_first_seq: u64,
+    pub(crate) text_first_seq: u64,
+    pub(crate) page: usize,
+    pub(crate) deltas: Vec<DeltaRef>,
+}
+
+/// Scan one borrowed page and record delta references for steps that never
+/// produced an `assistant/message` within it. Streaming, zero-copy: a step's
+/// chunks arrive contiguously, so deltas are appended to the pending step and
+/// sealed at its message (discarded — the deltas are folded into it) or at
+/// any other event that proves the step ended without one.
+pub(crate) fn scan_orphan_candidates<'a>(
+    entries: &[HistoryEntry<'a>],
+    page: usize,
+    page_base: usize,
+    out: &mut Vec<OrphanCandidate>,
+) {
+    type Pending = (u64, u64, Vec<DeltaRef>, u64, u64);
+    let mut pending: Option<Pending> = None;
+
+    macro_rules! seal {
+        ($out:expr, $pending:expr) => {
+            if let Some((turn, step, deltas, reasoning_first_seq, text_first_seq)) =
+                $pending.take()
+            {
+                $out.push(OrphanCandidate {
+                    turn,
+                    step,
+                    reasoning_first_seq,
+                    text_first_seq,
+                    page,
+                    deltas,
+                });
+            }
+        };
+    }
+
+    for entry in entries {
+        let Some(event) = &entry.event else {
+            continue;
+        };
+        let data = &event.data;
+        match event.kind {
+            "assistant/chunk" => {
+                let Some(chunk) = &data.chunk else {
+                    continue;
+                };
+                let Some(text) = &chunk.text else {
+                    continue;
+                };
+                if !matches!(chunk.kind, "text-delta" | "reasoning-delta") {
+                    continue;
+                }
+                let turn = data.turn.unwrap_or(0);
+                let step = data.step.unwrap_or(0);
+                if pending
+                    .as_ref()
+                    .is_some_and(|(current_turn, current_step, ..)| {
+                        (*current_turn, *current_step) != (turn, step)
+                    })
+                {
+                    seal!(out, pending);
+                }
+                let pending = pending
+                    .get_or_insert_with(|| (turn, step, Vec::new(), u64::MAX, u64::MAX));
+                let offset = text.get().as_ptr() as usize - page_base;
+                let reasoning = chunk.kind == "reasoning-delta";
+                if reasoning && pending.3 == u64::MAX {
+                    pending.3 = event.seq;
+                }
+                if !reasoning && pending.4 == u64::MAX {
+                    pending.4 = event.seq;
+                }
+                pending.2.push(DeltaRef {
+                    offset,
+                    len: text.get().len(),
+                    reasoning,
+                });
+            }
+            "assistant/message" => {
+                let turn = data.turn.unwrap_or(0);
+                let step = data.step.unwrap_or(0);
+                if pending
+                    .as_ref()
+                    .is_some_and(|(current_turn, current_step, ..)| {
+                        (*current_turn, *current_step) == (turn, step)
+                    })
+                {
+                    pending = None;
+                } else {
+                    seal!(out, pending);
+                }
+            }
+            _ => seal!(out, pending),
+        }
+    }
+    seal!(out, pending);
+}
+
+/// Replay-phase aggregation: for every orphaned step that truly never got an
+/// `assistant/message` across the whole fetch, concatenate its delta payloads
+/// (read back from the caller-held page bytes) into one JSON string literal
+/// and decode it once, producing one assembled `StepDelta` per reasoning/text
+/// stream. The caller holds `pages` alive until this point, which is what
+/// makes the deferred aggregation possible.
+pub(crate) fn aggregate_orphan_deltas(
+    pages: &[Vec<u8>],
+    candidates: &[OrphanCandidate],
+    message_steps: &std::collections::HashSet<(u64, u64)>,
+) -> Vec<HistoryEvent> {
+    let mut events = Vec::new();
+    for candidate in candidates {
+        if message_steps.contains(&(candidate.turn, candidate.step)) {
+            continue;
+        }
+        let bytes = &pages[candidate.page];
+        let reasoning: Vec<&str> = candidate
+            .deltas
+            .iter()
+            .filter(|delta| delta.reasoning)
+            .map(|delta| {
+                std::str::from_utf8(&bytes[delta.offset..delta.offset + delta.len])
+                    .expect("delta payload is UTF-8")
+            })
+            .collect();
+        let text: Vec<&str> = candidate
+            .deltas
+            .iter()
+            .filter(|delta| !delta.reasoning)
+            .map(|delta| {
+                std::str::from_utf8(&bytes[delta.offset..delta.offset + delta.len])
+                    .expect("delta payload is UTF-8")
+            })
+            .collect();
+        if !reasoning.is_empty() && let Ok(aggregated) = aggregate_delta_slices(&reasoning) {
+            events.push(HistoryEvent {
+                seq: candidate.reasoning_first_seq,
+                kind: HistoryEventKind::StepDelta {
+                    reasoning: true,
+                    text: aggregated,
+                },
+            });
+        }
+        if !text.is_empty() && let Ok(aggregated) = aggregate_delta_slices(&text) {
+            events.push(HistoryEvent {
+                seq: candidate.text_first_seq,
+                kind: HistoryEventKind::StepDelta {
+                    reasoning: false,
+                    text: aggregated,
+                },
+            });
+        }
+    }
+    events
+}
+
+/// Concatenate escaped delta payloads (each a quoted, escaped JSON string)
+/// into one JSON string literal and decode it once. Joining the interiors and
+/// re-quoting yields the escaped concatenation of the decoded texts.
+fn aggregate_delta_slices(raws: &[&str]) -> anyhow::Result<String> {
+    let mut joined = String::with_capacity(
+        raws.iter()
+            .map(|slice| slice.len().saturating_sub(2))
+            .sum::<usize>()
+            .saturating_add(2),
+    );
+    joined.push('"');
+    for slice in raws {
+        joined.push_str(&slice[1..slice.len().saturating_sub(1)]);
+    }
+    joined.push('"');
+    serde_json::from_str(&joined).context("aggregated delta text is not valid JSON")
+}
+
+fn convert_entry<'a>(entry: &HistoryEntry<'a>) -> Option<HistoryEvent> {
+    let event = entry.event.as_ref()?;
+    let data = &event.data;
+    // Chunk events are dropped entirely (their deltas are folded into the
+    // assembled assistant/message); do not even produce an Other event for
+    // the ~45k chunk records per page.
+    if event.kind == "assistant/chunk" {
+        return None;
+    }
+    let kind = match event.kind {
+        "turn/start" => HistoryEventKind::TurnStart,
+        "turn/end" => {
+            let (kind, error_message) = match &data.reason {
+                Some(ReasonWire::Obj(reason)) => {
+                    let kind = match reason.kind {
+                        Some("completed") => TurnEndKind::Completed,
+                        Some("aborted") => TurnEndKind::Aborted,
+                        Some("blocked") => TurnEndKind::Blocked,
+                        Some("error") => TurnEndKind::Error,
+                        Some("max-tokens") => TurnEndKind::MaxTokens,
+                        Some("interrupted") => TurnEndKind::Interrupted,
+                        _ => TurnEndKind::Other,
+                    };
+                    let error_message = reason
+                        .error
+                        .as_ref()
+                        .and_then(|error| error.message.as_ref())
+                        .and_then(|message| decode_text(message));
+                    (kind, error_message)
+                }
+                _ => (TurnEndKind::Other, None),
+            };
+            HistoryEventKind::TurnEnd {
+                kind,
+                error_message,
+            }
+        }
+        // `assistant/chunk` events are dropped entirely: their token-level
+        // deltas are already folded into the assembled `assistant/message`
+        // (whose blocks carry the full text and usage), so history replay
+        // never needs them.
+        "assistant/message" => {
+            let mut texts = Vec::new();
+            let mut reasoning_texts = Vec::new();
+            if let Some(blocks) = message_content_blocks(data.message) {
+                for block in blocks {
+                    let Some(text) = block.text.as_ref().and_then(|raw| decode_text(raw)) else {
+                        continue;
+                    };
+                    match block.kind {
+                        "text" => texts.push(text),
+                        "reasoning" => reasoning_texts.push(text),
+                        _ => {}
+                    }
+                }
+            }
+            let usage = data
+                .usage
+                .as_ref()
+                .and_then(|usage| parse_usage(usage.get()).ok());
+            HistoryEventKind::Message {
+                turn: data.turn.unwrap_or(0),
+                step: data.step.unwrap_or(0),
+                texts,
+                reasoning_texts,
+                usage,
+            }
+        }
+        "tool/call" => {
+            let call_id = data.call_id?.to_owned();
+            let name = data.name.unwrap_or("tool").to_owned();
+            let arguments = data.arguments.as_ref().and_then(|raw| decode_text(raw));
+            let view = entry
+                .view
+                .as_ref()
+                .and_then(|view| serde_json::from_str::<Value>(view.get()).ok());
+            HistoryEventKind::ToolCall {
+                call_id,
+                name,
+                arguments,
+                view,
+            }
+        }
+        "tool/result" => {
+            let message: Value = data
+                .message
+                .as_ref()
+                .and_then(|message| serde_json::from_str::<Value>(message.get()).ok())
+                .unwrap_or(Value::Null);
+            let call_id = message
+                .pointer("/source/callId")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .or_else(|| {
+                    message
+                        .pointer("/content/0/toolCallId")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned)
+                });
+            let content = message.get("content").cloned();
+            let failed = data.error.is_some()
+                || message
+                    .pointer("/content/0/isError")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+            let view = entry
+                .view
+                .as_ref()
+                .and_then(|view| serde_json::from_str::<Value>(view.get()).ok());
+            HistoryEventKind::ToolResult {
+                call_id,
+                content,
+                failed,
+                view,
+            }
+        }
+        "todo/write" => {
+            let todos = data
+                .todos
+                .as_ref()
+                .and_then(|todos| serde_json::from_str::<Value>(todos.get()).ok())
+                .unwrap_or_else(|| Value::Array(Vec::new()));
+            HistoryEventKind::TodoWrite { todos }
+        }
+        "request/context" => HistoryEventKind::RequestContext {
+            context_window: data.context_window,
+        },
+        "session/title" => {
+            let title = data.title.as_ref().and_then(|raw| decode_text(raw));
+            HistoryEventKind::SessionTitle { title }
+        }
+        // Unknown event types carry nothing the driver replays; skip them.
+        _ => return None,
+    };
+    Some(HistoryEvent {
+        seq: event.seq,
+        kind,
+    })
+}
+
+fn message_content_blocks<'a>(message: Option<&'a RawValue>) -> Option<Vec<ContentBlockWire<'a>>> {
+    let message = message?;
+    let parsed: MessageWire = serde_json::from_str(message.get()).ok()?;
+    parsed.content
+}
+
+#[derive(Deserialize, Default)]
+#[serde(bound(deserialize = "'de: 'a"))]
+struct MessageWire<'a> {
+    #[serde(default)]
+    content: Option<Vec<ContentBlockWire<'a>>>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(bound(deserialize = "'de: 'a"))]
+struct ContentBlockWire<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    #[serde(default)]
+    text: Option<&'a RawValue>,
+}
+
+/// Decode one escaped JSON string field into its text. A `RawValue` of a
+/// string field is always valid JSON, so failure only guards against a
+/// malformed page.
+fn decode_text(raw: &RawValue) -> Option<String> {
+    serde_json::from_str(raw.get()).ok()
+}
+
+fn parse_usage(raw: &str) -> anyhow::Result<TokenUsage> {
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct UsageWire {
+        #[serde(default)]
+        input_tokens: u64,
+        #[serde(default)]
+        output_tokens: u64,
+        #[serde(default)]
+        cache_read_tokens: u64,
+        #[serde(default)]
+        cache_write_tokens: u64,
+    }
+    let usage: UsageWire = serde_json::from_str(raw)?;
+    Ok(TokenUsage {
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_read_tokens: usage.cache_read_tokens,
+        cache_write_tokens: usage.cache_write_tokens,
+    })
+}

--- a/crates/waku-core/src/deepseek_session.rs
+++ b/crates/waku-core/src/deepseek_session.rs
@@ -334,6 +334,28 @@ impl DeepSeekServer {
         rpc_result_value(method, &response)
     }
 
+    /// Sends one request and returns the raw response body plus the `rpcId`
+    /// embedded in the request, so the caller can validate the envelope
+    /// without parsing the whole body into `serde_json::Value`. This matters
+    /// for large responses (a `session.history` page can be several MB).
+    pub(crate) fn rpc_raw(&self, method: &str, payload: Value) -> anyhow::Result<(Vec<u8>, String)> {
+        let rpc_id = format!("waku-{}", Uuid::new_v4());
+        let body = json!({
+            "type": "client-request",
+            "rpcId": rpc_id,
+            "method": method,
+            "payload": payload,
+        });
+        let bytes = crate::opencode_session::request_raw_on_port(
+            self.port,
+            "POST",
+            &format!("/api/{method}"),
+            Some(&body),
+            RPC_TIMEOUT,
+        )?;
+        Ok((bytes, rpc_id))
+    }
+
     pub(crate) fn respond(&self, rpc_id: &str, value: Value) -> anyhow::Result<()> {
         let body = json!({
             "type": "client-response",

--- a/crates/waku-core/src/driver/codex.rs
+++ b/crates/waku-core/src/driver/codex.rs
@@ -3008,6 +3008,57 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "requires an installed, authenticated codex"]
+    fn real_codex_driver_receives_turn_completion_over_shared_socket() {
+        let binary = crate::command_env::find_executable("codex").expect("codex is not installed");
+        let (events, receiver) = super::super::test_event_channel();
+        let driver = CodexDriver::start(
+            DriverStartOptions {
+                binary,
+                cwd: std::env::current_dir().expect("current directory"),
+                mode: RuntimeMode::FullAccess,
+                interaction_mode: InteractionMode::Build,
+                model: None,
+                reasoning_effort: None,
+                service_tier: None,
+                context_window: None,
+                agent_preset: None,
+                computer_use_enabled: false,
+                provider_cursor: None,
+            },
+            events,
+        )
+        .expect("Codex driver should start");
+        driver.prompt("Reply with exactly OK and do not use tools.".to_owned());
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(90);
+        let mut saw_text = false;
+        let mut saw_completion = false;
+        while std::time::Instant::now() < deadline {
+            let remaining = deadline
+                .checked_duration_since(std::time::Instant::now())
+                .unwrap_or_default();
+            let event = receiver
+                .recv_timeout(remaining)
+                .expect("Codex driver should emit a completion event");
+            match event {
+                DriverEvent::TextDelta(_) => saw_text = true,
+                DriverEvent::TurnFinished { success, .. } => {
+                    assert!(success, "the real Codex turn should complete successfully");
+                    saw_completion = true;
+                    break;
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_text, "the real Codex driver should stream answer text");
+        assert!(
+            saw_completion,
+            "the real Codex driver should receive turn/completed"
+        );
+    }
+
+    #[test]
     fn turns_request_readable_reasoning_summaries() {
         let params = turn_start_params(
             "thread-1",

--- a/crates/waku-core/src/driver/codex.rs
+++ b/crates/waku-core/src/driver/codex.rs
@@ -2,9 +2,16 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+#[cfg(not(unix))]
+use std::io::Write;
+#[cfg(not(unix))]
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+#[cfg(not(unix))]
+use std::process::ChildStdin;
+use std::process::Command;
+#[cfg(not(unix))]
+use std::process::Stdio;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -13,6 +20,8 @@ use anyhow::{Context as _, anyhow};
 use crossbeam_channel::{Sender, bounded, unbounded};
 use parking_lot::Mutex;
 use serde_json::{Value, json};
+#[cfg(unix)]
+use tungstenite::Message;
 #[cfg(test)]
 use uuid::Uuid;
 
@@ -129,6 +138,8 @@ impl BackgroundRpcState {
 
 pub struct CodexDriver {
     commands: Sender<CommandMessage>,
+    #[cfg(unix)]
+    _server: Option<super::codex_pool::PooledCodexServer>,
     mode: RuntimeMode,
     interaction_mode: InteractionMode,
     computer_use_process_directory: Option<PathBuf>,
@@ -136,7 +147,7 @@ pub struct CodexDriver {
     computer_use_preview_monitor: Option<computer_use_runtime::ComputerUsePreviewMonitor>,
 }
 
-struct CodexComputerUseConfig {
+pub(crate) struct CodexComputerUseConfig {
     server_path: PathBuf,
     server: String,
     repl: String,
@@ -168,7 +179,10 @@ impl CodexComputerUseConfig {
 /// Register Waku's long-lived QuickJS MCP server and keep the raw native helper
 /// private behind its built-in `sky` object. Codex sees only the compact
 /// `js` / `js_reset` execution surface.
-fn configure_computer_use_command(command: &mut Command, config: Option<&CodexComputerUseConfig>) {
+pub(crate) fn configure_computer_use_command(
+    command: &mut Command,
+    config: Option<&CodexComputerUseConfig>,
+) {
     if let Some(config) = config {
         command
             .arg("-c")
@@ -240,27 +254,39 @@ impl CodexDriver {
         let computer_use_server_path = computer_use
             .as_ref()
             .map(|config| config.server_path.clone());
+        #[cfg(unix)]
+        let server = super::codex_pool::acquire(&binary, &cwd, computer_use.as_ref())?;
+        #[cfg(unix)]
+        let socket = Arc::new(Mutex::new(server.connect()?));
         let title_binary = binary.clone();
         let title_cwd = cwd.clone();
+        #[cfg(not(unix))]
         let mut command = crate::command_env::command(&binary);
+        #[cfg(not(unix))]
         command.args(["app-server", "--stdio"]);
+        #[cfg(not(unix))]
         configure_computer_use_command(&mut command, computer_use.as_ref());
+        #[cfg(not(unix))]
         let command = command
             .current_dir(&cwd)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        #[cfg(not(unix))]
         let mut child =
             crate::command_env::spawn(command).context("failed to start `codex app-server`")?;
 
+        #[cfg(not(unix))]
         let stdin = child
             .stdin
             .take()
             .ok_or_else(|| anyhow!("Codex stdin unavailable"))?;
+        #[cfg(not(unix))]
         let stdout = child
             .stdout
             .take()
             .ok_or_else(|| anyhow!("Codex stdout unavailable"))?;
+        #[cfg(not(unix))]
         let stderr = child
             .stderr
             .take()
@@ -305,6 +331,10 @@ impl CodexDriver {
         let writer_title_generation = title_generation.clone();
         let writer_events = events.clone();
         let cwd_string = cwd.display().to_string();
+        #[cfg(unix)]
+        let stdin = CodexWriter::Socket(socket.clone());
+        #[cfg(not(unix))]
+        let stdin = CodexWriter::Stdio(stdin);
         thread::Builder::new()
             .name("waku-codex-writer".into())
             .spawn(move || {
@@ -323,8 +353,8 @@ impl CodexDriver {
                         }
                     }
                 });
-                if write_json_line(&mut stdin, &initialize).is_err()
-                    || write_json_line(
+                if write_codex_json_line(&mut stdin, &initialize).is_err()
+                    || write_codex_json_line(
                         &mut stdin,
                         &json!({
                             "method": "initialized",
@@ -343,7 +373,7 @@ impl CodexDriver {
                     // Register Waku's bundled skill through Codex's discoverable-skill
                     // mechanism. Keep the skill out of developerInstructions so it is
                     // loaded and displayed like Codex's own bundled skills.
-                    if write_json_line(
+                    if write_codex_json_line(
                         &mut stdin,
                         &json!({
                             "method": "skills/extraRoots/set",
@@ -410,7 +440,7 @@ impl CodexDriver {
                         "params": params
                     })
                 };
-                let _ = write_json_line(&mut stdin, &open_thread);
+                let _ = write_codex_json_line(&mut stdin, &open_thread);
 
                 let mut next_request_id = 10_u64;
                 while let Ok(command) = command_rx.recv() {
@@ -484,7 +514,7 @@ impl CodexDriver {
                                     "input": [{"type": "text", "text": text}]
                                 }
                             });
-                            if let Err(error) = write_json_line(&mut stdin, &message)
+                            if let Err(error) = write_codex_json_line(&mut stdin, &message)
                                 && let Some(text) = writer_pending_steers.lock().remove(&request_id)
                             {
                                 let _ = writer_events.send(DriverEvent::SteerRejected {
@@ -556,7 +586,7 @@ impl CodexDriver {
                                     "numTurns": turns
                                 }
                             });
-                            if let Err(error) = write_json_line(&mut stdin, &message)
+                            if let Err(error) = write_codex_json_line(&mut stdin, &message)
                                 && let Some((_, response)) =
                                     writer_pending_rollbacks.lock().remove(&request_id)
                             {
@@ -595,7 +625,7 @@ impl CodexDriver {
                                     "lastTurnId": last_turn_id
                                 }
                             });
-                            if let Err(error) = write_json_line(&mut stdin, &message)
+                            if let Err(error) = write_codex_json_line(&mut stdin, &message)
                                 && let Some(response) =
                                     writer_pending_forks.lock().remove(&request_id)
                             {
@@ -736,7 +766,7 @@ impl CodexDriver {
                         }
                         CommandMessage::Shutdown => break,
                     };
-                    if let Err(error) = write_json_line(&mut stdin, &message) {
+                    if let Err(error) = write_codex_json_line(&mut stdin, &message) {
                         let _ = writer_events.send(DriverEvent::Error(tr!(
                             "errors.provider_transport_write",
                             provider = "Codex",
@@ -758,13 +788,28 @@ impl CodexDriver {
         let reader_title_generation = title_generation;
         let reader_commands = commands.clone();
         let reader_events = events.clone();
-        let reader_thread = thread::Builder::new()
+        #[cfg(unix)]
+        let socket_for_reader = socket.clone();
+        let _reader_thread = thread::Builder::new()
             .name("waku-codex-reader".into())
             .spawn(move || {
                 let mut stream_state = CodexStreamState::default();
-                for line in BufReader::new(stdout).lines() {
+                #[cfg(not(unix))]
+                let mut stdout = BufReader::new(stdout);
+                loop {
+                    #[cfg(unix)]
+                    let line = read_codex_socket_message(&socket_for_reader);
+                    #[cfg(not(unix))]
+                    let line = {
+                        let mut line = String::new();
+                        match stdout.read_line(&mut line) {
+                            Ok(0) => Ok(None),
+                            Ok(_) => Ok(Some(line)),
+                            Err(error) => Err(error),
+                        }
+                    };
                     match line {
-                        Ok(line) if !line.trim().is_empty() => {
+                        Ok(Some(line)) if !line.trim().is_empty() => {
                             match serde_json::from_str::<Value>(&line) {
                                 Ok(value) => {
                                     let main_turn_started = is_codex_turn_started(
@@ -825,7 +870,10 @@ impl CodexDriver {
                                 }
                             }
                         }
-                        Ok(_) => {}
+                        Ok(Some(_)) => {}
+                        Ok(None) => break,
+                        #[cfg(unix)]
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => continue,
                         Err(error) => {
                             let _ = reader_events.send(DriverEvent::Error(tr!(
                                 "errors.provider_transport_read",
@@ -836,11 +884,17 @@ impl CodexDriver {
                         }
                     }
                 }
+                #[cfg(unix)]
+                let _ = reader_events.send(DriverEvent::ProcessExited);
             })?;
 
+        #[cfg(not(unix))]
         let last_visible_stderr = Arc::new(Mutex::new(None::<String>));
+        #[cfg(not(unix))]
         let stderr_last_error = last_visible_stderr.clone();
+        #[cfg(not(unix))]
         let stderr_events = events.clone();
+        #[cfg(not(unix))]
         let stderr_thread = thread::Builder::new()
             .name("waku-codex-stderr".into())
             .spawn(move || {
@@ -853,11 +907,12 @@ impl CodexDriver {
                 }
             })?;
 
+        #[cfg(not(unix))]
         thread::Builder::new()
             .name("waku-codex-process".into())
             .spawn(move || {
                 let status = child.wait();
-                let _ = reader_thread.join();
+                let _ = _reader_thread.join();
                 let _ = stderr_thread.join();
                 match status {
                     Ok(status) if !status.success() && last_visible_stderr.lock().is_none() => {
@@ -881,6 +936,8 @@ impl CodexDriver {
 
         Ok(Self {
             commands,
+            #[cfg(unix)]
+            _server: Some(server),
             mode,
             interaction_mode,
             computer_use_process_directory,
@@ -1123,10 +1180,56 @@ impl Drop for CodexDriver {
     }
 }
 
+enum CodexWriter {
+    #[cfg(unix)]
+    Socket(Arc<Mutex<super::codex_pool::CodexSocket>>),
+    #[cfg(not(unix))]
+    Stdio(ChildStdin),
+}
+
+#[cfg(unix)]
+fn write_codex_json_line(writer: &mut CodexWriter, value: &Value) -> std::io::Result<()> {
+    let CodexWriter::Socket(socket) = writer;
+    let payload = serde_json::to_string(value)?;
+    socket
+        .lock()
+        .send(Message::Text(payload.into()))
+        .map_err(std::io::Error::other)
+}
+
+#[cfg(not(unix))]
+fn write_codex_json_line(writer: &mut CodexWriter, value: &Value) -> std::io::Result<()> {
+    let CodexWriter::Stdio(writer) = writer;
+    serde_json::to_writer(&mut *writer, value)?;
+    writer.write_all(b"\n")?;
+    writer.flush()
+}
+
+#[cfg(not(unix))]
 fn write_json_line(writer: &mut impl Write, value: &Value) -> std::io::Result<()> {
     serde_json::to_writer(&mut *writer, value)?;
     writer.write_all(b"\n")?;
     writer.flush()
+}
+
+#[cfg(unix)]
+fn read_codex_socket_message(
+    socket: &Arc<Mutex<super::codex_pool::CodexSocket>>,
+) -> std::io::Result<Option<String>> {
+    loop {
+        match socket.lock().read() {
+            Ok(Message::Text(text)) => return Ok(Some(text.to_string())),
+            Ok(Message::Binary(bytes)) => {
+                return String::from_utf8(bytes.to_vec())
+                    .map(Some)
+                    .map_err(std::io::Error::other);
+            }
+            Ok(Message::Close(_)) => return Ok(None),
+            Ok(Message::Ping(_)) | Ok(Message::Pong(_)) | Ok(Message::Frame(_)) => continue,
+            Err(tungstenite::Error::Io(error)) => return Err(error),
+            Err(error) => return Err(std::io::Error::other(error)),
+        }
+    }
 }
 
 const CODEX_TITLE_INSTRUCTIONS: &str = "Generate a concise title for the user's coding task. Return only a plain title of at most six words. Do not use tools, quotes, markdown, labels, or ending punctuation.";
@@ -1178,6 +1281,106 @@ fn codex_title_turn_params(thread_id: &str, user_message: &str) -> Value {
 /// Codex app-server can persist a thread name but does not generate one. Match
 /// Codex Desktop's client-owned behavior with an isolated ephemeral turn, then
 /// hand the result back to the main writer for `thread/name/set`.
+#[cfg(unix)]
+fn generate_codex_title(binary: &Path, cwd: &Path, prompt: &str) -> anyhow::Result<String> {
+    let server = super::codex_pool::acquire(binary, cwd, None)?;
+    let socket = Arc::new(Mutex::new(server.connect()?));
+    let mut writer = CodexWriter::Socket(socket.clone());
+
+    write_codex_json_line(
+        &mut writer,
+        &json!({
+            "method": "initialize",
+            "id": 0,
+            "params": {
+                "clientInfo": {
+                    "name": "waku-title",
+                    "title": "Waku Title",
+                    "version": env!("CARGO_PKG_VERSION")
+                },
+                "capabilities": {"experimentalApi": true}
+            }
+        }),
+    )?;
+    write_codex_json_line(&mut writer, &json!({"method": "initialized", "params": {}}))?;
+    write_codex_json_line(
+        &mut writer,
+        &json!({
+            "method": "thread/start",
+            "id": 1,
+            "params": codex_title_thread_params(cwd)
+        }),
+    )?;
+
+    let deadline = Instant::now() + CODEX_TITLE_TIMEOUT;
+    let mut title_thread_id = None::<String>;
+    let mut generated = None::<String>;
+    loop {
+        if Instant::now() >= deadline {
+            return Err(anyhow!("Codex title generation timed out"));
+        }
+        let value = match read_codex_socket_message(&socket) {
+            Ok(Some(line)) => serde_json::from_str::<Value>(&line)?,
+            Ok(None) => return Err(anyhow!("Codex title connection closed")),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => continue,
+            Err(error) => return Err(error.into()),
+        };
+
+        if value.get("id").and_then(Value::as_u64) == Some(1) && value.get("method").is_none() {
+            if let Some(error) = value.pointer("/error/message").and_then(Value::as_str) {
+                return Err(anyhow!("Codex could not open a title thread: {error}"));
+            }
+            let thread_id = value
+                .pointer("/result/thread/id")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow!("Codex returned no title thread ID"))?
+                .to_owned();
+            title_thread_id = Some(thread_id.clone());
+            write_codex_json_line(
+                &mut writer,
+                &json!({
+                    "method": "turn/start",
+                    "id": 2,
+                    "params": codex_title_turn_params(&thread_id, prompt)
+                }),
+            )?;
+            continue;
+        }
+
+        if value.get("method").and_then(Value::as_str) == Some("item/completed")
+            && value.pointer("/params/threadId").and_then(Value::as_str)
+                == title_thread_id.as_deref()
+            && value.pointer("/params/item/type").and_then(Value::as_str) == Some("agentMessage")
+            && let Some(text) = value.pointer("/params/item/text").and_then(Value::as_str)
+        {
+            generated = Some(text.to_owned());
+            continue;
+        }
+
+        if value.get("method").and_then(Value::as_str) == Some("turn/completed")
+            && value.pointer("/params/threadId").and_then(Value::as_str)
+                == title_thread_id.as_deref()
+        {
+            let status = value
+                .pointer("/params/turn/status")
+                .and_then(Value::as_str)
+                .unwrap_or("failed");
+            if status != "completed" {
+                let message = value
+                    .pointer("/params/turn/error/message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("the title turn did not complete");
+                return Err(anyhow!("Codex title generation failed: {message}"));
+            }
+            return generated
+                .as_deref()
+                .and_then(normalize_codex_title)
+                .ok_or_else(|| anyhow!("Codex returned an empty task title"));
+        }
+    }
+}
+
+#[cfg(not(unix))]
 fn generate_codex_title(binary: &Path, cwd: &Path, prompt: &str) -> anyhow::Result<String> {
     let mut command = crate::command_env::command(binary);
     let command = command
@@ -1939,6 +2142,18 @@ fn handle_codex_message(
                 success: status == "completed",
                 summary: error,
             });
+            // A steer can race the provider's final turn notification. If the
+            // response to `turn/steer` arrives after this point (or is lost
+            // with the closing connection), do not leave the composer stuck
+            // in the steering state forever. The app will requeue it as a
+            // normal follow-up once it observes the completed turn.
+            for (_, message) in pending_steers.lock().drain() {
+                let _ = events.send(DriverEvent::SteerRejected {
+                    message,
+                    reason: "Codex completed the turn before acknowledging the steering request"
+                        .to_owned(),
+                });
+            }
         }
         "thread/name/updated" => {
             let current_thread_id = thread_id.lock().clone();
@@ -2498,12 +2713,14 @@ fn split_camel_case(value: &str) -> String {
         .unwrap_or_else(|| "Activity".into())
 }
 
+#[cfg(not(unix))]
 fn clean_stderr(line: &str) -> String {
     line.split_once(": ")
         .map(|(_, message)| message.to_owned())
         .unwrap_or_else(|| line.to_owned())
 }
 
+#[cfg(any(not(unix), test))]
 fn is_visible_stderr_notice(line: &str) -> bool {
     let lowercase = line.to_ascii_lowercase();
     if lowercase.contains("transport channel closed")
@@ -2594,11 +2811,7 @@ mod tests {
     #[test]
     fn goal_set_responses_become_goal_updates() {
         let harness = GoalHarness::new();
-        harness
-            .goals
-            .lock()
-            .pending
-            .insert(42, PendingGoalRpc::Set);
+        harness.goals.lock().pending.insert(42, PendingGoalRpc::Set);
         harness.handle(json!({"id": 42, "result": {"goal": goal_json()}}));
 
         let Ok(DriverEvent::GoalUpdated(Some(goal))) = harness.received.try_recv() else {
@@ -2853,6 +3066,8 @@ mod tests {
         let (commands, command_rx) = unbounded();
         let driver = CodexDriver {
             commands,
+            #[cfg(unix)]
+            _server: None,
             mode: RuntimeMode::FullAccess,
             interaction_mode: InteractionMode::Build,
             computer_use_process_directory: None,
@@ -3322,6 +3537,63 @@ mod tests {
             other => panic!("expected a rejected steer, got {other:?}"),
         }
         assert!(event_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn completed_turn_rejects_unacknowledged_steers() {
+        let thread_id = Mutex::new(Some("thread-1".to_owned()));
+        let turn_id = Mutex::new(Some("turn-9".to_owned()));
+        let turn_ids = Mutex::new(vec!["turn-9".to_owned()]);
+        let pending_rollbacks = Mutex::new(HashMap::new());
+        let pending_forks = Mutex::new(HashMap::new());
+        let pending_steers = Mutex::new(HashMap::from([
+            (52, "Please include a test".to_owned()),
+            (53, "Also explain the failure".to_owned()),
+        ]));
+        let background_rpcs = Mutex::new(BackgroundRpcState::default());
+        let goal_rpcs = Mutex::new(GoalRpcState::default());
+        let (goal_commands, _goal_command_rx) = unbounded();
+        let (event_tx, event_rx) = unbounded();
+        let mut stream_state = CodexStreamState::default();
+
+        handle_codex_message(
+            json!({
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "thread-1",
+                    "turn": {"id": "turn-9", "status": "completed"}
+                }
+            }),
+            &thread_id,
+            &turn_id,
+            &turn_ids,
+            &pending_rollbacks,
+            &pending_forks,
+            &pending_steers,
+            &background_rpcs,
+            &goal_rpcs,
+            &goal_commands,
+            &event_tx,
+            &mut stream_state,
+        );
+
+        assert!(pending_steers.lock().is_empty());
+        assert!(matches!(
+            event_rx.try_recv().unwrap(),
+            DriverEvent::TurnFinished { success: true, .. }
+        ));
+        let mut rejected = Vec::new();
+        while let Ok(DriverEvent::SteerRejected { message, .. }) = event_rx.try_recv() {
+            rejected.push(message);
+        }
+        rejected.sort();
+        assert_eq!(
+            rejected,
+            vec![
+                "Also explain the failure".to_owned(),
+                "Please include a test".to_owned()
+            ]
+        );
     }
 
     #[test]

--- a/crates/waku-core/src/driver/codex_pool.rs
+++ b/crates/waku-core/src/driver/codex_pool.rs
@@ -1,0 +1,318 @@
+//! Shared Codex app-server processes.
+//!
+//! Codex keeps thread state inside the app-server process and exposes a
+//! Unix-socket transport with one JSON-RPC connection per client.  Pooling the
+//! process while keeping a connection per Waku driver lets conversations share
+//! the expensive app-server without sharing their thread state or event loop.
+
+#![cfg(unix)]
+
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Stdio};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context as _, anyhow, bail};
+use tungstenite::client::{IntoClientRequest as _, client};
+use tungstenite::protocol::WebSocket;
+use uuid::Uuid;
+
+use super::codex::{CodexComputerUseConfig, configure_computer_use_command};
+
+const SERVER_START_TIMEOUT: Duration = Duration::from_secs(15);
+const SERVER_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub(crate) type CodexSocket = WebSocket<UnixStream>;
+
+pub(crate) struct CodexServer {
+    child: Arc<Mutex<Child>>,
+    socket_path: PathBuf,
+}
+
+impl CodexServer {
+    pub(crate) fn start(
+        binary: &Path,
+        cwd: &Path,
+        computer_use: Option<&CodexComputerUseConfig>,
+    ) -> anyhow::Result<Self> {
+        // macOS limits Unix socket paths to SUN_LEN. TMPDIR may itself be a
+        // long per-process path, so keep the rendezvous path deliberately
+        // short while retaining a private directory per server.
+        let socket_directory = PathBuf::from("/tmp").join(format!("w-{}", Uuid::new_v4()));
+        std::fs::create_dir(&socket_directory)
+            .context("failed to create private Codex socket directory")?;
+        let socket_path = socket_directory.join("s");
+        let mut command = crate::command_env::command(binary);
+        command
+            .args(["app-server", "--listen"])
+            .arg(format!("unix://{}", socket_path.display()))
+            .current_dir(cwd)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped());
+        configure_computer_use_command(&mut command, computer_use);
+        let mut child = match crate::command_env::spawn(&mut command) {
+            Ok(child) => child,
+            Err(error) => {
+                let _ = std::fs::remove_dir(&socket_directory);
+                return Err(error).context("failed to start `codex app-server`");
+            }
+        };
+        let stderr = match child.stderr.take() {
+            Some(stderr) => stderr,
+            None => {
+                terminate_child(&mut child);
+                let _ = std::fs::remove_dir(&socket_directory);
+                bail!("Codex app-server provided no diagnostic output")
+            }
+        };
+        let diagnostics = Arc::new(Mutex::new(Vec::<String>::new()));
+        let diagnostics_for_reader = Arc::clone(&diagnostics);
+        thread::Builder::new()
+            .name("waku-codex-server-stderr".into())
+            .spawn(move || {
+                use std::io::BufRead as _;
+                // Drain stderr so a noisy shared server can never block on a
+                // full pipe, while retaining enough diagnostics for startup
+                // failures to be actionable.
+                for line in std::io::BufReader::new(stderr)
+                    .lines()
+                    .map_while(Result::ok)
+                {
+                    let mut diagnostics = diagnostics_for_reader.lock().unwrap();
+                    diagnostics.push(line);
+                    if diagnostics.len() > 8 {
+                        diagnostics.remove(0);
+                    }
+                }
+            })
+            .context("could not start Codex stderr reader")?;
+
+        let started_at = Instant::now();
+        loop {
+            if socket_path.exists() {
+                match child.try_wait()? {
+                    Some(status) => {
+                        let diagnostics = diagnostics.lock().unwrap().join(" | ");
+                        bail!(
+                            "Codex app-server exited during startup ({status}){}",
+                            (!diagnostics.is_empty())
+                                .then(|| format!(": {diagnostics}"))
+                                .unwrap_or_default()
+                        )
+                    }
+                    None => {
+                        let child = Arc::new(Mutex::new(child));
+                        let server = Self { child, socket_path };
+                        // Make startup fail here rather than on the first
+                        // conversation if the listener is not accepting yet.
+                        let _ = server.connect()?;
+                        return Ok(server);
+                    }
+                }
+            }
+            if let Some(status) = child.try_wait()? {
+                let diagnostics = diagnostics.lock().unwrap().join(" | ");
+                bail!(
+                    "Codex app-server exited during startup ({status}){}",
+                    (!diagnostics.is_empty())
+                        .then(|| format!(": {diagnostics}"))
+                        .unwrap_or_default()
+                )
+            }
+            if started_at.elapsed() >= SERVER_START_TIMEOUT {
+                terminate_child(&mut child);
+                bail!("timed out starting Codex app-server Unix socket")
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    pub(crate) fn connect(&self) -> anyhow::Result<CodexSocket> {
+        let started_at = Instant::now();
+        loop {
+            match UnixStream::connect(&self.socket_path) {
+                Ok(stream) => {
+                    stream.set_read_timeout(Some(Duration::from_millis(100)))?;
+                    stream.set_write_timeout(Some(Duration::from_secs(15)))?;
+                    let request = "ws://localhost/".into_client_request()?;
+                    let (socket, _) = client(request, stream)
+                        .context("could not connect to Codex app-server Unix socket")?;
+                    return Ok(socket);
+                }
+                Err(error) if started_at.elapsed() < SERVER_START_TIMEOUT => {
+                    if self.child.lock().unwrap().try_wait()?.is_some() {
+                        return Err(anyhow!("Codex app-server exited before accepting clients"));
+                    }
+                    let _ = error;
+                    thread::sleep(Duration::from_millis(25));
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+
+    fn shutdown(&self) {
+        let mut child = self.child.lock().unwrap();
+        terminate_child(&mut child);
+        let _ = std::fs::remove_file(&self.socket_path);
+        if let Some(directory) = self.socket_path.parent() {
+            let _ = std::fs::remove_dir(directory);
+        }
+    }
+}
+
+fn terminate_child(child: &mut Child) {
+    if child.try_wait().is_ok_and(|status| status.is_some()) {
+        return;
+    }
+    #[cfg(unix)]
+    unsafe {
+        let _ = libc::kill(-(child.id() as libc::pid_t), libc::SIGTERM);
+    }
+    let deadline = Instant::now() + SERVER_EXIT_TIMEOUT;
+    while Instant::now() < deadline {
+        match child.try_wait() {
+            Ok(Some(_)) => return,
+            Ok(None) => thread::sleep(Duration::from_millis(20)),
+            Err(_) => break,
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[derive(Clone)]
+pub(crate) struct PooledCodexServer {
+    inner: Arc<PoolInner>,
+}
+
+struct PoolInner {
+    server: CodexServer,
+    slot: Option<Weak<PoolSlot>>,
+}
+
+impl Drop for PoolInner {
+    fn drop(&mut self) {
+        if let Some(slot) = self.slot.as_ref().and_then(Weak::upgrade) {
+            let mut state = slot.state.lock().unwrap();
+            let current = matches!(&*state, PoolState::Running(server) if std::ptr::eq(server.as_ptr(), self));
+            if current {
+                *state = PoolState::Stopping;
+                self.server.shutdown();
+                *state = PoolState::Vacant;
+                slot.changed.notify_all();
+                return;
+            }
+        }
+        self.server.shutdown();
+    }
+}
+
+impl Deref for PooledCodexServer {
+    type Target = CodexServer;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.server
+    }
+}
+
+type PoolKey = (PathBuf, PathBuf);
+
+enum PoolState {
+    Vacant,
+    Starting,
+    Running(Weak<PoolInner>),
+    Stopping,
+}
+
+struct PoolSlot {
+    state: Mutex<PoolState>,
+    changed: Condvar,
+}
+
+impl Default for PoolSlot {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(PoolState::Vacant),
+            changed: Condvar::new(),
+        }
+    }
+}
+
+fn pool() -> &'static Mutex<HashMap<PoolKey, Arc<PoolSlot>>> {
+    static POOL: OnceLock<Mutex<HashMap<PoolKey, Arc<PoolSlot>>>> = OnceLock::new();
+    POOL.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub(crate) fn acquire(
+    binary: &Path,
+    cwd: &Path,
+    computer_use: Option<&CodexComputerUseConfig>,
+) -> anyhow::Result<PooledCodexServer> {
+    // Computer Use currently bakes a process directory and MCP settings into
+    // the server command. Keep those sessions dedicated until that config is
+    // made explicitly shareable.
+    if computer_use.is_some() {
+        return Ok(PooledCodexServer {
+            inner: Arc::new(PoolInner {
+                server: CodexServer::start(binary, cwd, computer_use)?,
+                slot: None,
+            }),
+        });
+    }
+
+    let key = (binary.to_path_buf(), cwd.to_path_buf());
+    let slot = {
+        let mut pools = pool().lock().unwrap();
+        Arc::clone(pools.entry(key).or_default())
+    };
+    let superseded = loop {
+        let mut state = slot.state.lock().unwrap();
+        match &*state {
+            PoolState::Running(server) => {
+                if let Some(inner) = server.upgrade() {
+                    if inner.server.child.lock().unwrap().try_wait()?.is_none() {
+                        return Ok(PooledCodexServer { inner });
+                    }
+                    *state = PoolState::Starting;
+                    break Some(inner);
+                }
+                state = slot.changed.wait(state).unwrap();
+                drop(state);
+            }
+            PoolState::Vacant => {
+                *state = PoolState::Starting;
+                break None;
+            }
+            PoolState::Starting | PoolState::Stopping => {
+                state = slot.changed.wait(state).unwrap();
+                drop(state);
+            }
+        }
+    };
+    drop(superseded);
+
+    let started = CodexServer::start(binary, cwd, None);
+    let mut state = slot.state.lock().unwrap();
+    match started {
+        Ok(server) => {
+            let inner = Arc::new(PoolInner {
+                server,
+                slot: Some(Arc::downgrade(&slot)),
+            });
+            *state = PoolState::Running(Arc::downgrade(&inner));
+            slot.changed.notify_all();
+            Ok(PooledCodexServer { inner })
+        }
+        Err(error) => {
+            *state = PoolState::Vacant;
+            slot.changed.notify_all();
+            Err(error)
+        }
+    }
+}

--- a/crates/waku-core/src/driver/deepseek.rs
+++ b/crates/waku-core/src/driver/deepseek.rs
@@ -17,6 +17,9 @@ use serde_json::{Value, json};
 use uuid::Uuid;
 
 use super::activity;
+use crate::deepseek_history::{
+    HistoryEvent, HistoryEventKind, OrphanCandidate, TokenUsage, TurnEndKind,
+};
 use crate::deepseek_pool::PooledDeepSeekServer;
 use crate::driver::{
     DriverControl, DriverEventSender, DriverEventSink, DriverStartOptions, SessionOptions,
@@ -78,7 +81,12 @@ struct StreamState {
 }
 
 struct HistorySnapshot {
-    events: Vec<Value>,
+    events: Vec<HistoryEvent>,
+    /// Steps that streamed deltas without a same-page `assistant/message`.
+    /// The caller holds the raw page bytes (passed into `fetch_history`)
+    /// until the replay phase, where `aggregate_orphan_deltas` reassembles
+    /// the aborted steps' partial text from them.
+    orphan_candidates: Vec<OrphanCandidate>,
     projection_values: Option<Value>,
     last_seq: i64,
     turn_active: bool,
@@ -156,7 +164,7 @@ impl DeepSeekDriver {
             .map(str::to_owned)
             .or(agent_preset);
 
-        let baseline = fetch_history(&server, &session_id)
+        let baseline = fetch_history(&server, &session_id, &mut Vec::new())
             .context("could not read DeepSeek Harness session history")?;
         let available_commands = fetch_commands(&server, &session_id)
             .context("could not read DeepSeek Harness commands")?;
@@ -183,7 +191,7 @@ impl DeepSeekDriver {
         // Selecting a model or changing a native command-backed option appends
         // durable state. Take the history cut after those operations so their
         // already-buffered stream frames are deduplicated by sequence.
-        let history = fetch_history(&server, &session_id)
+        let history = fetch_history(&server, &session_id, &mut Vec::new())
             .context("could not refresh DeepSeek Harness session history")?;
         let _ = events.send(DriverEvent::Connected {
             provider_cursor: Some(ProviderResumeCursor::DeepSeek {
@@ -496,7 +504,7 @@ fn handle_command(
             }
         }
         CommandMessage::ApplyOptions(options) => {
-            let projections = fetch_history(server, session_id)
+            let projections = fetch_history(server, session_id, &mut Vec::new())
                 .ok()
                 .and_then(|history| history.projection_values);
             match apply_session_options(
@@ -569,12 +577,30 @@ fn handle_envelope(
         Some("session/subscribed") => {
             let remote_last_seq = payload.get("lastSeq").and_then(Value::as_i64).unwrap_or(-1);
             if remote_last_seq > state.last_seq {
-                match fetch_history(server, session_id) {
+                let mut pages = Vec::new();
+                match fetch_history(server, session_id, &mut pages) {
                     Ok(history) => {
-                        for entry in history.events {
-                            let event = entry.get("event").unwrap_or(&entry);
-                            let view = entry.get("view");
-                            handle_session_event(event, view, events, state);
+                        // Reassemble aborted steps' partial text from the
+                        // caller-held page bytes, then replay in seq order.
+                        let mut replay_events = history.events;
+                        let message_steps: HashSet<(u64, u64)> = replay_events
+                            .iter()
+                            .filter_map(|event| match &event.kind {
+                                HistoryEventKind::Message { turn, step, .. } => {
+                                    Some((*turn, *step))
+                                }
+                                _ => None,
+                            })
+                            .collect();
+                        replay_events.extend(crate::deepseek_history::aggregate_orphan_deltas(
+                            &pages,
+                            &history.orphan_candidates,
+                            &message_steps,
+                        ));
+                        replay_events.sort_by_key(|event| event.seq);
+                        replay_events.dedup_by_key(|event| event.seq);
+                        for event in &replay_events {
+                            replay_history_event(event, events, state);
                         }
                         if let Some(values) = history.projection_values.as_ref() {
                             emit_projection_values(values, events);
@@ -690,7 +716,10 @@ fn handle_session_event(
             drop(turns);
             let reason = data.pointer("/reason/kind").and_then(Value::as_str);
             let success = matches!(reason, Some("completed" | "max-tokens"));
-            let summary = turn_end_summary(data, reason);
+            let summary = turn_end_summary(
+                reason,
+                data.pointer("/reason/error/message").and_then(Value::as_str),
+            );
             if !success && let Some(summary) = summary.as_ref() {
                 let _ = events.send(DriverEvent::Error(summary.clone()));
             }
@@ -782,6 +811,193 @@ fn handle_session_event(
             let _ = events.send(DriverEvent::AutoTitleUpdated(title));
         }
         _ => {}
+    }
+}
+
+/// Replays one typed history event (from `fetch_history`) into driver events,
+/// mirroring `handle_session_event` for the live stream. Text fields are
+/// indices into the snapshot's shared, deduplicated decode pool.
+fn replay_history_event(
+    event: &HistoryEvent,
+    events: &impl DriverEventSink,
+    state: &mut StreamState,
+) {
+    let seq = event.seq;
+    if i64::try_from(seq).is_ok_and(|seq| seq <= state.last_seq) {
+        return;
+    }
+    state.last_seq = i64::try_from(seq).unwrap_or(i64::MAX);
+    match &event.kind {
+        HistoryEventKind::TurnStart => {
+            if !state.turn_active {
+                state.turn_active = true;
+                let _ = events.send(DriverEvent::TurnStarted);
+            }
+        }
+        HistoryEventKind::TurnEnd { kind, error_message } => {
+            let mut turns = state.completed_turn_seqs.lock();
+            if turns.last().copied() != Some(seq) {
+                turns.push(seq);
+            }
+            drop(turns);
+            let reason = match kind {
+                TurnEndKind::Completed => Some("completed"),
+                TurnEndKind::Aborted => Some("aborted"),
+                TurnEndKind::Blocked => Some("blocked"),
+                TurnEndKind::Error => Some("error"),
+                TurnEndKind::MaxTokens => Some("max-tokens"),
+                TurnEndKind::Interrupted => Some("interrupted"),
+                TurnEndKind::Other => None,
+            };
+            let success = matches!(kind, TurnEndKind::Completed | TurnEndKind::MaxTokens);
+            let summary = turn_end_summary(reason, error_message.as_deref());
+            if !success && let Some(summary) = summary.as_ref() {
+                let _ = events.send(DriverEvent::Error(summary.clone()));
+            }
+            if state.turn_active {
+                state.turn_active = false;
+                let _ = events.send(DriverEvent::TurnFinished { success, summary });
+            }
+        }
+        // History replay is message-level: `assistant/chunk` deltas were
+        // already folded into the assembled `assistant/message`, so nothing
+        // is emitted for them and `streamed_steps` is never marked here.
+        HistoryEventKind::Message {
+            turn,
+            step,
+            texts: message_texts,
+            reasoning_texts,
+            usage,
+        } => {
+            if !state.streamed_steps.remove(&(*turn, *step)) {
+                for text in message_texts {
+                    let _ = events.send(DriverEvent::TextDelta(text.clone()));
+                }
+                for text in reasoning_texts {
+                    let _ = events.send(DriverEvent::ReasoningDelta(text.clone()));
+                }
+            }
+            if let Some(usage) = usage {
+                emit_typed_usage(*usage, events);
+            }
+        }
+        HistoryEventKind::ToolCall {
+            call_id,
+            name,
+            arguments,
+            view,
+        } => {
+            let arguments = match arguments {
+                Some(arguments) => serde_json::from_str(arguments)
+                    .unwrap_or_else(|_| Value::String(arguments.clone())),
+                None => Value::Null,
+            };
+            let presented = view.as_ref().and_then(|view| view.get("view"));
+            let title = presented
+                .and_then(|view| view.get("title"))
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .or_else(|| activity::input_title(Some(&arguments)))
+                .unwrap_or_else(|| name.clone());
+            let kind = presented
+                .and_then(presented_activity_kind)
+                .unwrap_or_else(|| super::support::classify_tool(name));
+            state.tools.insert(
+                call_id.clone(),
+                ToolCallState {
+                    name: name.clone(),
+                    title: title.clone(),
+                    kind,
+                    arguments: arguments.clone(),
+                },
+            );
+            let item = activity::tool_activity(
+                Some(call_id.clone()),
+                kind,
+                title,
+                Some(&arguments),
+                None,
+                presented,
+                false,
+                false,
+            );
+            let _ = events.send(DriverEvent::RichActivity(item));
+        }
+        HistoryEventKind::ToolResult {
+            call_id,
+            content,
+            failed,
+            view,
+        } => {
+            let stored = call_id.as_ref().and_then(|call_id| state.tools.remove(call_id));
+            let presented = view.as_ref().and_then(|view| view.get("view"));
+            let name = stored
+                .as_ref()
+                .map(|tool| tool.name.as_str())
+                .unwrap_or("tool");
+            let kind = stored
+                .as_ref()
+                .map(|tool| tool.kind)
+                .or_else(|| presented.and_then(presented_activity_kind))
+                .unwrap_or_else(|| super::support::classify_tool(name));
+            let title = presented
+                .and_then(|view| view.get("title"))
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .or_else(|| stored.as_ref().map(|tool| tool.title.clone()))
+                .unwrap_or_else(|| name.to_owned());
+            let arguments = stored.as_ref().map(|tool| &tool.arguments);
+            let output = content.as_ref();
+            let item = activity::tool_activity(
+                call_id.clone(),
+                kind,
+                title,
+                arguments,
+                output,
+                presented,
+                *failed,
+                true,
+            );
+            let _ = events.send(DriverEvent::RichActivity(item));
+        }
+        HistoryEventKind::TodoWrite { todos } => {
+            let item = activity::tool_activity(
+                Some(format!("deepseek-todo-{seq}")),
+                ActivityKind::Plan,
+                "Plan updated".into(),
+                None,
+                Some(todos),
+                None,
+                false,
+                true,
+            );
+            let _ = events.send(DriverEvent::RichActivity(item));
+        }
+        HistoryEventKind::RequestContext { context_window } => {
+            let window = context_window.filter(|window| *window > 0);
+            if window.is_some() {
+                let _ = events.send(DriverEvent::UsageUpdated {
+                    context_tokens: None,
+                    context_window: window,
+                });
+            }
+        }
+        HistoryEventKind::SessionTitle { title } => {
+            let title = title
+                .as_deref()
+                .map(str::trim)
+                .filter(|title| !title.is_empty())
+                .map(str::to_owned);
+            let _ = events.send(DriverEvent::AutoTitleUpdated(title));
+        }
+        HistoryEventKind::StepDelta { reasoning, text } => {
+            // An aborted step's partial output, restored as one delta.
+            let _ = events.send(if *reasoning {
+                DriverEvent::ReasoningDelta(text.clone())
+            } else {
+                DriverEvent::TextDelta(text.clone())
+            });
+        }
     }
 }
 
@@ -1168,6 +1384,19 @@ fn emit_usage(usage: Option<&Value>, events: &impl DriverEventSink) {
     .into_iter()
     .filter_map(|field| usage.get(field).and_then(Value::as_u64))
     .fold(0_u64, u64::saturating_add);
+    emit_usage_total(total, events);
+}
+
+fn emit_typed_usage(usage: TokenUsage, events: &impl DriverEventSink) {
+    let total = usage
+        .input_tokens
+        .saturating_add(usage.output_tokens)
+        .saturating_add(usage.cache_read_tokens)
+        .saturating_add(usage.cache_write_tokens);
+    emit_usage_total(total, events);
+}
+
+fn emit_usage_total(total: u64, events: &impl DriverEventSink) {
     if total > 0 {
         let _ = events.send(DriverEvent::UsageUpdated {
             context_tokens: Some(total),
@@ -1176,15 +1405,14 @@ fn emit_usage(usage: Option<&Value>, events: &impl DriverEventSink) {
     }
 }
 
-fn turn_end_summary(data: &Value, reason: Option<&str>) -> Option<String> {
+fn turn_end_summary(reason: Option<&str>, error_message: Option<&str>) -> Option<String> {
     match reason {
         Some("completed") => None,
         Some("max-tokens") => Some("DeepSeek Harness reached the model output limit".into()),
         Some("aborted") => Some("DeepSeek Harness turn was cancelled".into()),
         Some("blocked") => Some("DeepSeek Harness blocked the turn".into()),
         Some("error") => Some(
-            data.pointer("/reason/error/message")
-                .and_then(Value::as_str)
+            error_message
                 .unwrap_or("DeepSeek Harness turn failed")
                 .to_owned(),
         ),
@@ -1374,37 +1602,67 @@ fn apply_session_options(
     Ok(())
 }
 
+/// Fetches and merges every `session.history` page into a message-level
+/// snapshot. Raw page bytes are pushed into `pages` (owned by the caller),
+/// so they stay alive until the replay phase: the snapshot's orphan
+/// candidates reference positions inside them, and
+/// `deepseek_history::aggregate_orphan_deltas` reassembles aborted steps'
+/// partial text from the caller-held bytes right before replay.
 fn fetch_history(
     server: &PooledDeepSeekServer,
     session_id: &str,
+    pages: &mut Vec<Vec<u8>>,
 ) -> anyhow::Result<HistorySnapshot> {
-    let mut entries = Vec::new();
+    let mut events = Vec::new();
+    let mut orphan_candidates = Vec::new();
     let mut projection_values = None;
     let mut before_seq = None;
+    // Chunk events are dropped from `events` (history replay is message-level),
+    // so the fetch-wide last seq must come from the wire envelope seqs.
+    let mut fetched_last_seq = -1_i64;
     loop {
         let mut payload = json!({"sessionId": session_id, "maxMessages": 200});
         if let Some(before_seq) = before_seq {
             payload["beforeSeq"] = json!(before_seq);
         }
-        let page = server.rpc("session.history", payload)?;
+        let (bytes, rpc_id) = server.rpc_raw("session.history", payload)?;
+        // Typed, zero-copy page parse: text fields stay raw until the batch
+        // decode below, so a large page never builds a `serde_json::Value`
+        // tree.
+        let page = crate::deepseek_history::parse_history_response(&bytes, &rpc_id)
+            .context("could not read DeepSeek Harness session history")?;
         if projection_values.is_none() {
-            projection_values = page.pointer("/projections/values").cloned();
+            projection_values = page.projections.as_ref().and_then(|projections| {
+                serde_json::from_str::<Value>(projections.values.get()).ok()
+            });
         }
-        let page_entries = page
-            .get("events")
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
-        let oldest = page_entries
+        let oldest = page
+            .events
             .iter()
-            .filter_map(|entry| entry.pointer("/event/seq").and_then(Value::as_u64))
+            .filter_map(|entry| entry.event.as_ref().map(|event| event.seq))
             .min();
-        entries.extend(page_entries);
-        if !page
-            .get("hasMore")
-            .and_then(Value::as_bool)
-            .unwrap_or(false)
-        {
+        for entry in &page.events {
+            if let Some(event) = entry.event.as_ref() {
+                fetched_last_seq =
+                    fetched_last_seq.max(i64::try_from(event.seq).unwrap_or(i64::MAX));
+            }
+        }
+        events.extend(crate::deepseek_history::convert_page(&page.events));
+        // Record steps that streamed deltas without a same-page message; the
+        // page bytes live on in `pages` so their deltas can be reassembled at
+        // replay time.
+        let page_index = pages.len();
+        let page_base = bytes.as_ptr() as usize;
+        crate::deepseek_history::scan_orphan_candidates(
+            &page.events,
+            page_index,
+            page_base,
+            &mut orphan_candidates,
+        );
+        let has_more = page.has_more;
+        drop(page);
+        pages.push(bytes);
+        if !has_more {
             break;
         }
         let Some(oldest) = oldest.filter(|oldest| *oldest > 0) else {
@@ -1412,42 +1670,27 @@ fn fetch_history(
         };
         before_seq = Some(oldest);
     }
-    entries.sort_by_key(|entry| {
-        entry
-            .pointer("/event/seq")
-            .and_then(Value::as_u64)
-            .unwrap_or(u64::MAX)
-    });
-    entries.dedup_by_key(|entry| {
-        entry
-            .pointer("/event/seq")
-            .and_then(Value::as_u64)
-            .unwrap_or(u64::MAX)
-    });
+    events.sort_by_key(|event| event.seq);
+    events.dedup_by_key(|event| event.seq);
 
-    let mut last_seq = -1_i64;
     let mut last_turn_start = None;
     let mut last_turn_end = None;
     let mut completed_turn_seqs = Vec::new();
-    for entry in &entries {
-        let event = entry.get("event").unwrap_or(entry);
-        let Some(seq) = event.get("seq").and_then(Value::as_u64) else {
-            continue;
-        };
-        last_seq = last_seq.max(i64::try_from(seq).unwrap_or(i64::MAX));
-        match event.get("type").and_then(Value::as_str) {
-            Some("turn/start") => last_turn_start = Some(seq),
-            Some("turn/end") => {
-                last_turn_end = Some(seq);
-                completed_turn_seqs.push(seq);
+    for event in &events {
+        match &event.kind {
+            HistoryEventKind::TurnStart => last_turn_start = Some(event.seq),
+            HistoryEventKind::TurnEnd { .. } => {
+                last_turn_end = Some(event.seq);
+                completed_turn_seqs.push(event.seq);
             }
             _ => {}
         }
     }
     Ok(HistorySnapshot {
-        events: entries,
+        events,
+        orphan_candidates,
         projection_values,
-        last_seq,
+        last_seq: fetched_last_seq,
         turn_active: last_turn_start
             .is_some_and(|start| last_turn_end.is_none_or(|end| start > end)),
         completed_turn_seqs,
@@ -1631,5 +1874,352 @@ mod tests {
                 context_window: Some(8192)
             }
         ));
+    }
+
+    /// History replay is message-level: the old path streams one `TextDelta`
+    /// per token chunk, the new path one `TextDelta` per assembled message
+    /// block. The UI-visible result is identical, so equivalence is asserted
+    /// on the aggregate: concatenated text, concatenated reasoning, and the
+    /// order-preserved non-text events.
+    #[derive(Default)]
+    struct Aggregate {
+        text: String,
+        reasoning: String,
+        last_usage: Option<String>,
+        other: Vec<String>,
+    }
+
+    fn aggregate_driver_events(events: &[String]) -> Aggregate {
+        let mut aggregate = Aggregate::default();
+        for event in events {
+            // Debug output quotes the payload; strip the quotes so the
+            // concatenation compares content, not quoting granularity.
+            if let Some(payload) = event
+                .strip_prefix("TextDelta(\"")
+                .and_then(|e| e.strip_suffix("\")"))
+            {
+                aggregate.text.push_str(payload);
+            } else if let Some(payload) = event
+                .strip_prefix("ReasoningDelta(\"")
+                .and_then(|e| e.strip_suffix("\")"))
+            {
+                aggregate.reasoning.push_str(payload);
+            } else if event.starts_with("UsageUpdated") {
+                // The old path reports usage per usage-chunk AND per message;
+                // the new path per message only. The UI-visible final value
+                // is the last one.
+                aggregate.last_usage = Some(event.clone());
+            } else {
+                aggregate.other.push(event.clone());
+            }
+        }
+        aggregate
+    }
+
+    fn assert_aggregates_match(old: &Aggregate, new: &Aggregate, label: &str) {
+        assert_eq!(old.text, new.text, "{label}: message text differs");
+        assert_eq!(old.reasoning, new.reasoning, "{label}: reasoning differs");
+        assert_eq!(old.last_usage, new.last_usage, "{label}: usage differs");
+        assert_eq!(old.other, new.other, "{label}: non-text events differ");
+    }
+
+
+    fn mask_activity_ids(debug: &str) -> String {
+        fn is_hex(byte: u8) -> bool {
+            byte.is_ascii_hexdigit()
+        }
+        let bytes = debug.as_bytes();
+        let mut out = Vec::with_capacity(debug.len());
+        let mut copied = 0;
+        let mut index = 0;
+        while index + 40 <= bytes.len() {
+            if &bytes[index..index + 4] == b"id: "
+                && bytes[index + 12] == b'-'
+                && bytes[index + 17] == b'-'
+                && bytes[index + 22] == b'-'
+                && bytes[index + 27] == b'-'
+                && (0..36).all(|offset| {
+                    matches!(offset, 8 | 13 | 18 | 23) || is_hex(bytes[index + 4 + offset])
+                })
+            {
+                out.extend_from_slice(&bytes[copied..index]);
+                out.extend_from_slice(b"id: <id>");
+                index += 40;
+                copied = index;
+            } else {
+                index += 1;
+            }
+        }
+        out.extend_from_slice(&bytes[copied..]);
+        String::from_utf8(out).unwrap()
+    }
+
+    fn state_signature(state: &StreamState) -> String {
+        let mut tools = state
+            .tools
+            .iter()
+            .map(|(call_id, tool)| {
+                format!(
+                    "{call_id}:{}|{}|{:?}|{}",
+                    tool.name,
+                    tool.title,
+                    tool.kind,
+                    tool.arguments
+                )
+            })
+            .collect::<Vec<_>>();
+        tools.sort();
+        // `last_seq` is fetch-derived in production (the wire max seq), not a
+        // replay output, so it is excluded here: the new path skips chunk
+        // events during replay while the old path replays them, which would
+        // otherwise make the replay side-effect diverge.
+        format!(
+            "turn_active={} turns={:?} tools={:?}",
+            state.turn_active,
+            &*state.completed_turn_seqs.lock(),
+            tools
+        )
+    }
+
+    /// Drives both the old `Value`-based replay (`handle_session_event`) and
+    /// the typed history path (`replay_history_event`) over the captured
+    /// `session.history` pages in ~/Desktop/1.json..8.json and asserts they
+    /// produce the same aggregated driver events and stream state. Skipped
+    /// when the capture files are absent.
+    #[test]
+    fn typed_history_replay_matches_value_replay() {
+        use crate::deepseek_history::{
+            convert_page, parse_history_response,
+        };
+
+        /// Activity ids are random UUIDs; mask them so both paths compare equal.
+
+
+        let mut tested = 0;
+        for index in 1..=8 {
+            let path = format!("/Users/dzz/Desktop/{index}.json");
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            tested += 1;
+
+            // Old path: parse the whole envelope into Value, extract events,
+            // sort/dedup by seq, replay through handle_session_event.
+            let envelope: Value = serde_json::from_slice(&bytes).unwrap();
+            let rpc_id = envelope.get("rpcId").and_then(Value::as_str).unwrap();
+            let value = envelope.pointer("/result/value").unwrap();
+            let mut entries = value
+                .get("events")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            entries.sort_by_key(|entry| {
+                entry
+                    .pointer("/event/seq")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(u64::MAX)
+            });
+            entries.dedup_by_key(|entry| {
+                entry
+                    .pointer("/event/seq")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(u64::MAX)
+            });
+            let (old_events, old_state) = {
+                let (events, event_rx, mut state) = harness();
+                for entry in &entries {
+                    let event = entry.get("event").unwrap_or(entry);
+                    let view = entry.get("view");
+                    handle_session_event(event, view, &events, &mut state);
+                }
+                drop(events);
+                let mut emitted = Vec::new();
+                while let Ok(event) = event_rx.try_recv() {
+                    emitted.push(mask_activity_ids(&format!("{event:?}")));
+                }
+                (emitted, state_signature(&state))
+            };
+
+            // New path: typed zero-copy parse, direct text decode, typed replay.
+            let (new_events, new_state) = {
+                let page = parse_history_response(&bytes, rpc_id).unwrap();
+                let mut events = convert_page(&page.events);
+                let mut candidates = Vec::new();
+                crate::deepseek_history::scan_orphan_candidates(
+                    &page.events,
+                    0,
+                    bytes.as_ptr() as usize,
+                    &mut candidates,
+                );
+                let message_steps: HashSet<(u64, u64)> = events
+                    .iter()
+                    .filter_map(|event| match &event.kind {
+                        HistoryEventKind::Message { turn, step, .. } => Some((*turn, *step)),
+                        _ => None,
+                    })
+                    .collect();
+                events.extend(crate::deepseek_history::aggregate_orphan_deltas(
+                    std::slice::from_ref(&bytes),
+                    &candidates,
+                    &message_steps,
+                ));
+                events.sort_by_key(|event| event.seq);
+                events.dedup_by_key(|event| event.seq);
+                let (sink, event_rx, mut state) = harness();
+                for event in &events {
+                    replay_history_event(event, &sink, &mut state);
+                }
+                drop(sink);
+                let mut emitted = Vec::new();
+                while let Ok(event) = event_rx.try_recv() {
+                    emitted.push(mask_activity_ids(&format!("{event:?}")));
+                }
+                (emitted, state_signature(&state))
+            };
+
+            // The old path replays every token delta; the new path replays
+            // assembled messages only.
+            assert!(
+                new_events.len() <= old_events.len(),
+                "{path}: message-level replay must not emit more events (old={} new={})",
+                old_events.len(),
+                new_events.len()
+            );
+            assert_aggregates_match(
+                &aggregate_driver_events(&old_events),
+                &aggregate_driver_events(&new_events),
+                &path,
+            );
+            assert_eq!(old_state, new_state, "{path}: stream state differs");
+        }
+        assert!(tested > 0, "no Desktop history capture files found");
+    }
+
+    /// Same equivalence check over all eight capture pages merged into ONE
+    /// fetch (the real resume path: several `session.history` requests are
+    /// pulled and merged, deduplicated by seq, then replayed).
+    #[test]
+    fn typed_history_merged_replay_matches_value_replay() {
+        use crate::deepseek_history::{
+            convert_page, parse_history_response,
+        };
+
+
+
+        // Realistic page order: the client pages backward with beforeSeq.
+        let order = [8, 5, 6, 1, 2, 7, 4, 3];
+        let mut loaded = Vec::new();
+        for index in order {
+            let path = format!("/Users/dzz/Desktop/{index}.json");
+            if let Ok(bytes) = std::fs::read(&path) {
+                loaded.push(bytes);
+            }
+        }
+        assert!(
+            loaded.len() == order.len(),
+            "expected all eight Desktop history capture files"
+        );
+
+        // Old path: per page Value parse, merge, sort/dedup by seq, replay.
+        let (old_events, old_state) = {
+            let mut entries = Vec::new();
+            for bytes in &loaded {
+                let envelope: Value = serde_json::from_slice(bytes).unwrap();
+                let value = envelope.pointer("/result/value").unwrap();
+                entries.extend(
+                    value
+                        .get("events")
+                        .and_then(Value::as_array)
+                        .cloned()
+                        .unwrap_or_default(),
+                );
+            }
+            entries.sort_by_key(|entry| {
+                entry
+                    .pointer("/event/seq")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(u64::MAX)
+            });
+            entries.dedup_by_key(|entry| {
+                entry
+                    .pointer("/event/seq")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(u64::MAX)
+            });
+            let (events, event_rx, mut state) = harness();
+            for entry in &entries {
+                let event = entry.get("event").unwrap_or(entry);
+                let view = entry.get("view");
+                handle_session_event(event, view, &events, &mut state);
+            }
+            drop(events);
+            let mut emitted = Vec::new();
+            while let Ok(event) = event_rx.try_recv() {
+                emitted.push(mask_activity_ids(&format!("{event:?}")));
+            }
+            (emitted, state_signature(&state))
+        };
+
+        // New path: per page typed parse + direct text decode, convert,
+        // merge, sort/dedup by seq, replay.
+        let (new_events, new_state) = {
+            let mut events = Vec::new();
+            let mut candidates = Vec::new();
+            for (page_index, bytes) in loaded.iter().enumerate() {
+                let rpc_id: String = {
+                    let envelope: Value = serde_json::from_slice(bytes).unwrap();
+                    envelope
+                        .get("rpcId")
+                        .and_then(Value::as_str)
+                        .unwrap()
+                        .to_owned()
+                };
+                let page = parse_history_response(bytes, &rpc_id).unwrap();
+                events.extend(convert_page(&page.events));
+                crate::deepseek_history::scan_orphan_candidates(
+                    &page.events,
+                    page_index,
+                    bytes.as_ptr() as usize,
+                    &mut candidates,
+                );
+            }
+            let message_steps: HashSet<(u64, u64)> = events
+                .iter()
+                .filter_map(|event| match &event.kind {
+                    HistoryEventKind::Message { turn, step, .. } => Some((*turn, *step)),
+                    _ => None,
+                })
+                .collect();
+            events.extend(crate::deepseek_history::aggregate_orphan_deltas(
+                &loaded,
+                &candidates,
+                &message_steps,
+            ));
+            events.sort_by_key(|event| event.seq);
+            events.dedup_by_key(|event| event.seq);
+            let (sink, event_rx, mut state) = harness();
+            for event in &events {
+                replay_history_event(event, &sink, &mut state);
+            }
+            drop(sink);
+            let mut emitted = Vec::new();
+            while let Ok(event) = event_rx.try_recv() {
+                emitted.push(mask_activity_ids(&format!("{event:?}")));
+            }
+            (emitted, state_signature(&state))
+        };
+
+        assert!(
+            new_events.len() <= old_events.len(),
+            "merged: message-level replay must not emit more events (old={} new={})",
+            old_events.len(),
+            new_events.len()
+        );
+        assert_aggregates_match(
+            &aggregate_driver_events(&old_events),
+            &aggregate_driver_events(&new_events),
+            "merged",
+        );
+        assert_eq!(old_state, new_state, "merged: stream state differs");
     }
 }

--- a/crates/waku-core/src/driver/mod.rs
+++ b/crates/waku-core/src/driver/mod.rs
@@ -5,6 +5,8 @@ mod activity;
 mod amp;
 mod claude;
 mod codex;
+#[cfg(unix)]
+mod codex_pool;
 mod computer_use;
 mod deepseek;
 mod opencode;

--- a/crates/waku-core/src/frontmatter.rs
+++ b/crates/waku-core/src/frontmatter.rs
@@ -2,7 +2,7 @@
 ///
 /// Unknown and unsupported values are ignored so a hand-written prompt still
 /// stays listed. YAML syntax, including folded and literal block scalars, is
-/// handled by `serde-saphyr`.
+/// handled without an external YAML dependency.
 pub(crate) fn parse_frontmatter_fields<'a>(
     contents: &'a str,
     mut visit: impl FnMut(&str, String),
@@ -14,34 +14,213 @@ pub(crate) fn parse_frontmatter_fields<'a>(
         return contents;
     };
 
-    if let Ok(fields) = serde_saphyr::from_str::<serde_json::Map<String, serde_json::Value>>(block)
-    {
-        for (key, value) in fields {
-            if let Some(value) = frontmatter_value(value) {
-                visit(&key, value);
-            }
+    for (key, value) in parse_block(block) {
+        if let Some(value) = normalize_value(&value) {
+            visit(&key, value);
         }
     }
 
     body.trim_start_matches(['-']).trim_start()
 }
 
-fn frontmatter_value(value: serde_json::Value) -> Option<String> {
-    let value = match value {
-        serde_json::Value::String(value) => value,
-        // Preserve the bracket notation historically accepted by command
-        // metadata such as `argument-hint: [pr-number]`.
-        serde_json::Value::Array(values) => {
-            let values = values
-                .into_iter()
-                .map(|value| value.as_str().map(str::to_owned))
-                .collect::<Option<Vec<_>>>()?;
-            format!("[{}]", values.join(", "))
+fn normalize_value(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Objects / nested mappings are ignored - they would have been
+    // Value::Object in the serde_saphyr path.
+    if trimmed.starts_with('{') && trimmed.ends_with('}') {
+        return None;
+    }
+    Some(trimmed.to_owned())
+}
+
+fn parse_block(block: &str) -> Vec<(String, String)> {
+    let lines: Vec<&str> = block.lines().collect();
+    let mut fields = Vec::new();
+    let mut idx = 0;
+    while idx < lines.len() {
+        let line = lines[idx];
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            idx += 1;
+            continue;
         }
-        serde_json::Value::Bool(value) => value.to_string(),
-        serde_json::Value::Number(value) => value.to_string(),
-        serde_json::Value::Null | serde_json::Value::Object(_) => return None,
+        // frontmatter keys are at indent 0; indented lines belong to a block scalar.
+        if line.starts_with(' ') || line.starts_with('\t') {
+            idx += 1;
+            continue;
+        }
+        let Some(colon) = line.find(':') else {
+            idx += 1;
+            continue;
+        };
+        let key = line[..colon].trim().to_owned();
+        if key.is_empty() {
+            idx += 1;
+            continue;
+        }
+        let after = line[colon + 1..].trim();
+        // Block scalar indicator: > / >- / >+ / | / |- etc.
+        if after.starts_with('>') || after.starts_with('|') {
+            let is_folded = after.starts_with('>');
+            let (value, consumed) = collect_block_scalar(&lines, idx + 1, is_folded);
+            if !value.is_empty() || !is_folded {
+                // For literal keep even empty; for folded empty means no content.
+                // Push only if we got something or the scalar was explicitly empty.
+            }
+            // Only push non-empty after normalize; normalize_value will filter.
+            if !value.trim().is_empty() {
+                fields.push((key, value));
+            } else if after.len() > 1 {
+                // block scalar with no content - ignore
+            }
+            idx += 1 + consumed;
+            continue;
+        }
+        if after.is_empty() {
+            // No inline value and no block indicator - ignore (unsupported / object).
+            idx += 1;
+            continue;
+        }
+        // Inline scalar: handle quoted strings, bracket arrays, plain.
+        let mut value = after.to_owned();
+        // Strip trailing comment for plain scalars? Keep simple: if # surrounded by space.
+        // Not needed for current tests.
+        value = strip_inline_value(&value);
+        fields.push((key, value));
+        idx += 1;
+    }
+    fields
+}
+
+fn strip_inline_value(raw: &str) -> String {
+    let s = raw.trim();
+    if s.len() >= 2 {
+        let bytes = s.as_bytes();
+        if (bytes[0] == b'"' && bytes[s.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[s.len() - 1] == b'\'')
+        {
+            // Remove surrounding quotes. YAML double quotes allow escapes but
+            // frontmatter only uses simple quoted strings.
+            return s[1..s.len() - 1].to_owned();
+        }
+    }
+    s.to_owned()
+}
+
+fn collect_block_scalar(lines: &[&str], start: usize, is_folded: bool) -> (String, usize) {
+    if start >= lines.len() {
+        return (String::new(), 0);
+    }
+    // Find base indent from first non-empty line.
+    let mut base_indent: Option<usize> = None;
+    for &line in &lines[start..] {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let indent = line.len() - line.trim_start_matches(' ').len();
+        // block content must be indented; if indent == 0 it's the next key.
+        if indent == 0 {
+            break;
+        }
+        base_indent = Some(indent);
+        break;
+    }
+    let Some(base) = base_indent else {
+        return (String::new(), 0);
     };
-    let value = value.trim();
-    (!value.is_empty()).then(|| value.to_owned())
+    let mut collected: Vec<&str> = Vec::new();
+    let mut consumed = 0;
+    for &line in &lines[start..] {
+        if line.trim().is_empty() {
+            // blank line is part of scalar (preserves break)
+            collected.push(line);
+            consumed += 1;
+            continue;
+        }
+        let indent = line.len() - line.trim_start_matches(' ').len();
+        if indent < base {
+            break;
+        }
+        collected.push(line);
+        consumed += 1;
+    }
+    let value = if is_folded {
+        fold_block_scalar(&collected, base)
+    } else {
+        literal_block_scalar(&collected, base)
+    };
+    (value, consumed)
+}
+
+fn fold_block_scalar(lines: &[&str], base: usize) -> String {
+    let mut out = String::new();
+    let mut prev_more_indented = false;
+    let mut prev_blank = false;
+    for &raw in lines {
+        if raw.trim().is_empty() {
+            // Blank line -> hard break. Collapse consecutive blanks to one extra newline?
+            // In YAML folded, a blank line is a "\n". We'll ensure one newline.
+            if !out.is_empty() && !out.ends_with('\n') {
+                out.push('\n');
+            } else if !out.is_empty() {
+                // consecutive blank already has newline, add one more
+                out.push('\n');
+            }
+            prev_blank = true;
+            prev_more_indented = false;
+            continue;
+        }
+        let indent = raw.len() - raw.trim_start_matches(' ').len();
+        let more_indented = indent > base;
+        // content after base indent, preserve extra spaces for more-indented
+        let content = &raw[base..];
+        if more_indented {
+            if !out.is_empty() && !out.ends_with('\n') {
+                out.push('\n');
+            }
+            out.push_str(content);
+            prev_more_indented = true;
+            prev_blank = false;
+        } else {
+            let trimmed = content.trim();
+            if out.is_empty() {
+                out.push_str(trimmed);
+            } else if prev_blank || prev_more_indented || out.ends_with('\n') {
+                if out.ends_with('\n') {
+                    // already at line start
+                } else {
+                    out.push('\n');
+                }
+                out.push_str(trimmed);
+            } else {
+                out.push(' ');
+                out.push_str(trimmed);
+            }
+            prev_more_indented = false;
+            prev_blank = false;
+        }
+    }
+    // chomping: tests use >- (strip). Our construction never adds a trailing newline,
+    // so strip is implicit. For keep (+) we would need to preserve, but not required.
+    out
+}
+
+fn literal_block_scalar(lines: &[&str], base: usize) -> String {
+    let mut out = String::new();
+    for (i, &raw) in lines.iter().enumerate() {
+        if raw.trim().is_empty() {
+            out.push('\n');
+            continue;
+        }
+        let content = if raw.len() >= base { &raw[base..] } else { raw };
+        out.push_str(content);
+        if i + 1 < lines.len() {
+            out.push('\n');
+        }
+    }
+    // Strip final break like chomping strip
+    out.trim_end_matches('\n').to_owned()
 }

--- a/crates/waku-core/src/lib.rs
+++ b/crates/waku-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod composer_complete;
 pub mod computer_use;
 pub mod cursor_session;
 pub mod daemon;
+pub mod deepseek_history;
 pub mod deepseek_pool;
 pub mod deepseek_session;
 pub mod driver;

--- a/crates/waku-core/src/opencode_session.rs
+++ b/crates/waku-core/src/opencode_session.rs
@@ -280,8 +280,7 @@ pub(crate) fn request_json_on_port(
     body: Option<&Value>,
     timeout: Duration,
 ) -> anyhow::Result<Value> {
-    let body = body.map(serde_json::to_vec).transpose()?;
-    let response = http_request(port, method, path, body.as_deref(), timeout)?;
+    let response = request_raw_on_port(port, method, path, body, timeout)?;
     // Some routes answer 204 No Content — `prompt_async` among them — and
     // the status was already checked, so an empty success body is Null.
     if response.iter().all(u8::is_ascii_whitespace) {
@@ -289,6 +288,20 @@ pub(crate) fn request_json_on_port(
     }
     serde_json::from_slice(&response)
         .with_context(|| format!("OpenCode returned invalid JSON for {method} {path}"))
+}
+
+/// Sends one request and returns the raw response body without parsing it.
+/// Callers that deserialize straight into a typed struct (instead of
+/// `serde_json::Value`) avoid building a full value tree for large payloads.
+pub(crate) fn request_raw_on_port(
+    port: u16,
+    method: &str,
+    path: &str,
+    body: Option<&Value>,
+    timeout: Duration,
+) -> anyhow::Result<Vec<u8>> {
+    let body = body.map(serde_json::to_vec).transpose()?;
+    http_request(port, method, path, body.as_deref(), timeout)
 }
 
 fn http_request(

--- a/crates/waku-core/src/server.rs
+++ b/crates/waku-core/src/server.rs
@@ -476,7 +476,7 @@ pub fn serve(
         match listener.accept() {
             Ok((stream, _)) => {
                 if active_connections
-                    .fetch_update(Ordering::AcqRel, Ordering::Acquire, |active| {
+                    .try_update(Ordering::AcqRel, Ordering::Acquire, |active| {
                         (active < MAX_CONNECTIONS).then_some(active + 1)
                     })
                     .is_err()

--- a/src/app/composer.rs
+++ b/src/app/composer.rs
@@ -1,3 +1,4 @@
+use super::runtime::session_has_unsettled_turn;
 use super::*;
 
 use anyhow::Context as _;
@@ -13,10 +14,11 @@ pub(super) enum ComposerSubmitAction {
 pub(super) fn composer_submit_action(
     status: Option<SessionStatus>,
     preparing: bool,
+    has_unsettled_turn: bool,
 ) -> ComposerSubmitAction {
     if preparing {
         ComposerSubmitAction::Preparing
-    } else if status.is_some_and(SessionStatus::is_busy) {
+    } else if status.is_some_and(SessionStatus::is_busy) && has_unsettled_turn {
         ComposerSubmitAction::Stop
     } else {
         ComposerSubmitAction::Send
@@ -2190,14 +2192,16 @@ impl Waku {
     fn execute_goal_composer_command(&mut self, prompt: &str, cx: &mut Context<Self>) -> bool {
         use crate::composer_complete::GoalCommand;
         use crate::model::{GoalOperation, ThreadGoalStatus};
-        let Some((session_id, command, current_goal)) = self.selected_session().and_then(|session| {
-            let command = crate::composer_complete::parse_goal_submission(
-                session.provider,
-                prompt,
-                &self.slash_command_index,
-            )?;
-            Some((session.id, command, session.thread_goal.clone()))
-        }) else {
+        let Some((session_id, command, current_goal)) =
+            self.selected_session().and_then(|session| {
+                let command = crate::composer_complete::parse_goal_submission(
+                    session.provider,
+                    prompt,
+                    &self.slash_command_index,
+                )?;
+                Some((session.id, command, session.thread_goal.clone()))
+            })
+        else {
             return false;
         };
         match command {
@@ -2692,8 +2696,11 @@ impl Waku {
             self.submission_preparations.contains(&session.id)
                 || self.response_fork_preparations.contains_key(&session.id)
         });
-        let submit_action =
-            composer_submit_action(session.map(|session| session.status), preparing);
+        let submit_action = composer_submit_action(
+            session.map(|session| session.status),
+            preparing,
+            session.is_some_and(session_has_unsettled_turn),
+        );
         let escape_stop_armed = session.is_some_and(|session| {
             self.escape_stop_confirmation
                 .is_armed_for(EscapeStopTarget::for_session(session), Instant::now())

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -100,6 +100,14 @@ pub(super) fn session_has_active_provider_turn(session: &AgentSession) -> bool {
             .is_some_and(|turn| turn.status == TurnStatus::Running && turn.provider_turn_started)
 }
 
+/// A busy status without a running turn is stale session metadata, not a
+/// provider turn that can own a follow-up. This can happen while a runtime is
+/// being reattached or after a completion event was applied to the transcript
+/// but the status projection lagged behind it.
+pub(super) fn session_has_unsettled_turn(session: &AgentSession) -> bool {
+    session.is_busy() && session.active_turn_id().is_some()
+}
+
 /// Merge the daemon's list-only session projection into the desktop catalog.
 ///
 /// Existing rows may already contain a hydrated transcript, so only list
@@ -2920,7 +2928,7 @@ impl Waku {
         if self.response_fork_preparations.contains_key(&session.id) {
             return;
         }
-        if session.is_busy() {
+        if session_has_unsettled_turn(session) {
             // While the agent is working, Enter queues a follow-up instead of
             // refusing the message. The queue drains once the turn settles.
             self.enqueue_follow_up_submission(session.id, submission, cx);
@@ -2940,7 +2948,7 @@ impl Waku {
         let Some(session) = self.selected_session().cloned() else {
             return;
         };
-        if !session.is_busy() {
+        if !session_has_unsettled_turn(&session) {
             self.submit_composer_submission(submission, cx);
             return;
         }
@@ -3152,7 +3160,7 @@ impl Waku {
             self.defer_queue_drain(session_id);
             return;
         }
-        if session.status.is_busy() {
+        if session_has_unsettled_turn(session) {
             self.enqueue_follow_up_submission(session_id, submission, cx);
             return;
         }

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -3106,7 +3106,7 @@ impl Waku {
         else {
             return;
         };
-        if session.is_busy()
+        if session_has_unsettled_turn(session)
             || session.queued_messages.is_empty()
             || self.ending_checkpoint_pending(session_id)
             // Messages parked behind a goal-initiated provider start stay

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2,7 +2,9 @@ use super::composer::{
     ComposerSubmitAction, composer_submit_action, dropped_file_mention, merged_submission,
     next_picker_highlight, visible_branch_entries,
 };
-use super::runtime::{merge_remote_session_catalog, session_has_active_provider_turn};
+use super::runtime::{
+    merge_remote_session_catalog, session_has_active_provider_turn, session_has_unsettled_turn,
+};
 use super::settings::visible_settings_pages;
 use super::{
     ESCAPE_STOP_CONFIRMATION_TIMEOUT, EscapeStopConfirmation, EscapeStopPress, EscapeStopTarget,
@@ -171,6 +173,23 @@ fn foreground_output_recovers_a_missed_provider_turn_start_for_steering() {
     assert!(session_accepts_turn_output(&mut session));
     assert_eq!(session.status, SessionStatus::Working);
     assert!(session_has_active_provider_turn(&session));
+}
+
+#[test]
+fn stale_busy_status_does_not_queue_a_new_submission() {
+    let mut session = AgentSession::new(Uuid::new_v4(), ProviderKind::Codex);
+    session.status = SessionStatus::Working;
+
+    assert!(!session_has_unsettled_turn(&session));
+}
+
+#[test]
+fn active_turn_keeps_submission_on_the_follow_up_path() {
+    let mut session = AgentSession::new(Uuid::new_v4(), ProviderKind::Codex);
+    session.begin_turn("still working");
+    session.status = SessionStatus::Working;
+
+    assert!(session_has_unsettled_turn(&session));
 }
 
 #[test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -132,23 +132,27 @@ fn remote_task_catalog_adds_web_tasks_without_replacing_hydrated_detail() {
 #[test]
 fn composer_only_offers_stop_after_submission_preparation() {
     assert_eq!(
-        composer_submit_action(Some(SessionStatus::Idle), false),
+        composer_submit_action(Some(SessionStatus::Idle), false, false),
         ComposerSubmitAction::Send
     );
     assert_eq!(
-        composer_submit_action(Some(SessionStatus::Connecting), true),
+        composer_submit_action(Some(SessionStatus::Connecting), true, false),
         ComposerSubmitAction::Preparing
     );
     assert_eq!(
-        composer_submit_action(Some(SessionStatus::Connecting), false),
+        composer_submit_action(Some(SessionStatus::Connecting), false, true),
         ComposerSubmitAction::Stop
     );
     assert_eq!(
-        composer_submit_action(Some(SessionStatus::Working), false),
+        composer_submit_action(Some(SessionStatus::Working), false, true),
         ComposerSubmitAction::Stop
     );
     assert_eq!(
-        composer_submit_action(Some(SessionStatus::Failed), false),
+        composer_submit_action(Some(SessionStatus::Failed), false, false),
+        ComposerSubmitAction::Send
+    );
+    assert_eq!(
+        composer_submit_action(Some(SessionStatus::Working), false, false),
         ComposerSubmitAction::Send
     );
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1702,7 +1702,7 @@ impl EntityInputHandler for TextInput {
         &mut self,
         range_utf16: Option<Range<usize>>,
         new_text: &str,
-        _: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if self.read_only {
@@ -1735,6 +1735,10 @@ impl EntityInputHandler for TextInput {
         if previous != self.content {
             cx.emit(InputEvent::Edited);
         }
+        // The caret moved; the layout that answers the next IME rect query
+        // only exists after the next paint, so have AppKit re-query the
+        // candidate window position once that frame lands.
+        window.invalidate_character_coordinates();
         cx.notify();
     }
 
@@ -1743,7 +1747,7 @@ impl EntityInputHandler for TextInput {
         range_utf16: Option<Range<usize>>,
         new_text: &str,
         new_selected_range_utf16: Option<Range<usize>>,
-        _: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if self.read_only {
@@ -1787,6 +1791,10 @@ impl EntityInputHandler for TextInput {
         if previous != self.content {
             cx.emit(InputEvent::Edited);
         }
+        // The composition moved the caret; the candidate window follows it,
+        // but the layout answering the IME rect query is still the previous
+        // frame's. Re-ask AppKit for the rect once the fresh frame paints.
+        window.invalidate_character_coordinates();
         cx.notify();
     }
 
@@ -1797,10 +1805,30 @@ impl EntityInputHandler for TextInput {
         _: &mut Window,
         _: &mut Context<Self>,
     ) -> Option<Bounds<Pixels>> {
-        let layout = self.last_layout.as_ref()?;
+        // AppKit can ask for the candidate rect before this field has painted
+        // once. Returning None becomes a zero NSRect in the macOS backend,
+        // which puts the candidate window at the screen origin.
+        let Some(layout) = self.last_layout.as_ref() else {
+            return Some(Bounds::new(bounds.origin, size(px(1.), px(1.))));
+        };
         let range = self.range_from_utf16(&range_utf16);
-        let start = layout.position_for_index(range.start)?;
-        let end = layout.position_for_index(range.end)?;
+        // The layout trails the content by one frame — it is only refreshed in
+        // `paint` — but AppKit asks for the IME candidate rect synchronously
+        // after `setMarkedText:`, before that frame lands. A composition that
+        // has grown past the last painted text would then miss every line and
+        // yield `None`, which the mac platform turns into a zero rect at the
+        // screen origin: the candidate window pops into the bottom-left corner
+        // of the display. Clamp to the layout's end instead, degrading to the
+        // caret's previous position until the fresh frame lands.
+        let layout_len = layout.len();
+        let end_index = range.end.min(layout_len);
+        let start_index = range.start.min(end_index);
+        let Some(start) = layout.position_for_index(start_index) else {
+            return Some(Bounds::new(bounds.origin, size(px(1.), px(1.))));
+        };
+        let Some(end) = layout.position_for_index(end_index) else {
+            return Some(Bounds::new(bounds.origin, size(px(1.), px(1.))));
+        };
         let line_height = layout.line_height();
         if start.y == end.y {
             Some(Bounds::from_corners(
@@ -3279,6 +3307,65 @@ mod tests {
             assert_eq!(input.content(), "あk");
             assert_eq!(input.marked_range, Some(3..4));
             assert_eq!(input.selected_range, 4..4);
+        });
+    }
+
+    /// The layout trails the content by one frame — it is only refreshed in
+    /// `paint` — but AppKit asks for the IME candidate rect synchronously
+    /// after `setMarkedText:`, before that frame lands. A composition that has
+    /// grown past the last painted text must still answer a bounds rect
+    /// (clamped to the layout's end) instead of `None`: the mac platform turns
+    /// a `None` into a zero rect at the screen origin and pops the candidate
+    /// window into the bottom-left corner of the display.
+    #[gpui::test]
+    fn ime_candidate_bounds_never_yield_none_for_a_stale_layout(cx: &mut TestAppContext) {
+        let (input, cx) = setup_input(cx, "hi", px(300.));
+
+        // Grow the composition past the last painted text ("hi") and answer
+        // the IME rect query in the same update, before any frame can land —
+        // the way AppKit asks for `firstRect(forCharacterRange:)` right after
+        // `setMarkedText:`. `last_layout` is still the two-byte "hi" layout.
+        cx.update(|window, cx| {
+            input.update(cx, |input, cx| {
+                input.replace_and_mark_text_in_range(None, "nihao", Some(2..2), window, cx);
+                assert_eq!(
+                    input.last_layout.as_ref().map(|layout| layout.len()),
+                    Some(2),
+                    "fixture must leave the layout one frame behind the content"
+                );
+                let bounds = input.bounds_for_range(2..7, window.bounds(), window, cx);
+                let bounds = bounds.expect(
+                    "a stale layout must still answer the IME rect, or the candidate \
+                     window falls back to the screen origin",
+                );
+                // The clamped answer is the end of the last painted text — the
+                // caret's previous position — which sits inside the window.
+                assert!(bounds.origin.x >= px(0.0));
+                assert!(bounds.origin.y >= px(0.0));
+                let expected = input.last_layout.as_ref().unwrap().position_for_index(2).unwrap();
+                assert_eq!(bounds.origin, expected);
+            })
+        });
+    }
+
+    /// The first IME query can arrive before the input has painted a layout;
+    /// it must still return a non-zero anchor instead of macOS's screen-origin
+    /// fallback for a missing rect.
+    #[gpui::test]
+    fn ime_candidate_bounds_have_a_fallback_before_first_layout(cx: &mut TestAppContext) {
+        let (input, cx) = setup_input(cx, "hi", px(300.));
+
+        cx.update(|window, cx| {
+            input.update(cx, |input, cx| {
+                input.last_layout = None;
+                let element_bounds = window.bounds();
+                let bounds = input
+                    .bounds_for_range(0..0, element_bounds, window, cx)
+                    .expect("IME queries must have an anchor before the first layout");
+                assert_eq!(bounds.origin, element_bounds.origin);
+                assert!(bounds.size.width > px(0.));
+                assert!(bounds.size.height > px(0.));
+            })
         });
     }
 


### PR DESCRIPTION
Closes #128

## Summary

### Why it was slow

Opening a DeepSeek Harness history session pulls several `session.history` pages (each 5–9 MB, 27k–46k events). Two costs dominated:

1. **Unstructured deserialization** — every page was parsed into a `serde_json::Value` tree. A single 8.9 MB page costs ~2.6M allocations / ~260 MB / ~150 ms, even though the driver reads only a handful of fields per event.
2. **Token-level history replay** — history replay streamed every `assistant/chunk` delta (`text-delta` / `reasoning-delta`, most a few bytes) to the UI as `TextDelta`/`ReasoningDelta`, which the UI then concatenated. A medium session (~8 pages, ~280k events) emitted **~220k delta events** just to rebuild text already assembled in each `assistant/message`. Measured open time: **~1.28 s** for 8 pages / 54.7 MB.

### The fix

- **Typed, zero-copy deserialization**: pages are parsed into structs mirroring the deepseek-harness wire contract (`sessions.schema.ts`, `types.ts`); text fields stay `&RawValue` (zero-copy) during the parse and are decoded once at conversion. `rpc_raw` returns the raw response bytes so a page never builds a `Value` tree.
- **Message-level history replay**: each assembled `assistant/message` emits its full text once; the ~220k token deltas are no longer replayed. Live streaming (`handle_session_event`) is untouched.
- **Aborted turns**: steps that streamed deltas but never produced a message are reassembled in the replay phase from the caller-held page bytes (offset references, no re-parse, no `unsafe`), so partial reasoning from interrupted turns is preserved as a single delta instead of being lost.
- **No text dedup pool**: at message level a page carries only a few hundred texts, so the earlier sort/dedup/one-shot-decode pool cost more than it saved; texts are decoded directly.

### Results (merged 8-page fetch, 279,607 events / 54.7 MB)

| strategy | time | allocations | bytes | replayed texts |
|---|---|---|---|---|
| before (`Value` tree + delta replay) | 1283 ms | 19,038,904 | 1633 MB | 220,956 |
| after (typed + message-level) | **186 ms** | **2,947** | **124 MB** | **~900** |

~6.9× faster, ~6,460× fewer allocations, ~13× fewer bytes, and the UI receives ~900 assembled texts instead of ~220k deltas.

### Testing

- Two equivalence tests replay captured pages (single page and the full merged fetch) through both the old `Value` path and the new typed path and assert identical aggregated text / reasoning / usage / non-text events / stream state.
- `cargo check --workspace` passes; full `waku-core` suite passes (one pre-existing environment-dependent websocket test fails identically on the clean tree).

---

## 摘要

### 为什么慢

打开 DeepSeek Harness 历史会话会拉取多次 `session.history` 分页(每页 5–9 MB、2.7 万–4.6 万事件)。开销集中在两处:

1. **非结构化反序列化**——每一页都被解析成一棵 `serde_json::Value` 树。单个 8.9 MB 页面约消耗 260 万次分配 / 260 MB / 150 ms,尽管驱动每个事件只读几个字段。
2. **逐 token 历史重放**——历史重放把每一个 `assistant/chunk` delta(`text-delta` / `reasoning-delta`,多数只有几个字节)作为 `TextDelta`/`ReasoningDelta` 发给 UI,再由 UI 拼接。一个中等规模会话(约 8 页、28 万事件)为了重建本就组装在每条 `assistant/message` 里的文本,发出 **约 22 万条 delta 事件**。实测打开时间:8 页 / 54.7 MB 约 **1.28 秒**。

### 修复方法

- **typed 零拷贝反序列化**:页面按 deepseek-harness wire 契约(`sessions.schema.ts`、`types.ts`)解析进结构体;文本字段在解析期保持 `&RawValue`(零拷贝),转换时一次性解码。`rpc_raw` 直接返回原始响应字节,页面不再建 `Value` 树。
- **消息级历史回放**:每条组装好的 `assistant/message` 只发一次完整文本;约 22 万条 token delta 不再重放。实时流式路径(`handle_session_event`)未动。
- **被中断的 turn**:只流出了 delta、从未产生消息的 step,在回放阶段从调用方持有的页字节按偏移重组(不重解析、无 `unsafe`),被打断的思考以单条 delta 形式保留,而不是丢失。
- **去掉文本去重池**:消息级下每页只有几百个文本,此前的排序/去重/单次解码池开销大于收益;文本直接解码。

### 结果(合并 8 页,279,607 事件 / 54.7 MB)

| 方案 | 耗时 | 分配 | 字节 | 回放文本数 |
|---|---|---|---|---|
| 修复前(`Value` 树 + delta 重放) | 1283 ms | 19,038,904 | 1633 MB | 220,956 |
| 修复后(typed + 消息级) | **186 ms** | **2,947** | **124 MB** | **~900** |

快约 6.9 倍、分配减少约 6460 倍、字节减少约 13 倍,UI 收到约 900 条组装文本而不是约 22 万条 delta。

### 测试

- 两个等价测试分别用单页和完整合并 fetch 的抓包,同时跑旧的 `Value` 路径和新的 typed 路径,断言聚合后的文本 / 思考 / 用量 / 非文本事件 / 流状态一致。
- `cargo check --workspace` 通过;`waku-core` 全量测试通过(仅一个与环境相关的 websocket 测试在干净树上同样失败,属既有问题)。
