### PR TITLE
fix(waku-core): prefer PATHEXT over the extensionless npm shim on Windows

### DIFF
--- a/crates/waku-core/src/command_env.rs
+++ b/crates/waku-core/src/command_env.rs
@@ -1116,7 +1116,9 @@ mod tests {
         let directory = std::env::temp_dir().join(format!("waku-pathext-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&directory);
         std::fs::create_dir_all(&directory).expect("create fixture directory");
-        // The npm shim layout: no extensionless file to find by name alone.
+        // Only a suffixed file exists here, so the bare name resolves through PATHEXT.
+        // A global npm install also drops an extensionless shim beside it; that layout is
+        // covered by a_bare_name_prefers_pathext_over_an_extensionless_shim.
         std::fs::write(directory.join("faux-provider.cmd"), "@echo off\n")
             .expect("write shim fixture");
 

--- a/crates/waku-core/src/command_env.rs
+++ b/crates/waku-core/src/command_env.rs
@@ -207,29 +207,34 @@ pub fn find_executable(name: &str) -> Option<PathBuf> {
         .find_map(|directory| resolve_executable_file(&directory.join(name)))
 }
 
-/// Accept `candidate` as it stands, then — on Windows — the same path with
-/// each `PATHEXT` suffix.
+/// On Windows, try the path with each `PATHEXT` suffix first, then accept
+/// `candidate` as it stands. Elsewhere the candidate is used directly.
 ///
-/// Nothing is executable by name alone there: an npm-installed provider CLI
-/// lands as `claude.cmd` beside `claude.ps1`, and Bun and Cargo install
+/// Nothing is executable by name alone on Windows: an npm-installed provider
+/// CLI lands as `claude.cmd` beside `claude.ps1`, and Bun and Cargo install
 /// `.exe`. Trying `PATHEXT` in its configured order picks the same file the
 /// shell would, and `std::process::Command` runs a `.cmd`/`.bat` through
 /// `cmd.exe` for us.
+///
+/// A global npm install also writes an extensionless POSIX shim next to those
+/// two, and `CreateProcess` cannot run it. Accepting the bare name before the
+/// suffixes would hand back that shim and every launch of the provider would
+/// fail, so the suffixed names have to win.
 fn resolve_executable_file(candidate: &Path) -> Option<PathBuf> {
-    if candidate.is_file() {
-        return Some(candidate.to_path_buf());
-    }
     #[cfg(windows)]
-    {
-        let stem = candidate.file_name()?.to_owned();
+    if let Some(stem) = candidate.file_name() {
+        let stem = stem.to_owned();
         for extension in executable_extensions() {
             let mut name = stem.clone();
             name.push(&extension);
-            let candidate = candidate.with_file_name(name);
-            if candidate.is_file() {
-                return Some(candidate);
+            let suffixed = candidate.with_file_name(name);
+            if suffixed.is_file() {
+                return Some(suffixed);
             }
         }
+    }
+    if candidate.is_file() {
+        return Some(candidate.to_path_buf());
     }
     None
 }
@@ -1126,6 +1131,36 @@ mod tests {
                 .to_lowercase(),
         );
         assert_eq!(resolve_executable_file(&directory.join("absent")), None);
+
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn a_bare_name_prefers_pathext_over_an_extensionless_shim() {
+        // A global npm install writes all three of these side by side. Only the `.cmd`
+        // can be launched by `CreateProcess`; the extensionless one is a POSIX shim.
+        let directory =
+            std::env::temp_dir().join(format!("waku-pathext-shim-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&directory);
+        std::fs::create_dir_all(&directory).expect("create fixture directory");
+        std::fs::write(directory.join("faux-provider"), "#!/bin/sh\n")
+            .expect("write posix shim fixture");
+        std::fs::write(directory.join("faux-provider.ps1"), "#!/usr/bin/env pwsh\n")
+            .expect("write powershell shim fixture");
+        std::fs::write(directory.join("faux-provider.cmd"), "@echo off\n")
+            .expect("write cmd shim fixture");
+
+        assert_eq!(
+            resolve_executable_file(&directory.join("faux-provider"))
+                .expect("resolve through PATHEXT")
+                .to_string_lossy()
+                .to_lowercase(),
+            directory
+                .join("faux-provider.cmd")
+                .to_string_lossy()
+                .to_lowercase(),
+        );
 
         let _ = std::fs::remove_dir_all(&directory);
     }


### PR DESCRIPTION
Fixes #130.

## Problem

On Windows, providers installed with a global `npm install` are detected but their model list comes up empty.

A global npm install writes three files side by side into the npm bin directory:

| File | What it is |
| --- | --- |
| `pi` | an extensionless POSIX `#!/bin/sh` shim |
| `pi.cmd` | the cmd shim |
| `pi.ps1` | the PowerShell shim |

`resolve_executable_file` accepted `candidate.is_file()` before trying the `PATHEXT` suffixes, so it matched the extensionless POSIX shim and returned it. `CreateProcess` cannot run that file, so every launch of the provider failed and the model list stayed empty. The doc comment above the function — and the existing `a_bare_name_resolves_through_pathext` test — assumed there would be no extensionless file to find by name alone, which is what npm disproves.

Thanks to @tsugumi42, whose report pinned this down to the exact function.

## Solution

Try the `PATHEXT` suffixes first on Windows, and keep the bare candidate as the fallback so a genuinely extensionless executable still resolves. Non-Windows behaviour is unchanged. The doc comment now records why the order matters.

I kept it to the ordering rather than filtering shims by content: the suffix list is already the rule Windows itself uses, so nothing new has to be maintained.

## Checks

Run on Windows 11 with Rust 1.97.1 and MSVC 14.44:

- `cargo fmt --package waku --package waku-protocol --package waku-client --package waku-core --package waku-daemon -- --check` — this change adds no new diff. There are 6 pre-existing diffs on a clean `main` with rustfmt 1.97.1, and the same 6 with this branch; I left them alone.
- `cargo check` — clean.
- `cargo test` — 311 passed, 3 failed. All 3 fail identically on a clean `main` here and are unrelated to this change: `transcript_file_links_route_by_the_active_workspace`, `working_tree_only_descends_into_expanded_directories` and `render_reads_only_the_cached_result_snapshot` assert against hardcoded `/Users/egoist/...` paths, so they cannot pass on Windows.
- `bun run protocol:check` — fails with `generated bindings are stale`, identically on a clean `main`. No wire type is touched here.
- `bun run --filter @waku/client check` — clean.
- `bun run --filter @waku/client test` — 11 pass.

The new test is the regression guard the contributing guide asks for. It builds the three-file npm layout and asserts the `.cmd` wins:

```
BEFORE the fix: test a_bare_name_prefers_pathext_over_an_extensionless_shim ... FAILED
AFTER  the fix: test a_bare_name_prefers_pathext_over_an_extensionless_shim ... ok
```

## Limitations

I verified this against the resolver, not against a running Waku with pi or opencode installed, so a confirmation from the reporter that the model list fills in would be worth having before merging.

`.ps1` is intentionally not handled: it is not in `PATHEXT` by default and `CreateProcess` cannot run it either, so the `.cmd` remains the right target.
