### PR TITLE
Steer the oldest queued follow-up with primary modifier + Enter

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2325,6 +2325,15 @@ impl Waku {
                             this.steer_composer_submission(submission, cx);
                         }
                     }
+                    ComposerEvent::SteerQueued => {
+                        // Staged attachments make this a real draft even when
+                        // the text field is empty. Preserve the shortcut's
+                        // previous no-op behavior until that draft is sent or
+                        // cleared.
+                        if this.composer_attachments.is_empty() {
+                            this.steer_oldest_queued_message(cx);
+                        }
+                    }
                     ComposerEvent::Edited => {
                         this.schedule_composer_draft_save(cx);
                         cx.notify();

--- a/src/app/composer.rs
+++ b/src/app/composer.rs
@@ -2360,12 +2360,7 @@ impl Waku {
             return None;
         }
         let theme = Theme::current(cx);
-        let steerable = session.is_busy()
-            && session.status != SessionStatus::Connecting
-            && self
-                .runtimes
-                .get(&session.id)
-                .is_some_and(|runtime| runtime.driver.supports_steer());
+        let steerable = self.session_can_steer(session);
         let mut list = div().flex().flex_col().py(px(4.0));
         for message in &session.queued_messages {
             let message_id = message.id;

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -2053,6 +2053,7 @@ impl Waku {
                 ComposerEvent::SubmitSteer(prompt) => {
                     this.submit_message_edit_prompt(prompt.clone(), cx)
                 }
+                ComposerEvent::SteerQueued => {}
                 ComposerEvent::Edited => cx.notify(),
                 ComposerEvent::Focus => {}
                 ComposerEvent::BackspaceOnEmpty => {}
@@ -2771,12 +2772,7 @@ impl Waku {
         // A turn that has not reached the provider yet cannot be steered; the
         // driver reports the outcome asynchronously via SteerAccepted or
         // SteerRejected once it is handed off.
-        let steerable = session.status != SessionStatus::Connecting
-            && self
-                .runtimes
-                .get(&session.id)
-                .is_some_and(|runtime| runtime.driver.supports_steer());
-        if !steerable {
+        if !self.session_can_steer(&session) {
             self.enqueue_follow_up_submission(session.id, submission, cx);
             return;
         }
@@ -2788,6 +2784,15 @@ impl Waku {
             self.enqueue_follow_up_submission(session.id, submission, cx);
         }
         cx.notify();
+    }
+
+    pub(super) fn session_can_steer(&self, session: &AgentSession) -> bool {
+        session.is_busy()
+            && session.status != SessionStatus::Connecting
+            && self
+                .runtimes
+                .get(&session.id)
+                .is_some_and(|runtime| runtime.driver.supports_steer())
     }
 
     /// Resolve presentation-preserving composer syntax immediately before a
@@ -2888,6 +2893,21 @@ impl Waku {
         };
         self.save();
         self.steer_composer_submission(ComposerSubmission::from_queued_message(message), cx);
+    }
+
+    /// Activate the same action as the oldest queued row's Steer control.
+    /// When that control is unavailable, leave the queue untouched rather
+    /// than removing and re-queueing its first message at the back.
+    pub(super) fn steer_oldest_queued_message(&mut self, cx: &mut Context<Self>) {
+        let Some((session_id, message_id)) = self.selected_session().and_then(|session| {
+            if !self.session_can_steer(session) {
+                return None;
+            }
+            Some((session.id, session.queued_messages.first()?.id))
+        }) else {
+            return;
+        };
+        self.steer_queued_message(session_id, message_id, cx);
     }
 
     /// Start the next queued follow-up as a fresh turn. Only called once a

--- a/src/input.rs
+++ b/src/input.rs
@@ -2517,7 +2517,8 @@ impl Focusable for TextInput {
 }
 
 /// What the composer tells its owner. `Submit` and `SubmitSteer` carry the
-/// trimmed prompt; the rest mirror [`InputEvent`] from the embedded field.
+/// trimmed prompt; the remaining events report composer-level interactions
+/// or mirror [`InputEvent`] from the embedded field.
 #[derive(Clone)]
 pub enum ComposerEvent {
     /// Enter: send the prompt, or queue it behind the running turn.
@@ -2525,6 +2526,9 @@ pub enum ComposerEvent {
     /// Primary modifier + Enter: deliver the prompt into the running turn
     /// instead of queueing it behind the turn.
     SubmitSteer(String),
+    /// Primary modifier + Enter in an empty composer: activate the oldest
+    /// queued follow-up's Steer control.
+    SteerQueued,
     Focus,
     Edited,
     /// Backspace in an already-empty composer — the chat idiom for "remove
@@ -2667,6 +2671,7 @@ impl Render for ComposerInput {
             .on_action(cx.listener(|composer, _: &SubmitSteer, _, cx| {
                 let value = composer.content(cx).trim().to_owned();
                 if value.is_empty() {
+                    cx.emit(ComposerEvent::SteerQueued);
                     return;
                 }
                 composer.input.update(cx, |input, cx| input.clear(cx));
@@ -2687,7 +2692,9 @@ impl EventEmitter<ComposerAttachmentPaste> for ComposerInput {}
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
     use std::path::PathBuf;
+    use std::rc::Rc;
     use std::time::{Duration, Instant};
 
     use gpui::{
@@ -2698,10 +2705,10 @@ mod tests {
 
     use super::TokenClass;
     use super::{
-        TextInput, EditHistory, FieldMode, SearchPaint, UNDO_GROUP_INTERVAL, UNDO_HISTORY_CAP,
-        media_paste_entries, cursor_should_be_visible, input_text_runs, next_word_boundary,
-        pasted_text_for_mode, previous_word_boundary, single_line_scroll, trimmed_splice,
-        visual_row_count, word_range_at,
+        ComposerEvent, ComposerInput, EditHistory, FieldMode, SearchPaint, TextInput,
+        UNDO_GROUP_INTERVAL, UNDO_HISTORY_CAP, cursor_should_be_visible, input_text_runs,
+        media_paste_entries, next_word_boundary, pasted_text_for_mode, previous_word_boundary,
+        single_line_scroll, trimmed_splice, visual_row_count, word_range_at,
     };
 
     struct InputHarness {
@@ -2712,6 +2719,16 @@ mod tests {
     impl Render for InputHarness {
         fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
             div().w(self.width).child(self.input.clone())
+        }
+    }
+
+    struct ComposerHarness {
+        composer: Entity<ComposerInput>,
+    }
+
+    impl Render for ComposerHarness {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div().w(px(300.)).child(self.composer.clone())
         }
     }
 
@@ -2734,6 +2751,51 @@ mod tests {
         cx.update(|window, cx| window.focus(&input.read(cx).focus(), cx));
         cx.run_until_parked();
         (input, cx)
+    }
+
+    fn setup_composer<'a>(
+        cx: &'a mut TestAppContext,
+    ) -> (Entity<ComposerInput>, &'a mut gpui::VisualTestContext) {
+        cx.update(super::init);
+        let (harness, cx) = cx.add_window_view(|window, cx| {
+            let composer = cx.new(|cx| ComposerInput::new(window, cx));
+            ComposerHarness { composer }
+        });
+        let composer = cx.read_entity(&harness, |harness, _| harness.composer.clone());
+        cx.update(|window, cx| window.focus(&composer.read(cx).focus(), cx));
+        cx.run_until_parked();
+        (composer, cx)
+    }
+
+    #[gpui::test]
+    fn secondary_enter_steers_text_or_activates_the_queue(cx: &mut TestAppContext) {
+        let (composer, cx) = setup_composer(cx);
+        let events: Rc<RefCell<Vec<ComposerEvent>>> = Rc::default();
+        let sink = events.clone();
+        cx.update(|_, cx| {
+            cx.subscribe(&composer, move |_, event: &ComposerEvent, _| {
+                sink.borrow_mut().push(event.clone());
+            })
+            .detach();
+        });
+
+        cx.simulate_keystrokes("secondary-enter");
+        assert!(matches!(
+            events.borrow().last(),
+            Some(ComposerEvent::SteerQueued)
+        ));
+
+        composer.update(cx, |composer, cx| composer.set_content("hold on", cx));
+        events.borrow_mut().clear();
+        cx.simulate_keystrokes("secondary-enter");
+        assert!(
+            events.borrow().iter().any(
+                |event| matches!(event, ComposerEvent::SubmitSteer(text) if text == "hold on")
+            )
+        );
+        cx.read_entity(&composer, |composer, cx| {
+            assert_eq!(composer.content(cx), "")
+        });
     }
 
     #[gpui::test]


### PR DESCRIPTION
## Motivation

While a turn is running, follow-up prompts queue behind it, and each queued row has a Steer control to release it into the running turn early. Releasing several queued messages previously required clicking each row in order.

## Change

Primary modifier + Enter (Cmd+Enter on macOS) in an empty composer now activates the selected session's oldest available Steer control. Repeated presses drain a steerable queue from front to back.

Existing behavior is preserved:

- Primary modifier + Enter with typed text still steers that text.
- With no queued message, the shortcut does nothing.
- When the Steer control is unavailable, the shortcut leaves the queue untouched instead of rotating its first message to the back.
- A staged attachment makes the composer a real draft, so the empty-text shortcut remains a no-op until the draft is sent or cleared.

## Implementation

- Added `ComposerEvent::SteerQueued`, emitted by the composer wrapper when its propagated steering action finds no text.
- Reused one `session_can_steer` predicate for both the visible row control and the keyboard path.
- Added `steer_oldest_queued_message` to resolve the selected session's first queued message and hand it to the existing `steer_queued_message` path.
- Message-edit composers explicitly ignore the queue-only event.

## Testing

- Added `secondary_enter_steers_text_or_activates_the_queue` for both the empty-composer event and preserved typed-text steering.
- `cargo test --locked` passes on current `main`: 727 passed, 24 intentionally ignored integration/doc tests.
- `git diff --check` passes.

No visual QA was performed.

Co-authored with Claude Fable 5.
