### PR TITLE
fix(waku-core): count Codex usage once across forked rollouts

### DIFF
--- a/crates/waku-core/src/usage_history.rs
+++ b/crates/waku-core/src/usage_history.rs
@@ -11,7 +11,9 @@
 //! append-only, so parsed records are memoised per file by `(size, mtime)` in
 //! a [`ScanCache`] the caller owns; warm rescans only reparse changed files.
 
+use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
 use std::io::BufRead as _;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -216,6 +218,7 @@ fn parse_codex_line(line: &str, state: &mut CodexScanState) -> Option<UsageRecor
     // Codex re-emits an unchanged token_count on some stream boundaries.
     // Summing those would double count, so identical consecutive payloads are
     // skipped.
+    let payload_signature = serde_json::to_string(payload).ok()?;
     let signature = serde_json::to_string(last).ok()?;
     if state.last_usage_signature.as_deref() == Some(signature.as_str()) {
         return None;
@@ -239,6 +242,13 @@ fn parse_codex_line(line: &str, state: &mut CodexScanState) -> Option<UsageRecor
         return None;
     }
 
+    let dedupe_key = {
+        let mut hasher = DefaultHasher::new();
+        timestamp_ms.hash(&mut hasher);
+        payload_signature.hash(&mut hasher);
+        format!("codex:{:x}", hasher.finish())
+    };
+
     Some(UsageRecord {
         provider: UsageProvider::Codex,
         timestamp_ms,
@@ -248,8 +258,12 @@ fn parse_codex_line(line: &str, state: &mut CodexScanState) -> Option<UsageRecor
         totals,
         // Codex does not report cost in the rollout.
         reported_cost_usd: None,
-        // Rollout files are unique per session; no global dedup needed.
-        dedupe_key: None,
+        // A forked or subagent rollout opens with a verbatim copy of the parent
+        // history, so the same token_count event exists in several files. Key on
+        // the event rather than the file holding it, and the aggregator counts it
+        // once. The session id is deliberately left out: the copy is read under
+        // the forked file's own session.
+        dedupe_key: Some(dedupe_key),
     })
 }
 
@@ -1132,6 +1146,68 @@ mod tests {
 
         // The identical re-emitted event is a duplicate, not more usage.
         assert!(parse_codex_line(&count, &mut state).is_none());
+    }
+
+    #[test]
+    fn codex_forked_rollouts_reuse_the_parent_dedupe_key() {
+        // A fork or subagent rollout starts with a verbatim copy of the parent
+        // history, under its own session id. That copied usage must not be counted
+        // a second time.
+        let context = r#"{"timestamp":"2026-08-06T16:31:20.000Z","type":"turn_context",
+            "payload":{"model":"gpt-5.3-codex","cwd":"/Users/me/dev/waku"}}"#
+            .replace('\n', " ");
+        let count = r#"{"timestamp":"2026-08-06T16:31:25.000Z","type":"event_msg",
+            "payload":{"type":"token_count","info":{"last_token_usage":{
+            "input_tokens":21047,"cached_input_tokens":1000,"cache_write_input_tokens":47,
+            "output_tokens":280,"reasoning_output_tokens":165}}}}"#
+            .replace('\n', " ");
+        let parent_meta = r#"{"timestamp":"2026-08-06T16:31:19.166Z","type":"session_meta",
+            "payload":{"id":"codex-parent","cwd":"/Users/me/dev/waku"}}"#
+            .replace('\n', " ");
+        let fork_meta = r#"{"timestamp":"2026-08-06T16:40:00.000Z","type":"session_meta",
+            "payload":{"id":"codex-fork","cwd":"/Users/me/dev/waku"}}"#
+            .replace('\n', " ");
+
+        let mut parent = CodexScanState::new();
+        parse_codex_line(&parent_meta, &mut parent);
+        parse_codex_line(&context, &mut parent);
+        let from_parent = parse_codex_line(&count, &mut parent).expect("parent usage");
+
+        let mut fork = CodexScanState::new();
+        parse_codex_line(&fork_meta, &mut fork);
+        parse_codex_line(&context, &mut fork);
+        let from_fork = parse_codex_line(&count, &mut fork).expect("copied usage");
+
+        assert_eq!(from_parent.session_id, "codex-parent");
+        assert_eq!(from_fork.session_id, "codex-fork");
+        assert!(from_parent.dedupe_key.is_some());
+        assert_eq!(from_parent.dedupe_key, from_fork.dedupe_key);
+
+        // The aggregator drops the copy, so the tokens are counted once.
+        let rates = rate_table(&[("gpt-5.3-codex", FLAT_RATE)]);
+        let day = Utc
+            .timestamp_millis_opt(from_parent.timestamp_ms)
+            .single()
+            .expect("fixture timestamp")
+            .with_timezone(&Local)
+            .date_naive();
+        let roots = vec![PathBuf::from("/Users/me/dev/waku")];
+        let mut aggregator = Aggregator::new(day, day, &roots);
+        aggregator.add(&from_parent, &rates);
+        aggregator.add(&from_fork, &rates);
+        let history = derive_history(
+            aggregator,
+            UsageWindow::TrailingDays(1),
+            day,
+            day,
+            PricingStatus::Fresh,
+            1,
+            0,
+            Vec::new(),
+            Duration::ZERO,
+        );
+        assert_eq!(history.records, 1);
+        assert_eq!(history.total_tokens, from_parent.totals.total());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #38.

## Problem

The Usage view overcounts Codex tokens. @tsugumi42 measured 3,974,476,585 tokens against 2,526,018,476 for a fork-aware calculation over the same logs — a 57% overcount from 11,861 copied usage records across 182 fork/subagent rollout files.

The cause is one assumption in `parse_codex_line`:

```rust
// Rollout files are unique per session; no global dedup needed.
dedupe_key: None,
```

That holds for a plain session, but a forked or subagent rollout opens with a verbatim copy of the parent's history, so the same `token_count` event exists in several files. Claude records already carry a `dedupe_key` and the aggregator's global pass drops their cross-file repeats; Codex records opted out of that pass entirely, so every copy was added again. This matches the report that Claude totals agreed while Codex did not.

## Solution

Key each Codex record on the event rather than on the file holding it: a hash of the event timestamp and its payload. The copied lines are identical, so a copy hashes to the parent's key and the aggregator's existing `seen` set drops it.

The session id is deliberately excluded from the key — a copied event is read under the forked file's own `session_meta`, so including it would make every copy look distinct again. Sessions are still counted separately, since that is tracked apart from usage records.

I kept this in the existing dedupe machinery rather than detecting fork parentage from `session_meta`: it needs no knowledge of how a fork records its origin, and it also covers plain resumed sessions if they ever copy history the same way.

## Checks

Run on Windows 11, Rust 1.97.1:

- `cargo fmt -p waku-core -- --check` — clean, and clean on `main` too.
- `cargo test -p waku-core` — 302 passed, 5 failed. The same 5 fail on a clean `main` here (`worktree`, `checkpoint`, `skills::every_ecosystem_root_is_listed`, `driver::codex::computer_use_cleanup...`, `driver::opencode::cancelling_event_stream...`) and are environment-dependent, unrelated to this change. Clean `main` reports 301 passed; the extra pass is the new test.
- `bun run --filter @waku/client check` and `test` — unaffected by this change, both clean.

The new test builds the parent and the forked rollout from the same event lines under different `session_meta`, and asserts the aggregator counts the tokens once:

```
BEFORE the fix: test codex_forked_rollouts_reuse_the_parent_dedupe_key ... FAILED
AFTER  the fix: test codex_forked_rollouts_reuse_the_parent_dedupe_key ... ok
```

## Limitations

I do not have a real Codex rollout set with forks, so the fixture is built from the shape described in the issue and the existing parser tests, not from captured logs. @tsugumi42, if you still have that log set, comparing the Usage totals before and after this change would confirm the 57% gap closes to the fork-aware number.

If two genuinely distinct events ever shared a timestamp, model and byte-identical payload, one would now be dropped. That would require the same cumulative `total_token_usage` in the same millisecond, which the payload makes very unlikely.

AI assistance was used while working on this change.
