### PR TITLE
fix(ohmypi): discover oversized model catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unreleased]
 
+- Discover Oh My Pi models when the configured catalog exceeds its RPC frame limit
+
 ## [0.1.13]
 
 - Add Vercel Fx support

--- a/crates/waku-core/src/driver/pi.rs
+++ b/crates/waku-core/src/driver/pi.rs
@@ -24,15 +24,13 @@ use crate::driver::{
     DriverControl, DriverEventSender, DriverEventSink, DriverStartOptions, SessionOptions,
 };
 use crate::model::{ActivityKind, DriverEvent, InteractionMode, ProviderResumeCursor, RuntimeMode};
+use crate::pi_rpc::ChunkAssembly;
 
 const RPC_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Oh My Pi has to start a whole second agent to clone a session, so it needs
 /// more headroom than a request against the already-running process.
 const CLONE_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// Oh My Pi refuses to reassemble beyond this, so neither should Waku.
-const MAX_REASSEMBLED_FRAME_BYTES: usize = 64 * 1024 * 1024;
 
 /// Which dialect of the Pi RPC protocol a session speaks.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -867,99 +865,6 @@ fn cursor_from_state(flavor: PiFlavor, response: &Value) -> Option<ProviderResum
         .and_then(Value::as_str)
         .map(PathBuf::from);
     Some(flavor.cursor(session_id.to_owned(), session_file))
-}
-
-/// Reassembles the `rpc_chunk` runs Oh My Pi emits for frames over its 1 MiB
-/// stdout ceiling. Without this a large tool result degrades to an error frame
-/// and the activity row renders empty.
-#[derive(Default)]
-struct ChunkAssembly {
-    active: Option<PendingChunks>,
-}
-
-struct PendingChunks {
-    chunk_id: String,
-    count: u64,
-    next_index: u64,
-    byte_length: usize,
-    data: Vec<u8>,
-}
-
-impl ChunkAssembly {
-    /// Returns the logical message to dispatch, or `None` while a chunked
-    /// frame is still arriving.
-    fn accept(&mut self, value: Value) -> Result<Option<Value>, String> {
-        if value.get("type").and_then(Value::as_str) != Some("rpc_chunk") {
-            // The run must be uninterrupted, so anything else invalidates a
-            // partial frame rather than silently splicing around it.
-            if self.active.take().is_some() {
-                return Err("chunked frame was interrupted".to_owned());
-            }
-            return Ok(Some(value));
-        }
-        let (chunk_id, index, count, byte_length, data) = (|| {
-            Some((
-                value.get("chunkId").and_then(Value::as_str)?,
-                value.get("index").and_then(Value::as_u64)?,
-                value.get("count").and_then(Value::as_u64)?,
-                value.get("byteLength").and_then(Value::as_u64)?,
-                value.get("data").and_then(Value::as_str)?,
-            ))
-        })()
-        .ok_or_else(|| "chunk frame was malformed".to_owned())?;
-        let byte_length = usize::try_from(byte_length)
-            .map_err(|_| "chunked frame exceeds the reassembly limit".to_owned())?;
-        if count == 0 || index >= count {
-            self.active = None;
-            return Err("chunk frame was malformed".to_owned());
-        }
-        if byte_length > MAX_REASSEMBLED_FRAME_BYTES {
-            self.active = None;
-            return Err("chunked frame exceeds the reassembly limit".to_owned());
-        }
-        let decoded = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, data)
-            .map_err(|error| format!("chunk payload was not valid base64: {error}"))?;
-
-        let pending = match self.active.take() {
-            Some(pending)
-                if pending.chunk_id == chunk_id
-                    && pending.count == count
-                    && pending.byte_length == byte_length
-                    && pending.next_index == index =>
-            {
-                pending
-            }
-            Some(_) => {
-                return Err("chunked frame was interrupted".to_owned());
-            }
-            None if index == 0 => PendingChunks {
-                chunk_id: chunk_id.to_owned(),
-                count,
-                next_index: 0,
-                byte_length,
-                data: Vec::with_capacity(byte_length),
-            },
-            None => return Err("chunked frame started mid-sequence".to_owned()),
-        };
-        let mut pending = pending;
-        pending.data.extend_from_slice(&decoded);
-        pending.next_index += 1;
-        if pending.data.len() > pending.byte_length {
-            return Err("chunked frame overran its declared length".to_owned());
-        }
-        if pending.next_index < pending.count {
-            self.active = Some(pending);
-            return Ok(None);
-        }
-        if pending.data.len() != pending.byte_length {
-            return Err("chunked frame did not match its declared length".to_owned());
-        }
-        let text = String::from_utf8(pending.data)
-            .map_err(|_| "chunked frame was not valid UTF-8".to_owned())?;
-        serde_json::from_str(&text)
-            .map(Some)
-            .map_err(|error| format!("chunked frame was not valid JSON: {error}"))
-    }
 }
 
 /// Pi already computes context occupancy for its own footer. Prefer that
@@ -1902,45 +1807,6 @@ mod tests {
             event_rx.try_recv().unwrap(),
             DriverEvent::AutoTitleUpdated(Some(title)) if title == "Named by Oh My Pi"
         ));
-    }
-
-    #[test]
-    fn chunked_frames_reassemble_and_reject_broken_runs() {
-        use base64::Engine as _;
-        let encode = |bytes: &[u8]| base64::engine::general_purpose::STANDARD.encode(bytes);
-
-        let payload = json!({"type": "response", "id": "waku-1", "success": true});
-        let bytes = serde_json::to_vec(&payload).unwrap();
-        let (first, second) = bytes.split_at(bytes.len() / 2);
-        let chunk = |index: u64, data: &[u8]| {
-            json!({
-                "type": "rpc_chunk",
-                "chunkId": "rpc-1",
-                "index": index,
-                "count": 2,
-                "byteLength": bytes.len(),
-                "data": encode(data),
-            })
-        };
-
-        let mut assembly = ChunkAssembly::default();
-        assert_eq!(assembly.accept(chunk(0, first)).unwrap(), None);
-        assert_eq!(assembly.accept(chunk(1, second)).unwrap(), Some(payload));
-
-        // An ordinary frame passes straight through.
-        let mut assembly = ChunkAssembly::default();
-        let plain = json!({"type": "agent_start"});
-        assert_eq!(assembly.accept(plain.clone()).unwrap(), Some(plain.clone()));
-
-        // Anything interleaved into a run invalidates it rather than splicing.
-        let mut assembly = ChunkAssembly::default();
-        assert_eq!(assembly.accept(chunk(0, first)).unwrap(), None);
-        assert!(assembly.accept(plain).is_err());
-        assert!(assembly.active.is_none());
-
-        // A run that starts mid-sequence is not a frame Waku can trust.
-        let mut assembly = ChunkAssembly::default();
-        assert!(assembly.accept(chunk(1, second)).is_err());
     }
 
     #[test]

--- a/crates/waku-core/src/lib.rs
+++ b/crates/waku-core/src/lib.rs
@@ -52,6 +52,7 @@ pub mod workspace;
 pub mod worktree;
 
 mod fs_ext;
+mod pi_rpc;
 mod protocol;
 mod server;
 

--- a/crates/waku-core/src/model_catalog.rs
+++ b/crates/waku-core/src/model_catalog.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 use serde_json::{Value, json};
 
 use crate::model::{ProviderAgentPreset, ProviderKind, ProviderModel, ProviderModelOption};
+use crate::pi_rpc::ChunkAssembly;
 
 const CODEX_RPC_TIMEOUT: Duration = Duration::from_secs(5);
 const PI_RPC_TIMEOUT: Duration = Duration::from_secs(10);
@@ -665,13 +666,24 @@ fn discover_pi_models(binary: &Path, dialect: PiDialect) -> Vec<ProviderModel> {
     };
     let (tx, rx) = mpsc::channel();
     std::thread::spawn(move || {
+        let mut chunks = ChunkAssembly::default();
         for line in BufReader::new(stdout).lines().map_while(Result::ok) {
-            if let Ok(value) = serde_json::from_str::<Value>(&line) {
+            let Ok(value) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
+            if let Ok(Some(value)) = chunks.accept(value) {
                 let _ = tx.send(value);
             }
         }
     });
 
+    if dialect == PiDialect::OhMyPi {
+        // Negotiate before the catalog request so responses over OMP's 1 MiB
+        // physical-frame limit arrive as lossless `rpc_chunk` runs.
+        let protocol_request =
+            json!({"id": "waku-protocol", "type": "negotiate_protocol", "protocolVersion": 2});
+        let _ = write_json_line(&mut stdin, &protocol_request);
+    }
     let models_request = json!({"id": "waku-models", "type": "get_available_models"});
     let result = if write_json_line(&mut stdin, &models_request).is_ok()
         && let Some(models) = recv_pi_rpc_response(&rx, "waku-models", PI_RPC_TIMEOUT)
@@ -1577,6 +1589,42 @@ done
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "extension-provider/extension-model");
         assert_eq!(models[0].name, "Extension Model");
+        assert!(models[0].is_default);
+        let _ = std::fs::remove_file(binary);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ohmypi_rpc_discovery_negotiates_and_reassembles_chunked_models() {
+        let binary = write_fake_pi(
+            "ohmypi-chunks",
+            r#"#!/bin/sh
+negotiated=false
+while IFS= read -r request; do
+  case "$request" in
+    *waku-protocol*)
+      negotiated=true
+      printf '%s\n' '{"id":"waku-protocol","type":"response","success":true,"data":{"protocolVersion":2}}'
+      ;;
+    *waku-models*)
+      if [ "$negotiated" != true ]; then
+        exit 1
+      fi
+      printf '%s\n' '{"type":"rpc_chunk","chunkId":"models-1","index":0,"count":2,"byteLength":155,"data":"eyJpZCI6Indha3UtbW9kZWxzIiwidHlwZSI6InJlc3BvbnNlIiwic3VjY2VzcyI6dHJ1ZSwiZGF0YSI6eyJtb2RlbHMiOlt7InByb3Y="}'
+      printf '%s\n' '{"type":"rpc_chunk","chunkId":"models-1","index":1,"count":2,"byteLength":155,"data":"aWRlciI6Im9tcC1wcm92aWRlciIsImlkIjoib21wLW1vZGVsIiwibmFtZSI6Ik9NUCBNb2RlbCIsInJlYXNvbmluZyI6ZmFsc2V9XX19"}'
+      ;;
+    *waku-state*)
+      printf '%s\n' '{"id":"waku-state","type":"response","success":true,"data":{"model":{"provider":"omp-provider","id":"omp-model"},"thinkingLevel":"medium"}}'
+      ;;
+  esac
+done
+"#,
+        );
+
+        let models = discover_pi_models(&binary, PiDialect::OhMyPi);
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "omp-provider/omp-model");
         assert!(models[0].is_default);
         let _ = std::fs::remove_file(binary);
     }

--- a/crates/waku-core/src/pi_rpc.rs
+++ b/crates/waku-core/src/pi_rpc.rs
@@ -1,0 +1,140 @@
+//! Shared framing for Pi-compatible RPC transports.
+
+use serde_json::Value;
+
+/// Oh My Pi refuses to reassemble beyond this, so neither should Waku.
+const MAX_REASSEMBLED_FRAME_BYTES: usize = 64 * 1024 * 1024;
+
+/// Reassembles the `rpc_chunk` runs Oh My Pi emits for frames over its 1 MiB
+/// stdout ceiling.
+#[derive(Default)]
+pub(crate) struct ChunkAssembly {
+    active: Option<PendingChunks>,
+}
+
+struct PendingChunks {
+    chunk_id: String,
+    count: u64,
+    next_index: u64,
+    byte_length: usize,
+    data: Vec<u8>,
+}
+
+impl ChunkAssembly {
+    /// Returns the logical message to dispatch, or `None` while a chunked
+    /// frame is still arriving.
+    pub(crate) fn accept(&mut self, value: Value) -> Result<Option<Value>, String> {
+        if value.get("type").and_then(Value::as_str) != Some("rpc_chunk") {
+            // The run must be uninterrupted, so anything else invalidates a
+            // partial frame rather than silently splicing around it.
+            if self.active.take().is_some() {
+                return Err("chunked frame was interrupted".to_owned());
+            }
+            return Ok(Some(value));
+        }
+        let (chunk_id, index, count, byte_length, data) = (|| {
+            Some((
+                value.get("chunkId").and_then(Value::as_str)?,
+                value.get("index").and_then(Value::as_u64)?,
+                value.get("count").and_then(Value::as_u64)?,
+                value.get("byteLength").and_then(Value::as_u64)?,
+                value.get("data").and_then(Value::as_str)?,
+            ))
+        })()
+        .ok_or_else(|| "chunk frame was malformed".to_owned())?;
+        let byte_length = usize::try_from(byte_length)
+            .map_err(|_| "chunked frame exceeds the reassembly limit".to_owned())?;
+        if count == 0 || index >= count {
+            self.active = None;
+            return Err("chunk frame was malformed".to_owned());
+        }
+        if byte_length > MAX_REASSEMBLED_FRAME_BYTES {
+            self.active = None;
+            return Err("chunked frame exceeds the reassembly limit".to_owned());
+        }
+        let decoded = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, data)
+            .map_err(|error| format!("chunk payload was not valid base64: {error}"))?;
+
+        let pending = match self.active.take() {
+            Some(pending)
+                if pending.chunk_id == chunk_id
+                    && pending.count == count
+                    && pending.byte_length == byte_length
+                    && pending.next_index == index =>
+            {
+                pending
+            }
+            Some(_) => {
+                return Err("chunked frame was interrupted".to_owned());
+            }
+            None if index == 0 => PendingChunks {
+                chunk_id: chunk_id.to_owned(),
+                count,
+                next_index: 0,
+                byte_length,
+                data: Vec::with_capacity(byte_length),
+            },
+            None => return Err("chunked frame started mid-sequence".to_owned()),
+        };
+        let mut pending = pending;
+        pending.data.extend_from_slice(&decoded);
+        pending.next_index += 1;
+        if pending.data.len() > pending.byte_length {
+            return Err("chunked frame overran its declared length".to_owned());
+        }
+        if pending.next_index < pending.count {
+            self.active = Some(pending);
+            return Ok(None);
+        }
+        if pending.data.len() != pending.byte_length {
+            return Err("chunked frame did not match its declared length".to_owned());
+        }
+        let text = String::from_utf8(pending.data)
+            .map_err(|_| "chunked frame was not valid UTF-8".to_owned())?;
+        serde_json::from_str(&text)
+            .map(Some)
+            .map_err(|error| format!("chunked frame was not valid JSON: {error}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine as _;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn chunked_frames_reassemble_and_reject_broken_runs() {
+        let encode = |bytes: &[u8]| base64::engine::general_purpose::STANDARD.encode(bytes);
+        let payload = json!({"type": "response", "id": "waku-1", "success": true});
+        let bytes = serde_json::to_vec(&payload).unwrap();
+        let (first, second) = bytes.split_at(bytes.len() / 2);
+        let chunk = |index: u64, data: &[u8]| {
+            json!({
+                "type": "rpc_chunk",
+                "chunkId": "rpc-1",
+                "index": index,
+                "count": 2,
+                "byteLength": bytes.len(),
+                "data": encode(data),
+            })
+        };
+
+        let mut assembly = ChunkAssembly::default();
+        assert_eq!(assembly.accept(chunk(0, first)).unwrap(), None);
+        assert_eq!(assembly.accept(chunk(1, second)).unwrap(), Some(payload));
+
+        let mut assembly = ChunkAssembly::default();
+        let plain = json!({"type": "agent_start"});
+        assert_eq!(assembly.accept(plain.clone()).unwrap(), Some(plain.clone()));
+
+        let mut assembly = ChunkAssembly::default();
+        assert_eq!(assembly.accept(chunk(0, first)).unwrap(), None);
+        assert!(assembly.accept(plain).is_err());
+        assert!(assembly.active.is_none());
+
+        let mut assembly = ChunkAssembly::default();
+        assert!(assembly.accept(chunk(1, second)).is_err());
+    }
+}


### PR DESCRIPTION
## Problem

Oh My Pi model discovery uses `get_available_models`, whose response can exceed OMP's 1 MiB protocol-v1 physical frame limit for large configured catalogs. Waku already negotiated protocol v2 and reassembled `rpc_chunk` frames for live sessions, but the separate catalog probe did neither. The oversized response was therefore lost and the picker reported that OMP returned no models.

## Solution

- Move the existing, bounded `rpc_chunk` assembler into a shared internal module used by both the session driver and catalog discovery.
- Best-effort negotiate OMP protocol v2 before requesting models. Older/plain v1 responses still pass through unchanged.
- Add an end-to-end catalog-probe regression test whose fake OMP requires negotiation and returns the model response in two chunks.
- Record the user-visible fix in the changelog.

The reassembly validation and 64 MiB ceiling are unchanged from the existing session transport.

## Validation

- `cargo test --locked -p waku-core` with an isolated HOME — 334 passed, 24 ignored
- `cargo test --locked -p waku-core pi_rpc` — 3 passed
- `cargo test --locked -p waku-core ohmypi_catalog_against_the_real_cli -- --ignored --nocapture` against OMP 18.0.1 — passed
- Changed Rust files: `rustfmt --check` — passed
- `bun run protocol:check` — passed
- `bun run --filter @waku/client check` — passed
- `bun run --filter @waku/client test` — 11 passed

## Local environment notes

- Full-workspace `cargo check --locked` reached GPUI and then stopped because this machine has Command Line Tools but not Xcode's optional Metal compiler. The changed `waku-core` crate compiles and its full suite passes.
- The documented repository-wide Rust 1.96 format command reports existing diffs in untouched files on `origin/main`; all files changed by this PR pass Rust 1.96 `rustfmt --check`.

No configuration, migration, or rollout changes are required.