### PR TITLE
fix(waku-core): ignore Pi whitespace-only assistant text

### DIFF
--- a/crates/waku-core/src/driver/pi.rs
+++ b/crates/waku-core/src/driver/pi.rs
@@ -1277,7 +1277,7 @@ fn handle_pi_message(
                     if let Some(delta) = update
                         .get("delta")
                         .and_then(Value::as_str)
-                        .filter(|delta| !delta.is_empty())
+                        .filter(|delta| !delta.trim().is_empty())
                     {
                         state.message_saw_text = true;
                         let _ = events.send(DriverEvent::TextDelta(delta.to_owned()));
@@ -1411,7 +1411,7 @@ fn emit_completed_message_fallback(
                 if let Some(text) = block
                     .get("text")
                     .and_then(Value::as_str)
-                    .filter(|text| !text.is_empty())
+                    .filter(|text| !text.trim().is_empty())
                 {
                     state.message_saw_text = true;
                     let _ = events.send(DriverEvent::TextDelta(text.to_owned()));
@@ -1730,6 +1730,59 @@ mod tests {
         assert!(matches!(
             event_rx.recv().unwrap(),
             DriverEvent::TurnFinished { success: true, .. }
+        ));
+        assert!(matches!(event_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    /// Whitespace-only streamed and completed text must not become separate
+    /// assistant messages in the transcript. Pi emits a bare `"\n\n"` text
+    /// block at the start of many assistant messages; without filtering both
+    /// event paths every tool step produced an empty markdown row, which
+    /// rendered as the large vertical gaps between activity summaries.
+    #[test]
+    fn filters_whitespace_only_streamed_and_completed_text() {
+        let (pending, commands, _command_rx, mut state) = harness();
+        let (events, event_rx) = unbounded();
+        for value in [
+            json!({"type": "agent_start"}),
+            json!({
+                "type": "message_start",
+                "message": {"role": "assistant"}
+            }),
+            json!({
+                "type": "message_update",
+                "assistantMessageEvent": {"type": "text_delta", "delta": "\n\n"}
+            }),
+            json!({
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "\n\n"}]
+                }
+            }),
+            json!({
+                "type": "message_start",
+                "message": {"role": "assistant"}
+            }),
+            json!({
+                "type": "message_update",
+                "assistantMessageEvent": {"type": "text_delta", "delta": "\n real text \n"}
+            }),
+        ] {
+            handle_pi_message(
+                PiFlavor::Pi,
+                value,
+                &pending,
+                &commands,
+                &events,
+                &mut state,
+            );
+        }
+
+        assert!(matches!(event_rx.recv().unwrap(), DriverEvent::TurnStarted));
+        assert!(matches!(
+            event_rx.recv().unwrap(),
+            DriverEvent::TextDelta(value) if value == "\n real text \n"
         ));
         assert!(matches!(event_rx.try_recv(), Err(TryRecvError::Empty)));
     }


### PR DESCRIPTION
Fixes #166.

## Problem

Pi can emit a bare `"\n\n"` assistant text block around tool calls. Waku filtered only empty strings, so whitespace-only text became a `TextDelta` and created a blank assistant transcript row between activity groups.

The same text can arrive through two provider event paths:

- a streamed `message_update` / `text_delta`
- the completed-message fallback used when no text delta was accepted

Filtering only the streamed path still allowed `message_end` to restore the blank row.

## Solution

Ignore whitespace-only assistant text in both Pi event paths while preserving the original contents of non-blank text.

The regression test reproduces both forms in one provider event sequence: a whitespace-only streamed delta followed by its completed message, then a real text delta. It asserts that only the real text reaches the transcript.

## Checks

- `cargo fmt --package waku-core -- --check`
- `cargo check --locked`
- `cargo test --locked`
- `bun run protocol:check`
- `bun run --filter @waku/client check`
- `bun run --filter @waku/client test` — 11 passed
- `git diff --check`

## Limitations

This prevents new blank transcript rows. It does not rewrite whitespace-only messages already persisted in existing sessions.
