### PR TITLE
Scope queued follow-up tooltips to each control

### DIFF
--- a/src/app/composer.rs
+++ b/src/app/composer.rs
@@ -2556,6 +2556,7 @@ impl Waku {
                     .when(menu_open, |element| element.bg(theme.overlay_strong))
                     .hover(|element| element.bg(theme.overlay_strong))
                     .active(|element| element.opacity(0.8))
+                    .tooltip(Tooltip::text(tr!("composer.queued_message_actions")))
                     .child(icon("icons/ellipsis.svg", 12.5, theme.text_secondary)),
                 SharedString::from(format!("queued-message-more-menu-{message_id}")),
                 &menu_handle,
@@ -2579,32 +2580,62 @@ impl Waku {
                     ]
                 },
             );
+            // Edit-in-composer is the row's click action, but the tooltip
+            // belongs on the text region only. GPUI still fires ancestor
+            // tooltips over children, so a row-level hint flashes on
+            // steer/remove and sticks on the more trigger (which had none).
             list = list.child(
                 div()
                     .id(SharedString::from(format!("queued-message-{message_id}")))
                     .h(px(30.0))
-                    .pl(px(12.0))
                     .pr(px(6.0))
                     .flex()
                     .items_center()
                     .gap(px(9.0))
-                    .cursor_default()
-                    .tab_index(0)
-                    .focus_visible(|style| style.border_1().border_color(theme.accent))
                     .hover(|element| element.bg(theme.overlay))
-                    .tooltip(Tooltip::text(tr!("composer.edit_in_composer")))
-                    .child(icon("icons/queue.svg", 12.0, theme.text_tertiary))
                     .child(
                         div()
+                            .id(SharedString::from(format!(
+                                "queued-message-edit-{message_id}"
+                            )))
                             .flex_1()
                             .min_w_0()
-                            .truncate()
-                            .text_size(sp(12.5))
-                            .text_color(theme.text)
-                            .child(SharedString::from(content)),
+                            .h_full()
+                            .pl(px(12.0))
+                            .flex()
+                            .items_center()
+                            .gap(px(9.0))
+                            .cursor_default()
+                            .tab_index(0)
+                            .focus_visible(|style| style.border_1().border_color(theme.accent))
+                            .tooltip(Tooltip::text(tr!("composer.edit_in_composer")))
+                            .child(icon("icons/queue.svg", 12.0, theme.text_tertiary))
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .truncate()
+                                    .text_size(sp(12.5))
+                                    .text_color(theme.text)
+                                    .child(SharedString::from(content)),
+                            )
+                            .on_click(cx.listener(move |this, _, window, cx| {
+                                this.edit_queued_message(session_id, message_id, window, cx);
+                            }))
+                            .on_key_down(cx.listener(
+                                move |this, event: &KeyDownEvent, window, cx| {
+                                    if matches!(event.keystroke.key.as_str(), "enter" | "space") {
+                                        this.edit_queued_message(
+                                            session_id, message_id, window, cx,
+                                        );
+                                        cx.stop_propagation();
+                                    }
+                                },
+                            )),
                     )
                     .child(
                         div()
+                            .flex_none()
                             .flex()
                             .items_center()
                             .gap(px(2.0))
@@ -2648,16 +2679,7 @@ impl Waku {
                                     )),
                             )
                             .child(more_control),
-                    )
-                    .on_click(cx.listener(move |this, _, window, cx| {
-                        this.edit_queued_message(session_id, message_id, window, cx);
-                    }))
-                    .on_key_down(cx.listener(move |this, event: &KeyDownEvent, window, cx| {
-                        if matches!(event.keystroke.key.as_str(), "enter" | "space") {
-                            this.edit_queued_message(session_id, message_id, window, cx);
-                            cx.stop_propagation();
-                        }
-                    })),
+                    ),
             );
         }
         Some(


### PR DESCRIPTION
## Summary
- Queued follow-up rows put **Edit in composer** on the whole row, so Steer/Remove flashed that hint first and More kept showing it.
- Scope that tooltip to the text hit target (same as the web composer) and give More `composer.queued_message_actions`.

Fixes #173

## Test plan
- [ ] Queue a follow-up while a turn is running so the card appears above the composer
- [ ] Hover the message text → **Edit in composer**
- [ ] Hover Steer → **Steer current turn**, with no flash of **Edit in composer**
- [ ] Hover Remove → **Remove from queue**
- [ ] Hover More → **Follow-up actions** (zh-CN: 后续消息操作)
- [ ] Clicking the text still pulls the message into the composer; Steer/Remove/More still work; Enter/Space on the text region still edits
