### PR TITLE
Tail Claude background task output on Windows

### DIFF
--- a/crates/waku-core/src/driver/claude.rs
+++ b/crates/waku-core/src/driver/claude.rs
@@ -14,12 +14,12 @@
 //! from `claude --help`.
 
 use std::collections::{HashMap, HashSet};
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::fs::File;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::io::Read;
 use std::io::{BufRead, BufReader, Write};
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
@@ -651,13 +651,17 @@ impl Drop for ClaudeTaskOutputTails {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 const CLAUDE_TASK_OUTPUT_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Claude keeps live Bash output outside its JSON stream. The installed CLI
-/// writes it under `/tmp/claude-<uid>/<workspace>/<session>/tasks/<id>.output`;
-/// locate the workspace component instead of reproducing Claude's private cwd
-/// escaping rules.
+/// writes it under `<root>/<workspace>/<session>/tasks/<id>.output`; locate the
+/// workspace component instead of reproducing Claude's private cwd escaping
+/// rules. Only the root differs by platform.
+///
+/// The Unix root stays the literal `/tmp`: on macOS `std::env::temp_dir()`
+/// resolves to a per-user `/var/folders/…` path, which is not where the CLI
+/// writes.
 #[cfg(unix)]
 fn claude_task_output_path(session_id: &str, task_id: &str) -> Option<PathBuf> {
     // SAFETY: `geteuid` has no preconditions and does not retain pointers.
@@ -669,7 +673,13 @@ fn claude_task_output_path(session_id: &str, task_id: &str) -> Option<PathBuf> {
     )
 }
 
-#[cfg(unix)]
+/// Windows has no per-uid suffix; the CLI writes under `%TEMP%\claude`.
+#[cfg(windows)]
+fn claude_task_output_path(session_id: &str, task_id: &str) -> Option<PathBuf> {
+    claude_task_output_path_in(&std::env::temp_dir().join("claude"), session_id, task_id)
+}
+
+#[cfg(any(unix, windows))]
 fn claude_task_output_path_in(root: &Path, session_id: &str, task_id: &str) -> Option<PathBuf> {
     if task_id.is_empty()
         || task_id.contains('/')
@@ -693,7 +703,7 @@ fn claude_task_output_path_in(root: &Path, session_id: &str, task_id: &str) -> O
         .find(|path| path.is_file())
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn drain_utf8_output(bytes: &mut Vec<u8>, final_read: bool) -> Option<String> {
     if bytes.is_empty() {
         return None;
@@ -716,7 +726,7 @@ fn drain_utf8_output(bytes: &mut Vec<u8>, final_read: bool) -> Option<String> {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn stream_claude_task_output(
     path: PathBuf,
     key: BackgroundWorkKey,
@@ -757,7 +767,7 @@ fn stream_claude_task_output(
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn stream_claude_task_output_when_ready(
     session_id: String,
     task_id: String,
@@ -780,7 +790,7 @@ fn stream_claude_task_output_when_ready(
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn start_claude_task_output_tail(
     session_id: &str,
     item: &BackgroundWorkItem,
@@ -818,7 +828,7 @@ fn start_claude_task_output_tail(
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 fn start_claude_task_output_tail(
     _session_id: &str,
     _item: &BackgroundWorkItem,
@@ -1718,7 +1728,7 @@ mod tests {
         )
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     #[test]
     fn locates_claudes_native_task_output_across_workspace_slugs() {
         let root = std::env::temp_dir().join(format!("waku-claude-output-test-{}", Uuid::new_v4()));
@@ -1741,7 +1751,7 @@ mod tests {
         std::fs::remove_dir_all(root).unwrap();
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     #[test]
     fn live_task_output_preserves_split_utf8() {
         let bytes = "first 界".as_bytes();
@@ -1760,7 +1770,7 @@ mod tests {
         assert!(pending.is_empty());
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     #[test]
     fn native_task_output_streams_before_completion() {
         let root = std::env::temp_dir().join(format!("waku-claude-tail-test-{}", Uuid::new_v4()));


### PR DESCRIPTION
Closes #162.

## Problem

Live output from Claude's background Bash tasks never reaches the UI on Windows. Nothing errors — the pane stays empty for the lifetime of the task and the output only appears once Claude reports the result in its stream.

The tailing path is gated on Unix, and the non-Unix `start_claude_task_output_tail` is an empty stub, so nothing is ever tailed. Windows support landed in #46, so this reads as an omission rather than an unsupported platform.

## Why the change is small

Only the root directory was ever platform-specific. Claude writes the same `<workspace>/<session>/tasks/<id>.output` tree on Windows, under `%TEMP%\claude` instead of `/tmp/claude-<uid>`, and `claude_task_output_path_in` is already neutral: it takes the root as a parameter, reads it, joins the session and task components on each entry, and returns the first that is a file. It also already rejects both `/` and `\` in the ids, so the traversal guard needed nothing for Windows.

So the resolver gains a Windows arm and everything else loses its `#[cfg(unix)]`:

```rust
/// Windows has no per-uid suffix; the CLI writes under `%TEMP%\claude`.
#[cfg(windows)]
fn claude_task_output_path(session_id: &str, task_id: &str) -> Option<PathBuf> {
    claude_task_output_path_in(&std::env::temp_dir().join("claude"), session_id, task_id)
}
```

The Unix arm keeps the literal `/tmp`. On macOS `std::env::temp_dir()` resolves to a per-user `/var/folders/…` path, which is not where the CLI writes, so sharing `temp_dir()` between the two would have broken macOS quietly. The stub is now `#[cfg(not(any(unix, windows)))]` so other targets still compile.

## Checks

- `cargo test -p waku-core --lib` — 342 passed, 0 failed
- `cargo fmt --package waku-core -- --check` — no diff in `driver/claude.rs`
- `cargo check` — clean (run on the sibling branch against the same base; this touches one file in the same crate)

The three tests covering this only touch temp files, so they run on both platforms now instead of being skipped on Windows. On this Windows machine:

```
test driver::claude::tests::locates_claudes_native_task_output_across_workspace_slugs ... ok
test driver::claude::tests::live_task_output_preserves_split_utf8 ... ok
test driver::claude::tests::native_task_output_streams_before_completion ... ok
```

`native_task_output_streams_before_completion` is the one that matters: it tails a real file, appends to it mid-run, and asserts both deltas arrive — the behaviour that was silently absent on Windows.

## Verified against a real Claude tree

The layout is not documented anywhere I could find, so I checked the resolver against actual files rather than trusting the shape. On Windows 11 26200 with the current Claude Code release, a throwaway test calling `claude_task_output_path` with a live session and task id resolved to:

```
Some("C:\\Users\\<user>\\AppData\\Local\\Temp\\claude\\d--LQ\\d64a4568-…\\tasks\\b3cd09sfb.output")
```

which is the file that background task actually wrote. Sibling entries under `claude\` that are not workspaces — `bundled-skills` and similar — are skipped by the existing `.find(|path| path.is_file())`, as expected. That test was removed before committing; it only proves the path on one machine.

## Known limitations

- I do not have Waku installed, so the end-to-end symptom — an empty output pane — is read off the source rather than observed in the running app. What is verified here is that the resolver finds Claude's real files on Windows and that the tail delivers deltas from a file as it grows.
- I have not checked whether the other drivers have an equivalent Windows gap.
