### PR TITLE
Keep Amp threads resumable after app restart

### DIFF
--- a/crates/waku-core/src/driver/amp.rs
+++ b/crates/waku-core/src/driver/amp.rs
@@ -65,6 +65,9 @@ pub(super) fn amp_args(
     }
     args.extend([
         "--execute".to_owned(),
+        // Closing Waku ends this execute process, but its thread must remain
+        // available for `threads continue` after the app restarts.
+        "--no-archive-after-execute".to_owned(),
         // Implies --stream-json, which --stream-json-input requires.
         "--stream-json-thinking".to_owned(),
         "--stream-json-input".to_owned(),
@@ -706,6 +709,7 @@ mod tests {
         assert!(args.contains(&"--stream-json-thinking".to_owned()));
         assert!(args.contains(&"--stream-json-input".to_owned()));
         assert!(args.contains(&"--execute".to_owned()));
+        assert!(args.contains(&"--no-archive-after-execute".to_owned()));
         assert!(args.contains(&"--fast".to_owned()));
         // The prompt is never an argument; it goes in on stdin.
         assert!(!args.iter().any(|arg| arg.contains("Reply with")));


### PR DESCRIPTION
## Problem

Waku runs Amp with `--execute` and `--stream-json-input`, keeping one Amp process alive for the conversation. When Waku exits, the process's stdin closes and the execute session finishes. Amp archives newly created threads after execute by default.

Waku persists the Amp thread ID and attempts to restore it with `amp threads continue <thread-id>` after an app restart. Because the thread was archived during shutdown, the restored conversation fails with:

```
Amp: Error: This thread is archived and cannot be continued.
```

This leaves previously usable Amp conversations unable to accept new messages after restarting Waku.

## Solution

Pass Amp's `--no-archive-after-execute` option whenever Waku starts an Amp execute process. The Amp process can still end normally when Waku closes, but the provider thread remains unarchived and available to `threads continue` on the next launch.

The existing CLI argument test now asserts that this persistence option is always included.

## Checks

- `cargo test -p waku-core` — 354 passed, 24 ignored
- `cargo test -p waku-core cli_args_stream_json_in_and_out_and_resume_the_exact_thread`
- `rustfmt --edition 2024 --check crates/waku-core/src/driver/amp.rs`
- `git diff --check`
- `bun run protocol:check`
- `bun run --filter @waku/client check`
- `bun run --filter @waku/client test` — 11 passed

## Local baseline limitations

- Workspace `cargo check` reaches `gpui_macos` but cannot complete because the local Xcode installation does not include the Metal Toolchain (`xcrun: unable to find utility "metal"`).
- The workspace-wide `cargo fmt --check` also reports a pre-existing formatting difference in `crates/waku-core/src/driver/codex.rs`; the edited Amp driver passes a direct rustfmt check.
- Threads already archived by an older Waku run are not silently unarchived, preserving explicit archive state. They can be restored once with `amp threads archive --unarchive <thread-id>`; this change prevents future Waku shutdowns from archiving them.