### PR TITLE
Fix Codex Computer Use startup config

### DIFF
--- a/crates/waku-core/src/driver/codex.rs
+++ b/crates/waku-core/src/driver/codex.rs
@@ -37,6 +37,9 @@ const DISABLE_EXTERNAL_COMPUTER_USE_MCP_COMMAND: &str =
 const DISABLE_EXTERNAL_COMPUTER_USE_MCP: &str = "mcp_servers.computer-use.enabled=false";
 const DISABLE_EXTERNAL_COMPUTER_USE_SKILL: &str =
     r#"skills.config=[{name="computer-use:computer-use",enabled=false}]"#;
+// Codex validates MCP transport fields even for disabled servers, so the
+// override needs a valid stdio command before disabling the bundled server.
+const DISABLE_CODEX_NODE_REPL_COMMAND: &str = "mcp_servers.node_repl.command=\"/usr/bin/true\"";
 const DISABLE_CODEX_NODE_REPL: &str = "mcp_servers.node_repl.enabled=false";
 
 enum CommandMessage {
@@ -179,6 +182,8 @@ fn configure_computer_use_command(command: &mut Command, config: Option<&CodexCo
             .arg(DISABLE_EXTERNAL_COMPUTER_USE_MCP)
             .arg("-c")
             .arg(DISABLE_EXTERNAL_COMPUTER_USE_SKILL)
+            .arg("-c")
+            .arg(DISABLE_CODEX_NODE_REPL_COMMAND)
             .arg("-c")
             .arg(DISABLE_CODEX_NODE_REPL)
             .env("WAKU_COMPUTER_USE_SERVER", &config.server_path)
@@ -2963,6 +2968,11 @@ mod tests {
             enabled_arguments
                 .iter()
                 .any(|argument| argument == DISABLE_CODEX_NODE_REPL)
+        );
+        assert!(
+            enabled_arguments
+                .iter()
+                .any(|argument| argument == DISABLE_CODEX_NODE_REPL_COMMAND)
         );
         assert!(
             enabled


### PR DESCRIPTION
## Summary

- prevent Codex from rejecting Waku Computer Use configuration with an invalid `node_repl` transport
- provide a harmless command transport before disabling the built-in `node_repl` server
- extend the existing command configuration test to cover the override

## Root cause

When Computer Use is enabled, Waku disables Codex `node_repl` MCP server by writing only `mcp_servers.node_repl.enabled = false`. Codex still validates the inherited server definition and fails startup with `invalid transport`.

## Fix

Set `mcp_servers.node_repl.command = "/usr/bin/true"` alongside the disable flag. This keeps the server disabled while making the generated configuration valid for Codex.

## Validation

- `cargo test -p waku-core`
- verified a real Codex 0.148.0 app-server starts without the transport error using the patched arguments
- `git diff --check`