### PR TITLE
Add Configurable Font Family Settings and Scrollable Menus

### DIFF
--- a/crates/waku-client/src/persistence.rs
+++ b/crates/waku-client/src/persistence.rs
@@ -249,6 +249,11 @@ pub struct AppSettings {
     /// and tool output — in pixels. Hand-edited values are clamped when
     /// applied.
     pub code_font_size: f32,
+    /// Custom UI sans font family. `None` uses the platform system font.
+    pub ui_font_family: Option<String>,
+    /// Custom monospace family for code surfaces. `None` uses the bundled
+    /// JetBrains Mono.
+    pub mono_font_family: Option<String>,
     pub daemon_exposure: DaemonExposureSettings,
     /// Preferred target of the header's "open project in app" control, by
     /// catalog id. `None` — and an id no longer installed — fall back to the
@@ -265,6 +270,8 @@ impl Default for AppSettings {
             language: AppLanguage::default(),
             ui_font_size: DEFAULT_UI_FONT_SIZE,
             code_font_size: DEFAULT_CODE_FONT_SIZE,
+            ui_font_family: None,
+            mono_font_family: None,
             daemon_exposure: DaemonExposureSettings::default(),
             open_in_app: None,
         }
@@ -289,6 +296,18 @@ pub fn sanitized_ui_font_size(size: f32) -> f32 {
 
 pub fn sanitized_code_font_size(size: f32) -> f32 {
     sanitized_font_size(size, DEFAULT_CODE_FONT_SIZE)
+}
+
+pub const DEFAULT_SANS_FAMILY: &str = ".SystemUIFont";
+pub const DEFAULT_MONO_FAMILY: &str = "JetBrains Mono";
+
+/// Normalizes a hand-edited font family: trim whitespace, collapse empties
+/// to `None`. Existence is validated by the app layer when the setting is
+/// chosen, so persistence accepts the stored value as-is.
+pub fn sanitized_font_family(family: Option<String>) -> Option<String> {
+    family
+        .map(|family| family.trim().to_string())
+        .filter(|family| !family.is_empty())
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -368,6 +387,10 @@ pub struct PersistedState {
     pub ui_font_size: f32,
     #[serde(default = "default_code_font_size")]
     pub code_font_size: f32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ui_font_family: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mono_font_family: Option<String>,
     #[serde(default)]
     pub daemon_exposure: DaemonExposureSettings,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -441,6 +464,8 @@ impl PersistedState {
             language: AppLanguage::default(),
             ui_font_size: DEFAULT_UI_FONT_SIZE,
             code_font_size: DEFAULT_CODE_FONT_SIZE,
+            ui_font_family: None,
+            mono_font_family: None,
             daemon_exposure: DaemonExposureSettings::default(),
             open_in_app: None,
             sidebar_visible: true,
@@ -564,6 +589,8 @@ impl PersistedState {
             language: self.language,
             ui_font_size: self.ui_font_size,
             code_font_size: self.code_font_size,
+            ui_font_family: self.ui_font_family.clone(),
+            mono_font_family: self.mono_font_family.clone(),
             daemon_exposure: self.daemon_exposure.clone(),
             open_in_app: self.open_in_app.clone(),
         }
@@ -600,6 +627,8 @@ impl PersistedState {
         self.language = settings.language;
         self.ui_font_size = sanitized_ui_font_size(settings.ui_font_size);
         self.code_font_size = sanitized_code_font_size(settings.code_font_size);
+        self.ui_font_family = sanitized_font_family(settings.ui_font_family);
+        self.mono_font_family = sanitized_font_family(settings.mono_font_family);
         self.daemon_exposure = settings.daemon_exposure;
         self.open_in_app = settings.open_in_app;
     }

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -123,7 +123,7 @@ settings.computer_use:
 settings.general_keywords:
   en: general local projects conversations privacy analytics telemetry anonymous sharing updates automatic sparkle version
 settings.appearance_keywords:
-  en: appearance theme system light dark language english chinese simplified font size text editor
+  en: appearance theme system light dark language english chinese simplified font family ui mono code editor
 settings.providers_keywords:
   en: providers agents models cli version install detect claude codex cursor opencode amp grok pi
 settings.skills:
@@ -282,6 +282,16 @@ settings.code_font_size:
   en: Code font size
 settings.code_font_size_description:
   en: Text size in the file editor, diffs, code blocks, and tool output
+settings.ui_font:
+  en: UI font
+settings.ui_font_description:
+  en: Font family for the interface and messages
+settings.mono_font:
+  en: Code font
+settings.mono_font_description:
+  en: Monospace font for the file editor, diffs, code blocks, and tool output
+settings.font_default:
+  en: System default
 settings.theme_system:
   en: System
 settings.theme_light:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -63,7 +63,7 @@ settings.usage: 使用状況
 settings.daemon: デーモン
 settings.computer_use: コンピュータ操作
 settings.general_keywords: 一般 ローカル プロジェクト 会話 プライバシー 分析 テレメトリ 匿名 共有 アップデート 自動 バージョン
-settings.appearance_keywords: 外観 テーマ システム ライト ダーク 言語 英語 中国語 簡体字 日本語 フォント サイズ 文字 エディタ
+settings.appearance_keywords: 外観 テーマ システム ライト ダーク 言語 英語 中国語 簡体字 日本語 フォント ファミリー UI 等幅 コード サイズ エディタ
 settings.providers_keywords: プロバイダー エージェント モデル CLI バージョン インストール 検出 claude codex cursor opencode amp grok pi
 settings.skills: スキル
 settings.skills_keywords: スキル ライブラリ エージェント 無効 有効 削除 claude codex cursor opencode pi amp 共有
@@ -143,6 +143,11 @@ settings.ui_font_size: UI のフォントサイズ
 settings.ui_font_size_description: インターフェース全体とメッセージの文字サイズ
 settings.code_font_size: コードのフォントサイズ
 settings.code_font_size_description: ファイルエディタ、差分表示、コードブロック、ツール出力の文字サイズ
+settings.ui_font: UI フォント
+settings.ui_font_description: インターフェースとメッセージのフォントファミリー
+settings.mono_font: コードフォント
+settings.mono_font_description: ファイルエディタ、差分表示、コードブロック、ツール出力の等幅フォント
+settings.font_default: システムデフォルト
 settings.theme_system: システム
 settings.theme_light: ライト
 settings.theme_dark: ダーク

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -59,7 +59,7 @@ settings.usage: 用量
 settings.daemon: 守护进程
 settings.computer_use: 电脑操作
 settings.general_keywords: 通用 本地 项目 对话 隐私 匿名 使用数据 分析 分享 更新 自动 版本
-settings.appearance_keywords: 外观 主题 系统 浅色 深色 语言 英语 中文 简体 字号 字体 大小 编辑器
+settings.appearance_keywords: 外观 主题 系统 浅色 深色 语言 英语 中文 简体 字号 字体 字族 界面 等宽 代码 编辑器
 settings.providers_keywords: 服务商 智能体 模型 命令行 版本 安装 检测 claude codex cursor opencode amp grok pi
 settings.skills: 技能
 settings.skills_keywords: 技能 技能库 智能体 禁用 启用 删除 claude codex cursor opencode pi amp 共享
@@ -139,6 +139,11 @@ settings.ui_font_size: 界面字号
 settings.ui_font_size_description: 整个界面与消息的文字大小
 settings.code_font_size: 代码字号
 settings.code_font_size_description: 文件编辑器、差分视图、代码块与工具输出的文字大小
+settings.ui_font: 界面字体
+settings.ui_font_description: 界面与消息使用的字体
+settings.mono_font: 代码字体
+settings.mono_font_description: 文件编辑器、差分视图、代码块与工具输出使用的等宽字体
+settings.font_default: 系统默认
 settings.theme_system: 跟随系统
 settings.theme_light: 浅色
 settings.theme_dark: 深色

--- a/src/app.rs
+++ b/src/app.rs
@@ -1927,6 +1927,12 @@ impl Waku {
         window.set_rem_size(px(waku_client::persistence::sanitized_ui_font_size(
             state.ui_font_size,
         )));
+        // Resolve the custom font families before any markdown or chrome
+        // renders; render paths read the static, never the settings file.
+        crate::fonts::install(
+            state.ui_font_family.as_deref(),
+            state.mono_font_family.as_deref(),
+        );
         let analytics = crate::analytics::Analytics::new(
             state.language.locale(),
             state.analytics_id,

--- a/src/app/background_work.rs
+++ b/src/app/background_work.rs
@@ -1230,7 +1230,7 @@ impl Waku {
                     .child(
                         div()
                             .text_size(sp(12.5))
-                            .font_family(md::render::MONO_FAMILY)
+                            .font_family(crate::fonts::mono())
                             .text_color(theme.text_secondary)
                             .child(value),
                     ),
@@ -1239,7 +1239,7 @@ impl Waku {
         let output = output.unwrap_or_else(|| SharedString::from(tr!("background.no_output")));
         let output_flat = md::render::flatten_plain(
             output,
-            md::render::MONO_FAMILY,
+            crate::fonts::mono(),
             FontWeight::NORMAL,
             theme.text_secondary,
         );
@@ -1302,7 +1302,7 @@ impl Waku {
                                 .p(px(8.0))
                                 .text_size(sp(12.5))
                                 .line_height(sp(15.0))
-                                .font_family(md::render::MONO_FAMILY)
+                                .font_family(crate::fonts::mono())
                                 .text_color(theme.text_secondary)
                                 .child(output_text),
                         )

--- a/src/app/components.rs
+++ b/src/app/components.rs
@@ -529,7 +529,7 @@ fn render_markdown_message_body<'a>(
         .unwrap_or_else(|| {
             md::render::plain_text(
                 content.to_owned(),
-                md::render::SANS_FAMILY,
+                crate::fonts::sans(),
                 FontWeight::NORMAL,
                 theme.text,
                 ctx,
@@ -744,7 +744,7 @@ pub(super) fn render_message(params: MessageRender, cx: &mut App) -> AnyElement 
                 .line_height(sp(16.0))
                 .child(md::render::plain_text(
                     content.clone(),
-                    md::render::SANS_FAMILY,
+                    crate::fonts::sans(),
                     FontWeight::NORMAL,
                     theme.text_tertiary,
                     ctx,

--- a/src/app/composer.rs
+++ b/src/app/composer.rs
@@ -110,7 +110,7 @@ impl Waku {
                             .p(px(8.0))
                             .rounded(px(7.0))
                             .bg(theme.inset)
-                            .font_family(crate::md::render::MONO_FAMILY)
+                            .font_family(crate::fonts::mono())
                             .text_size(sp(12.5))
                             .line_height(sp(16.0))
                             .text_color(theme.text_secondary)

--- a/src/app/file_search.rs
+++ b/src/app/file_search.rs
@@ -980,7 +980,7 @@ impl Waku {
                 .border_b_1()
                 .border_color(theme.border)
                 .bg(theme.surface)
-                .font_family(".SystemUIFont")
+                .font_family(crate::fonts::sans())
                 .cursor_default()
                 .flex()
                 .items_start()

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -322,7 +322,7 @@ impl Render for Waku {
             .relative()
             .flex()
             .text_color(theme.text)
-            .font_family(".SystemUIFont")
+            .font_family(crate::fonts::sans())
             // Both panels slide through a container that narrows while their
             // content keeps its full width and is clipped: the sidebar list
             // and the right panel's surfaces never reflow on the way in or
@@ -474,7 +474,7 @@ impl Waku {
         );
         let message = md::render::plain_text(
             message,
-            md::render::SANS_FAMILY,
+            crate::fonts::sans(),
             FontWeight::NORMAL,
             theme.text,
             &text_ctx,

--- a/src/app/right_panel.rs
+++ b/src/app/right_panel.rs
@@ -451,7 +451,7 @@ pub(super) fn render_diff_code_row(
         .flex_none()
         .flex()
         .items_stretch()
-        .font_family(md::render::MONO_FAMILY)
+        .font_family(crate::fonts::mono())
         .text_size(px(style.text_size))
         .line_height(px(style.row_height))
         .when_some(edge, |row, edge| row.border_l_2().border_color(edge))
@@ -463,7 +463,7 @@ pub(super) fn render_diff_code_row(
 fn review_diff_flat_text(line: &crate::review_diff::Line, theme: &Theme) -> md::render::FlatText {
     let text = line.content.clone();
     let palette = MarkdownPalette::from_theme(theme);
-    let code_font = font(md::render::MONO_FAMILY);
+    let code_font = font(crate::fonts::mono());
     let mut runs = Vec::with_capacity(line.tokens.len() * 2 + 1);
     let mut offset = 0;
     let mut push = |len: usize, color: Hsla| {
@@ -3175,7 +3175,7 @@ impl Waku {
                         let text = SharedString::from(number.to_string());
                         let run = gpui::TextRun {
                             len: text.len(),
-                            font: gpui::font(md::render::MONO_FAMILY),
+                            font: gpui::font(crate::fonts::mono()),
                             color: number_color,
                             ..Default::default()
                         };
@@ -3211,7 +3211,7 @@ impl Waku {
             .flex()
             .flex_col()
             .bg(theme.surface)
-            .font_family(md::render::MONO_FAMILY)
+            .font_family(crate::fonts::mono())
             .text_size(px(text_size))
             .line_height(px(line_height))
             .children(find_bar)
@@ -3853,7 +3853,7 @@ impl Waku {
                 .min_w_0()
                 .flex()
                 .items_stretch()
-                .font_family(md::render::MONO_FAMILY)
+                .font_family(crate::fonts::mono())
                 .text_size(px(12.5))
                 .line_height(px(16.0))
                 .text_color(theme.text_tertiary)
@@ -3888,7 +3888,7 @@ impl Waku {
                 .min_w_0()
                 .flex()
                 .items_stretch()
-                .font_family(md::render::MONO_FAMILY)
+                .font_family(crate::fonts::mono())
                 .text_size(px(12.5))
                 .line_height(px(16.0))
                 .text_color(theme.text_tertiary)

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -112,7 +112,7 @@ impl Waku {
             .flex()
             .bg(theme.canvas)
             .text_color(theme.text)
-            .font_family(".SystemUIFont")
+            .font_family(crate::fonts::sans())
             .child(self.render_settings_sidebar(window, cx))
             .child(self.render_settings_content(window, cx))
             .into_any_element()
@@ -1331,6 +1331,60 @@ impl Waku {
             },
         );
 
+        let selected_ui_font_family = self.state.ui_font_family.clone();
+        let selected_mono_font_family = self.state.mono_font_family.clone();
+        let weak = cx.entity().downgrade();
+        let ui_font_family_handle = self.menu_handle("ui-font-family-selector", cx);
+        let ui_font_family_selector = dropdown_menu(
+            MenuChip::new("ui-font-family-selector")
+                .label(font_family_label(selected_ui_font_family.as_deref()))
+                .outlined()
+                .selected(ui_font_family_handle.is_open())
+                .w(px(200.0))
+                .justify_between(),
+            "ui-font-family-selector-menu",
+            &ui_font_family_handle,
+            MenuAlign::BelowRight,
+            move |cx| {
+                let weak = weak.clone();
+                font_family_menu_items(
+                    cx,
+                    selected_ui_font_family.as_deref(),
+                    Rc::new(move |family, window, cx| {
+                        let _ = weak.update(cx, |this, cx| {
+                            this.set_ui_font_family(family, window, cx);
+                        });
+                    }),
+                )
+            },
+        );
+
+        let weak = cx.entity().downgrade();
+        let mono_font_family_handle = self.menu_handle("mono-font-family-selector", cx);
+        let mono_font_family_selector = dropdown_menu(
+            MenuChip::new("mono-font-family-selector")
+                .label(font_family_label(selected_mono_font_family.as_deref()))
+                .outlined()
+                .selected(mono_font_family_handle.is_open())
+                .w(px(200.0))
+                .justify_between(),
+            "mono-font-family-selector-menu",
+            &mono_font_family_handle,
+            MenuAlign::BelowRight,
+            move |cx| {
+                let weak = weak.clone();
+                font_family_menu_items(
+                    cx,
+                    selected_mono_font_family.as_deref(),
+                    Rc::new(move |family, window, cx| {
+                        let _ = weak.update(cx, |this, cx| {
+                            this.set_mono_font_family(family, window, cx);
+                        });
+                    }),
+                )
+            },
+        );
+
         let weak = cx.entity().downgrade();
         let language_handle = self.menu_handle("language-selector", cx);
         let language_selector = dropdown_menu(
@@ -1494,6 +1548,70 @@ impl Waku {
                     )
                     .child(code_font_size_selector),
             )
+            .child(div().mx(px(20.0)).h(px(1.0)).bg(theme.border))
+            .child(
+                div()
+                    .w_full()
+                    .min_h(px(60.0))
+                    .px(px(20.0))
+                    .py(px(12.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(24.0))
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .child(
+                                div()
+                                    .text_size(sp(13.5))
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .text_color(theme.text)
+                                    .child(tr!("settings.ui_font")),
+                            )
+                            .child(
+                                div()
+                                    .mt(px(5.0))
+                                    .text_size(sp(12.5))
+                                    .line_height(sp(18.0))
+                                    .text_color(theme.text_secondary)
+                                    .child(tr!("settings.ui_font_description")),
+                            ),
+                    )
+                    .child(ui_font_family_selector),
+            )
+            .child(div().mx(px(20.0)).h(px(1.0)).bg(theme.border))
+            .child(
+                div()
+                    .w_full()
+                    .min_h(px(60.0))
+                    .px(px(20.0))
+                    .py(px(12.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(24.0))
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .child(
+                                div()
+                                    .text_size(sp(13.5))
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .text_color(theme.text)
+                                    .child(tr!("settings.mono_font")),
+                            )
+                            .child(
+                                div()
+                                    .mt(px(5.0))
+                                    .text_size(sp(12.5))
+                                    .line_height(sp(18.0))
+                                    .text_color(theme.text_secondary)
+                                    .child(tr!("settings.mono_font_description")),
+                            ),
+                    )
+                    .child(mono_font_family_selector),
+            )
             .into_any_element()
     }
 
@@ -1519,6 +1637,40 @@ impl Waku {
         self.state.code_font_size = size;
         self.remeasure_font_sized_surfaces();
         self.save();
+        cx.notify();
+    }
+
+    fn set_ui_font_family(&mut self, family: Option<String>, window: &mut Window, cx: &mut Context<Self>) {
+        let family = waku_client::persistence::sanitized_font_family(family);
+        if self.state.ui_font_family == family {
+            return;
+        }
+        self.state.ui_font_family = family.clone();
+        crate::fonts::install(
+            family.as_deref(),
+            self.state.mono_font_family.as_deref(),
+        );
+        // Chrome text is measured against the sans face; cached row heights
+        // would misplace scroll anchors under the new metrics.
+        self.remeasure_font_sized_surfaces();
+        self.save();
+        window.refresh();
+        cx.notify();
+    }
+
+    fn set_mono_font_family(&mut self, family: Option<String>, window: &mut Window, cx: &mut Context<Self>) {
+        let family = waku_client::persistence::sanitized_font_family(family);
+        if self.state.mono_font_family == family {
+            return;
+        }
+        self.state.mono_font_family = family.clone();
+        crate::fonts::install(
+            self.state.ui_font_family.as_deref(),
+            family.as_deref(),
+        );
+        self.remeasure_font_sized_surfaces();
+        self.save();
+        window.refresh();
         cx.notify();
     }
 
@@ -1710,7 +1862,7 @@ impl Waku {
                                 .when_some(version, |element, version| {
                                     element.child(
                                         div()
-                                            .font_family(crate::md::render::MONO_FAMILY)
+                                            .font_family(crate::fonts::mono())
                                             .text_size(sp(12.5))
                                             .text_color(theme.text_tertiary)
                                             .child(SharedString::from(format!("v{version}"))),
@@ -2435,6 +2587,40 @@ fn font_size_label(size: f32) -> String {
     } else {
         format!("{size} px")
     }
+}
+
+/// Chip label for a font-family dropdown. `None` reads as the default.
+fn font_family_label(family: Option<&str>) -> String {
+    family
+        .map(str::to_string)
+        .unwrap_or_else(|| tr!("settings.font_default").to_string())
+}
+
+/// Menu items for a font-family dropdown: the default first, then every
+/// installed system font. The enumeration runs once per process on first
+/// menu open (a one-shot user action), then is cached in [`crate::fonts`].
+fn font_family_menu_items(
+    cx: &App,
+    selected: Option<&str>,
+    on_select: Rc<dyn Fn(Option<String>, &mut Window, &mut App)>,
+) -> Vec<MenuItem> {
+    let mut items = vec![{
+        let on_select = on_select.clone();
+        MenuItem::new(tr!("settings.font_default"), move |window, cx| {
+            on_select(None, window, cx);
+        })
+        .selected(selected.is_none())
+    }];
+    items.extend(crate::fonts::available_font_names(cx).iter().map(|name| {
+        let name = name.clone();
+        let on_select = on_select.clone();
+        let matches = selected.is_some_and(|selected| selected.eq_ignore_ascii_case(&name));
+        MenuItem::new(name.clone(), move |window, cx| {
+            on_select(Some(name.clone()), window, cx);
+        })
+        .selected(matches)
+    }));
+    items
 }
 
 /// "Checked …" caption for the Providers page. Recomputed whenever the page

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -2602,6 +2602,7 @@ fn font_family_label(family: Option<&str>) -> String {
 fn font_family_menu_items(
     cx: &App,
     selected: Option<&str>,
+    #[allow(clippy::type_complexity)] // matches MenuItem's own callback shape
     on_select: Rc<dyn Fn(Option<String>, &mut Window, &mut App)>,
 ) -> Vec<MenuItem> {
     let mut items = vec![{

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -1340,7 +1340,7 @@ impl Waku {
                 .label(font_family_label(selected_ui_font_family.as_deref()))
                 .outlined()
                 .selected(ui_font_family_handle.is_open())
-                .w(px(200.0))
+                .w(px(116.0))
                 .justify_between(),
             "ui-font-family-selector-menu",
             &ui_font_family_handle,
@@ -1366,7 +1366,7 @@ impl Waku {
                 .label(font_family_label(selected_mono_font_family.as_deref()))
                 .outlined()
                 .selected(mono_font_family_handle.is_open())
-                .w(px(200.0))
+                .w(px(116.0))
                 .justify_between(),
             "mono-font-family-selector-menu",
             &mono_font_family_handle,

--- a/src/app/sidebar.rs
+++ b/src/app/sidebar.rs
@@ -407,7 +407,7 @@ impl Waku {
             .child(
                 div()
                     .text_color(theme.text_tertiary)
-                    .font_family(crate::md::render::MONO_FAMILY)
+                    .font_family(crate::fonts::mono())
                     .child(SharedString::from(format!("{fps} FPS"))),
             )
     }

--- a/src/app/skills_page.rs
+++ b/src/app/skills_page.rs
@@ -914,7 +914,7 @@ impl Waku {
             div()
                 .min_w_0()
                 .truncate()
-                .font_family(crate::md::render::MONO_FAMILY)
+                .font_family(crate::fonts::mono())
                 .text_size(px(size.max(12.5)))
                 .text_color(theme.text_secondary)
                 .child(SharedString::from(value))
@@ -1124,7 +1124,7 @@ impl Waku {
                 .border_color(theme.border)
                 .child(
                     div()
-                        .font_family(crate::md::render::MONO_FAMILY)
+                        .font_family(crate::fonts::mono())
                         .text_size(sp(12.5))
                         .text_color(theme.text_ghost)
                         .child("SKILL.md"),

--- a/src/app/transcript_view.rs
+++ b/src/app/transcript_view.rs
@@ -2211,7 +2211,7 @@ impl Waku {
                     .flex()
                     .flex_col()
                     .gap(px(8.0))
-                    .font_family(md::render::MONO_FAMILY)
+                    .font_family(crate::fonts::mono())
                     .text_size(px(mono_size))
                     .line_height(px(mono_line))
                     .text_color(theme.text_secondary)
@@ -2318,7 +2318,7 @@ impl Waku {
                                             .pr(px(8.0))
                                             .child(md::render::plain_text(
                                                 content.clone(),
-                                                md::render::MONO_FAMILY,
+                                                crate::fonts::mono(),
                                                 FontWeight::NORMAL,
                                                 theme.text_secondary,
                                                 &ctx,
@@ -2359,7 +2359,7 @@ impl Waku {
                                     .min_w_0()
                                     .child(md::render::plain_text(
                                         content.clone(),
-                                        md::render::MONO_FAMILY,
+                                        crate::fonts::mono(),
                                         FontWeight::NORMAL,
                                         theme.text_secondary,
                                         &ctx,
@@ -2416,7 +2416,7 @@ impl Waku {
             .track_scroll(&viewport.scroll_handle)
             .flex()
             .flex_col()
-            .font_family(md::render::MONO_FAMILY)
+            .font_family(crate::fonts::mono())
             .text_size(px(diff_mono_size))
             .line_height(px(diff_mono_line))
             .on_scroll_wheel(move |_, _, cx| contain_scroll(&wheel_scroll, cx));
@@ -2564,7 +2564,7 @@ fn activity_diff_break_row(label: Option<String>, theme: &Theme) -> AnyElement {
         .flex_none()
         .flex()
         .items_center()
-        .font_family(md::render::MONO_FAMILY)
+        .font_family(crate::fonts::mono())
         // Fixed like the Review panel's gap and hunk captions: a caption in
         // the code surface follows neither font setting.
         .text_size(px(12.5))

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -1,7 +1,7 @@
 //! Resolved font families.
 //!
 //! Every render path reads [`sans`] / [`mono`], which return a plain
-//! `&'static str` from a lock-protected static — no `cx`, no allocation.
+//! `&'static str` from a lock-free atomic static — no `cx`, no allocation.
 //! Values are installed once at window startup and again whenever the
 //! setting changes; each install leaks at most two short strings, which is
 //! bounded by how often a user changes their font in a session.
@@ -117,10 +117,11 @@ mod tests {
     }
 
     #[test]
-    fn concurrent_reads_do_not_block() {
-        // Regression test for P1: verify sans() and mono() can be called
-        // from multiple threads without blocking. The implementation must
-        // not use locks in the read path.
+    fn concurrent_reads_are_safe() {
+        // Verify that sans() and mono() can be called safely from multiple
+        // threads concurrently. This exercises the atomic read path under
+        // concurrent load to catch data races or undefined behavior, but
+        // does not verify lock-free semantics (RwLock would also pass).
         let _guard = TEST_LOCK.lock().unwrap();
         install(Some("Test Sans"), Some("Test Mono"));
 

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -1,0 +1,98 @@
+//! Resolved font families.
+//!
+//! Every render path reads [`sans`] / [`mono`], which return a plain
+//! `&'static str` from a lock-protected static — no `cx`, no allocation.
+//! Values are installed once at window startup and again whenever the
+//! setting changes; each install leaks at most two short strings, which is
+//! bounded by how often a user changes their font in a session.
+//!
+//! Custom families are validated against the platform font list at choice
+//! time (see the settings UI), so the install path trusts persisted values.
+//! A hand-edited settings file naming a missing family falls back through
+//! GPUI's per-platform resolution; it cannot crash rendering.
+
+use std::sync::{OnceLock, RwLock};
+
+use gpui::App;
+pub use waku_client::persistence::{DEFAULT_MONO_FAMILY, DEFAULT_SANS_FAMILY};
+
+#[derive(Clone, Copy)]
+struct Families {
+    sans: &'static str,
+    mono: &'static str,
+}
+
+const DEFAULT_FAMILIES: Families = Families {
+    sans: DEFAULT_SANS_FAMILY,
+    mono: DEFAULT_MONO_FAMILY,
+};
+
+static FAMILIES: RwLock<Families> = RwLock::new(DEFAULT_FAMILIES);
+
+fn leak(name: &str) -> &'static str {
+    Box::leak(name.to_string().into_boxed_str())
+}
+
+/// Install the resolved families from persisted settings. Called when a
+/// window opens and whenever either setting changes.
+pub fn install(ui_font_family: Option<&str>, mono_font_family: Option<&str>) {
+    let resolve = |candidate: Option<&str>, fallback: &'static str| match candidate {
+        Some(family) if !family.trim().is_empty() => leak(family.trim()),
+        _ => fallback,
+    };
+    *FAMILIES.write().unwrap() = Families {
+        sans: resolve(ui_font_family, DEFAULT_SANS_FAMILY),
+        mono: resolve(mono_font_family, DEFAULT_MONO_FAMILY),
+    };
+}
+
+/// The resolved UI sans family. Defaults to the platform system font.
+pub fn sans() -> &'static str {
+    FAMILIES.read().unwrap().sans
+}
+
+/// The resolved monospace family for code surfaces.
+pub fn mono() -> &'static str {
+    FAMILIES.read().unwrap().mono
+}
+
+/// Every installed system font family, sorted. Enumerated once per process
+/// on first use — a one-shot user action such as opening a settings menu —
+/// never on a render path.
+pub fn available_font_names(cx: &App) -> &'static [String] {
+    static AVAILABLE: OnceLock<Vec<String>> = OnceLock::new();
+    AVAILABLE.get_or_init(|| {
+        let mut names = cx.text_system().all_font_names();
+        names.retain(|name| !name.starts_with('.'));
+        names.sort_unstable();
+        names.dedup();
+        names
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_platform_fallbacks() {
+        assert_eq!(sans(), DEFAULT_SANS_FAMILY);
+        assert_eq!(mono(), DEFAULT_MONO_FAMILY);
+    }
+
+    #[test]
+    fn install_overrides_and_blank_resets() {
+        install(Some("Fira Code"), None);
+        assert_eq!(mono(), DEFAULT_MONO_FAMILY);
+
+        install(None, Some("IBM Plex Mono"));
+        assert_eq!(sans(), DEFAULT_SANS_FAMILY);
+        assert_eq!(mono(), "IBM Plex Mono");
+
+        install(Some("  "), Some(""));
+        assert_eq!(sans(), DEFAULT_SANS_FAMILY);
+        assert_eq!(mono(), DEFAULT_MONO_FAMILY);
+
+        install(None, None);
+    }
+}

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -11,7 +11,7 @@
 //! A hand-edited settings file naming a missing family falls back through
 //! GPUI's per-platform resolution; it cannot crash rendering.
 
-use std::sync::{OnceLock, RwLock};
+use std::sync::{atomic::AtomicPtr, atomic::Ordering, OnceLock};
 
 use gpui::App;
 pub use waku_client::persistence::{DEFAULT_MONO_FAMILY, DEFAULT_SANS_FAMILY};
@@ -27,7 +27,7 @@ const DEFAULT_FAMILIES: Families = Families {
     mono: DEFAULT_MONO_FAMILY,
 };
 
-static FAMILIES: RwLock<Families> = RwLock::new(DEFAULT_FAMILIES);
+static FAMILIES: AtomicPtr<Families> = AtomicPtr::new(&DEFAULT_FAMILIES as *const Families as *mut Families);
 
 fn leak(name: &str) -> &'static str {
     Box::leak(name.to_string().into_boxed_str())
@@ -40,20 +40,28 @@ pub fn install(ui_font_family: Option<&str>, mono_font_family: Option<&str>) {
         Some(family) if !family.trim().is_empty() => leak(family.trim()),
         _ => fallback,
     };
-    *FAMILIES.write().unwrap() = Families {
+    let families = Box::new(Families {
         sans: resolve(ui_font_family, DEFAULT_SANS_FAMILY),
         mono: resolve(mono_font_family, DEFAULT_MONO_FAMILY),
-    };
+    });
+    let ptr = Box::leak(families) as *mut Families;
+    FAMILIES.store(ptr, Ordering::Release);
 }
 
 /// The resolved UI sans family. Defaults to the platform system font.
 pub fn sans() -> &'static str {
-    FAMILIES.read().unwrap().sans
+    // SAFETY: FAMILIES always points to a leaked Box<Families>, either
+    // DEFAULT_FAMILIES (static) or a heap allocation from install().
+    // Ordering::Acquire synchronizes with the Release store in install().
+    unsafe { &*FAMILIES.load(Ordering::Acquire) }.sans
 }
 
 /// The resolved monospace family for code surfaces.
 pub fn mono() -> &'static str {
-    FAMILIES.read().unwrap().mono
+    // SAFETY: FAMILIES always points to a leaked Box<Families>, either
+    // DEFAULT_FAMILIES (static) or a heap allocation from install().
+    // Ordering::Acquire synchronizes with the Release store in install().
+    unsafe { &*FAMILIES.load(Ordering::Acquire) }.mono
 }
 
 /// Every installed system font family, sorted. Enumerated once per process
@@ -73,15 +81,27 @@ pub fn available_font_names(cx: &App) -> &'static [String] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Serialize tests that modify global FAMILIES to prevent races.
+    // Without this lock, defaults_match_platform_fallbacks might read
+    // values installed by install_overrides_and_blank_resets when
+    // tests run concurrently, causing flaky failures.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn defaults_match_platform_fallbacks() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        // Reset to known state in case a previous test left modifications
+        install(None, None);
         assert_eq!(sans(), DEFAULT_SANS_FAMILY);
         assert_eq!(mono(), DEFAULT_MONO_FAMILY);
     }
 
     #[test]
     fn install_overrides_and_blank_resets() {
+        let _guard = TEST_LOCK.lock().unwrap();
+
         install(Some("Fira Code"), None);
         assert_eq!(mono(), DEFAULT_MONO_FAMILY);
 
@@ -93,6 +113,33 @@ mod tests {
         assert_eq!(sans(), DEFAULT_SANS_FAMILY);
         assert_eq!(mono(), DEFAULT_MONO_FAMILY);
 
+        install(None, None);
+    }
+
+    #[test]
+    fn concurrent_reads_do_not_block() {
+        // Regression test for P1: verify sans() and mono() can be called
+        // from multiple threads without blocking. The implementation must
+        // not use locks in the read path.
+        let _guard = TEST_LOCK.lock().unwrap();
+        install(Some("Test Sans"), Some("Test Mono"));
+
+        let handles: Vec<_> = (0..10)
+            .map(|_| {
+                std::thread::spawn(|| {
+                    for _ in 0..1000 {
+                        let _ = sans();
+                        let _ = mono();
+                    }
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Clean up
         install(None, None);
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -3303,7 +3303,7 @@ mod tests {
             12,
             TextRun {
                 len: 12,
-                font: font(".SystemUIFont"),
+                font: font(crate::fonts::sans()),
                 color: plain,
                 background_color: None,
                 underline: None,
@@ -3346,7 +3346,7 @@ mod tests {
             10,
             TextRun {
                 len: 10,
-                font: font(".SystemUIFont"),
+                font: font(crate::fonts::sans()),
                 color: hsla(0.0, 0.0, 1.0, 1.0),
                 background_color: None,
                 underline: None,
@@ -3396,7 +3396,7 @@ mod tests {
             20,
             TextRun {
                 len: 20,
-                font: font(".SystemUIFont"),
+                font: font(crate::fonts::sans()),
                 color: plain,
                 background_color: None,
                 underline: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ mod browser;
 mod computer_use;
 pub mod daemon;
 mod driver;
+mod fonts;
 mod input;
 mod md;
 mod platform;

--- a/src/md/render.rs
+++ b/src/md/render.rs
@@ -138,11 +138,12 @@ impl Metrics {
     }
 }
 
-pub const SANS_FAMILY: &str = ".SystemUIFont";
-/// The bundled mono face. "SF Mono" only exists on machines that installed it
-/// with Xcode or Terminal, and silently falls back to the sans face when it
-/// does not — which reads as proportional code.
-pub const MONO_FAMILY: &str = "JetBrains Mono";
+/// Defaults for the sans and mono families live in [`crate::fonts`], which
+/// also holds the user-configured resolutions read at render time via
+/// [`crate::fonts::sans`] / [`crate::fonts::mono`]. These aliases exist for
+/// tests and callers that need the literal defaults.
+#[allow(unused_imports)] // test-only aliases
+pub use crate::fonts::{DEFAULT_MONO_FAMILY as MONO_FAMILY, DEFAULT_SANS_FAMILY as SANS_FAMILY};
 
 /// Inline-code wash geometry. Paint-only: the box overhangs the glyphs
 /// horizontally and insets vertically inside the line box.
@@ -298,9 +299,9 @@ pub fn flatten(
         let end = text.len();
 
         let mut run_font = font(if run.style.code {
-            MONO_FAMILY
+            crate::fonts::mono()
         } else {
-            SANS_FAMILY
+            crate::fonts::sans()
         });
         run_font.weight = if run.style.bold && base_weight < FontWeight::SEMIBOLD {
             FontWeight::SEMIBOLD
@@ -1521,7 +1522,7 @@ fn render_code_block(language: Option<&str>, code: &str, ctx: &Ctx) -> AnyElemen
     // code block is exactly the case the cache exists for.
     let flat = ctx.flat(key.index, || {
         let lang = language.and_then(highlight::lang_for_tag);
-        let mut code_font = font(MONO_FAMILY);
+        let mut code_font = font(crate::fonts::mono());
         code_font.weight = FontWeight::NORMAL;
         FlatText {
             text: SharedString::from(code.to_owned()),
@@ -1953,7 +1954,7 @@ mod tests {
     #[test]
     fn code_runs_tile_the_block_including_newlines() {
         let code = "fn main() {\n    let x = 1; // c\n}";
-        let mut code_font = font(MONO_FAMILY);
+        let mut code_font = font(crate::fonts::mono());
         code_font.weight = FontWeight::NORMAL;
         let runs = code_runs(code, Some(Lang::Rust), &code_font, &palette());
         assert_eq!(
@@ -2048,7 +2049,7 @@ mod tests {
     #[test]
     fn highlighting_never_changes_run_lengths() {
         let code = "const a = `t ${b}`;\n// note\nlet n = 0x1F;";
-        let mut code_font = font(MONO_FAMILY);
+        let mut code_font = font(crate::fonts::mono());
         code_font.weight = FontWeight::NORMAL;
         let highlighted = code_runs(code, Some(Lang::Script), &code_font, &palette());
         let plain = code_runs(code, None, &code_font, &palette());

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -453,33 +453,43 @@ fn reveal_offset(
     container_y: Pixels,
     center: bool,
 ) -> Option<Pixels> {
-    let item_y = *tops.get(&index)? - container_y + offset_now;
-    // Item height from its next sibling's recorded top; the last item (or a
-    // gap in the map) falls back to a typical row height.
+    // GPUI scroll convention: offset is negative (0 = top, -N = scrolled down).
+    // Convert recorded absolute tops to content-space coordinates.
+    let item_y = *tops.get(&index)? - container_y;
     let item_height = tops
         .get(&(index + 1))
         .map(|next| (*next - tops[&index]).max(px(1.0)))
         .unwrap_or_else(|| px(28.0));
+    // Content height: bottom of the lowest recorded item.
     let content_bottom = tops
         .iter()
         .map(|(i, top)| {
             let height = tops.get(&(i + 1)).map(|next| *next - *top).unwrap_or(item_height);
-            (*top - container_y + offset_now) + height
+            (*top - container_y) + height
         })
         .fold(px(0.0), Pixels::max);
-    let max_offset = (content_bottom - viewport).max(px(0.0));
+    let max_scroll = (content_bottom - viewport).max(px(0.0));
 
     const MARGIN: f32 = 4.0;
+    // offset_now is negative; visible range is [-offset_now, -offset_now + viewport].
+    let visible_top = -offset_now;
+    let visible_bottom = visible_top + viewport;
+
     let target = if center {
+        // Center the item in the viewport.
         item_y - (viewport - item_height) / 2.0
-    } else if item_y < offset_now + px(MARGIN) {
+    } else if item_y < visible_top + px(MARGIN) {
+        // Item above viewport; scroll up to reveal it with margin.
         item_y - px(MARGIN)
-    } else if item_y + item_height > offset_now + viewport - px(MARGIN) {
+    } else if item_y + item_height > visible_bottom - px(MARGIN) {
+        // Item below viewport; scroll down to reveal it with margin.
         item_y + item_height - viewport + px(MARGIN)
     } else {
+        // Already visible; no adjustment needed.
         return None;
     };
-    Some(target.clamp(px(0.0), max_offset))
+    // Clamp to valid scroll range and negate for GPUI convention.
+    Some(-target.clamp(px(0.0), max_scroll))
 }
 
 /// Where a dropdown's card sits relative to its trigger.
@@ -1144,9 +1154,9 @@ impl RenderOnce for MenuCard {
                         }
                     },
                     move |_, (), window, _| {
-                        if let Some(target) = applied_target.take() {
-                            let current = paint_scroll.offset().y;
-                            paint_scroll.set_offset(point(current, target));
+                        if let Some(target_y) = applied_target.take() {
+                            let current_x = paint_scroll.offset().x;
+                            paint_scroll.set_offset(point(current_x, target_y));
                             // Consume the request so a later hover re-render
                             // cannot yank the list back after manual scrolling.
                             paint_handle.state.borrow_mut().pending_reveal = None;

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -436,6 +436,80 @@ fn trigger_bounds_probe(handle: &ContextMenuHandle) -> impl IntoElement {
     .inset_0()
 }
 
+#[cfg(test)]
+mod reveal_offset_tests {
+    use super::*;
+
+    /// A five-row list, each row exactly 30px tall, recorded in frame space
+    /// with the container top at 100px.
+    fn five_rows() -> HashMap<usize, Pixels> {
+        (0..5)
+            .map(|i| (i, px(100.0 + 30.0 * i as f32)))
+            .collect()
+    }
+
+    #[test]
+    fn reveal_returns_none_when_item_is_visible() {
+        // Viewport 90px, offset 0 (GPUI negative convention): rows 0-2 visible.
+        assert_eq!(
+            reveal_offset(&five_rows(), 1, px(0.0), px(90.0), px(100.0), false),
+            None
+        );
+    }
+
+    #[test]
+    fn reveal_scrolls_down_with_negative_offset_when_item_is_below() {
+        // Row 4 (content y 120, height falls back to 28 since no row 5 is
+        // recorded) is below a 90px viewport at offset 0. Raw nudge target
+        // is 120+28-90+4 = 62, clamped to max_scroll = 148-90 = 58.
+        assert_eq!(
+            reveal_offset(&five_rows(), 4, px(0.0), px(90.0), px(100.0), false),
+            Some(px(-58.0))
+        );
+    }
+
+    #[test]
+    fn reveal_scrolls_up_when_item_is_above_the_viewport() {
+        // Scrolled to the bottom (offset -60, visible 60-150): row 0 (y 0-30)
+        // is above. Nudge up to y - margin → -4, clamped to 0.
+        assert_eq!(
+            reveal_offset(&five_rows(), 0, px(-60.0), px(90.0), px(100.0), false),
+            Some(px(0.0))
+        );
+    }
+
+    #[test]
+    fn reveal_centers_the_item_when_asked() {
+        // Viewport 90px, row 2 (y 60-90): centered target = 60 - (90-30)/2 = 30.
+        assert_eq!(
+            reveal_offset(&five_rows(), 2, px(0.0), px(90.0), px(100.0), true),
+            Some(px(-30.0))
+        );
+    }
+
+    #[test]
+    fn reveal_clamps_centering_to_the_scrollable_range() {
+        // Centering row 0 would want a negative scroll; clamps to 0 (offset 0).
+        assert_eq!(
+            reveal_offset(&five_rows(), 0, px(0.0), px(90.0), px(100.0), true),
+            Some(px(0.0))
+        );
+        // Centering row 4 wants 120-(90-28)/2 = 89 > max_scroll 58; clamps.
+        assert_eq!(
+            reveal_offset(&five_rows(), 4, px(0.0), px(90.0), px(100.0), true),
+            Some(px(-58.0))
+        );
+    }
+
+    #[test]
+    fn reveal_returns_none_for_an_unrecorded_index() {
+        assert_eq!(
+            reveal_offset(&five_rows(), 99, px(0.0), px(90.0), px(100.0), true),
+            None
+        );
+    }
+}
+
 /// The content-space scroll offset that brings `index` into view.
 ///
 /// `tops` holds each item's absolute frame-space top edge as recorded by the

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -29,9 +29,10 @@ use std::rc::Rc;
 use gpui::{
     AnyElement, App, Bounds, Display, Element, ElementId, FocusHandle, FontWeight, GlobalElementId,
     InspectorElementId, InteractiveElement, IntoElement, KeyDownEvent, LayoutId, MouseButton,
-    MouseDownEvent, ParentElement, Pixels, Point, Position, RenderOnce, SharedString, Size, Style,
+    MouseDownEvent, ParentElement, Pixels, Point, Position, RenderOnce, ScrollHandle,
+    SharedString, Size, Style,
     StatefulInteractiveElement, Styled, Window, actions, anchored, canvas, deferred, div, img,
-    prelude::FluentBuilder, px,
+    prelude::FluentBuilder, point, px,
 };
 
 actions!(
@@ -224,6 +225,9 @@ struct MenuState {
     submenu_highlighted: Option<usize>,
     /// Whether arrow-key navigation currently belongs to the flyout.
     submenu_focused: bool,
+    /// Scroll position of the card's item list, kept on the handle so the
+    /// list survives hover-highlight re-renders and resets when reopened.
+    card_scroll: ScrollHandle,
     /// A dropdown/popover trigger toggles its own surface on left click. The
     /// outside-click capture must leave that click alone so the later trigger
     /// handler can close it; a context-menu row has no such handler.
@@ -351,6 +355,7 @@ impl ContextMenuHandle {
             state.submenu_highlighted = None;
             state.submenu_focused = false;
             state.trigger_click_toggles = trigger_click_toggles;
+            state.card_scroll.set_offset(point(Pixels::ZERO, Pixels::ZERO));
             was_open
         };
         if !was_open {
@@ -954,6 +959,7 @@ impl RenderOnce for MenuCard {
                 state.submenu_highlighted,
             )
         };
+        let scroll = self.handle.state.borrow().card_scroll.clone();
         let submenu = active_submenu.and_then(|index| {
             let MenuItem::Submenu { items, .. } = items.get(index)? else {
                 return None;
@@ -961,6 +967,7 @@ impl RenderOnce for MenuCard {
             Some((index, items(cx)))
         });
 
+        let items_id = SharedString::from(format!("{}-items", self.id));
         let mut root_card = div()
             .id(self.id)
             .min_w(px(176.0))
@@ -974,8 +981,21 @@ impl RenderOnce for MenuCard {
             .flex()
             .flex_col();
 
+        // A menu can hold hundreds of entries (e.g. a system font picker).
+        // Cap the list to the viewport so the card never outgrows the
+        // window, and let it scroll; the handle lives on the shared state so
+        // the offset survives hover-highlight re-renders of this card.
+        let max_list_height = (window.viewport_size().height - px(48.0)).max(px(120.0));
+        let mut items_card = div()
+            .id(items_id)
+            .max_h(max_list_height)
+            .overflow_y_scroll()
+            .track_scroll(&scroll)
+            .flex()
+            .flex_col();
+
         for (index, item) in items.into_iter().enumerate() {
-            root_card = root_card.child(render_menu_item(
+            items_card = items_card.child(render_menu_item(
                 item,
                 index,
                 highlighted == Some(index) || active_submenu == Some(index),
@@ -986,6 +1006,8 @@ impl RenderOnce for MenuCard {
                 cx,
             ));
         }
+
+        root_card = root_card.child(items_card);
 
         let mut surface = div()
             .occlude()

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -24,6 +24,7 @@
 //!   menu at all.
 
 use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use gpui::{
@@ -199,6 +200,13 @@ impl MenuItem {
         }
     }
 
+    /// Whether this entry presents itself as the current choice. The first
+    /// such entry seeds the keyboard cursor when the menu opens, so a long
+    /// list can be revealed centered on where the choice actually lives.
+    fn is_selected(&self) -> bool {
+        matches!(self, Self::Entry { selected: true, .. })
+    }
+
     fn click_handler(self) -> Option<Rc<dyn Fn(&mut Window, &mut App)>> {
         match self {
             Self::Entry {
@@ -228,6 +236,16 @@ struct MenuState {
     /// Scroll position of the card's item list, kept on the handle so the
     /// list survives hover-highlight re-renders and resets when reopened.
     card_scroll: ScrollHandle,
+    /// Paint-frame record of every item's absolute top edge, so a target
+    /// index can be converted into a content-space scroll offset.
+    item_tops: Rc<RefCell<HashMap<usize, Pixels>>>,
+    /// Absolute bounds of the scrolling list box in the current frame.
+    container_bounds: Rc<Cell<Option<Bounds<Pixels>>>>,
+    /// Item to bring into view on the next frame. The flag centers it
+    /// (opening onto the current selection) or nudges minimally (arrow keys).
+    pending_reveal: Option<(usize, bool)>,
+    /// Whether the open-with-selection reveal already ran for this cycle.
+    did_initial_reveal: bool,
     /// A dropdown/popover trigger toggles its own surface on left click. The
     /// outside-click capture must leave that click alone so the later trigger
     /// handler can close it; a context-menu row has no such handler.
@@ -356,6 +374,7 @@ impl ContextMenuHandle {
             state.submenu_focused = false;
             state.trigger_click_toggles = trigger_click_toggles;
             state.card_scroll.set_offset(point(Pixels::ZERO, Pixels::ZERO));
+            state.did_initial_reveal = false;
             was_open
         };
         if !was_open {
@@ -415,6 +434,52 @@ fn trigger_bounds_probe(handle: &ContextMenuHandle) -> impl IntoElement {
     )
     .absolute()
     .inset_0()
+}
+
+/// The content-space scroll offset that brings `index` into view.
+///
+/// `tops` holds each item's absolute frame-space top edge as recorded by the
+/// layout probes; `container_y` is the list box's own absolute top, so an
+/// item's content-space position is `tops[index] - container_y + offset_now`.
+/// With `center`, the item lands mid-viewport (used when opening onto the
+/// current selection); otherwise the view only moves far enough to pull the
+/// item inside a small margin, preserving the reader's position for small
+/// arrow-key steps. Returns `None` when no movement is needed.
+fn reveal_offset(
+    tops: &HashMap<usize, Pixels>,
+    index: usize,
+    offset_now: Pixels,
+    viewport: Pixels,
+    container_y: Pixels,
+    center: bool,
+) -> Option<Pixels> {
+    let item_y = *tops.get(&index)? - container_y + offset_now;
+    // Item height from its next sibling's recorded top; the last item (or a
+    // gap in the map) falls back to a typical row height.
+    let item_height = tops
+        .get(&(index + 1))
+        .map(|next| (*next - tops[&index]).max(px(1.0)))
+        .unwrap_or_else(|| px(28.0));
+    let content_bottom = tops
+        .iter()
+        .map(|(i, top)| {
+            let height = tops.get(&(i + 1)).map(|next| *next - *top).unwrap_or(item_height);
+            (*top - container_y + offset_now) + height
+        })
+        .fold(px(0.0), Pixels::max);
+    let max_offset = (content_bottom - viewport).max(px(0.0));
+
+    const MARGIN: f32 = 4.0;
+    let target = if center {
+        item_y - (viewport - item_height) / 2.0
+    } else if item_y < offset_now + px(MARGIN) {
+        item_y - px(MARGIN)
+    } else if item_y + item_height > offset_now + viewport - px(MARGIN) {
+        item_y + item_height - viewport + px(MARGIN)
+    } else {
+        return None;
+    };
+    Some(target.clamp(px(0.0), max_offset))
 }
 
 /// Where a dropdown's card sits relative to its trigger.
@@ -960,6 +1025,20 @@ impl RenderOnce for MenuCard {
             )
         };
         let scroll = self.handle.state.borrow().card_scroll.clone();
+
+        // Opening onto a menu whose entries carry a current selection: start
+        // the keyboard cursor there and center the list on it, so a font
+        // picker with hundreds of entries opens where the choice lives.
+        {
+            let mut state = self.handle.state.borrow_mut();
+            if !state.did_initial_reveal {
+                if let Some(index) = items.iter().position(|item| item.is_selected()) {
+                    state.highlighted = Some(index);
+                    state.pending_reveal = Some((index, true));
+                }
+                state.did_initial_reveal = true;
+            }
+        }
         let submenu = active_submenu.and_then(|index| {
             let MenuItem::Submenu { items, .. } = items.get(index)? else {
                 return None;
@@ -986,8 +1065,17 @@ impl RenderOnce for MenuCard {
         // window, and let it scroll; the handle lives on the shared state so
         // the offset survives hover-highlight re-renders of this card.
         let max_list_height = (window.viewport_size().height - px(48.0)).max(px(120.0));
+        let (item_tops, container_bounds, pending_reveal) = {
+            let state = self.handle.state.borrow();
+            (
+                state.item_tops.clone(),
+                state.container_bounds.clone(),
+                state.pending_reveal,
+            )
+        };
         let mut items_card = div()
             .id(items_id)
+            .relative()
             .max_h(max_list_height)
             .overflow_y_scroll()
             .track_scroll(&scroll)
@@ -995,16 +1083,80 @@ impl RenderOnce for MenuCard {
             .flex_col();
 
         for (index, item) in items.into_iter().enumerate() {
-            items_card = items_card.child(render_menu_item(
-                item,
-                index,
-                highlighted == Some(index) || active_submenu == Some(index),
-                false,
-                &theme,
-                self.handle.clone(),
-                window,
-                cx,
-            ));
+            let tops = item_tops.clone();
+            items_card = items_card.child(
+                div()
+                    .relative()
+                    // Zero-cost probe: record this item's absolute top edge
+                    // during layout so scroll-to-reveal can map index → y.
+                    .child(
+                        canvas(
+                            move |bounds: Bounds<Pixels>, _, _| {
+                                tops.borrow_mut().insert(index, bounds.origin.y);
+                            },
+                            |_, _, _, _| (),
+                        )
+                        .absolute()
+                        .inset_0(),
+                    )
+                    .child(render_menu_item(
+                        item,
+                        index,
+                        highlighted == Some(index) || active_submenu == Some(index),
+                        false,
+                        &theme,
+                        self.handle.clone(),
+                        window,
+                        cx,
+                    )),
+            );
+        }
+
+        // Runs its layout callback after every sibling above has laid out,
+        // so all probes have recorded. Computes the reveal target from the
+        // recorded geometry; the paint callback applies the offset and asks
+        // for one more frame when it moved.
+        let applied_target: Rc<Cell<Option<Pixels>>> = Rc::new(Cell::new(None));
+        {
+            let prepaint_scroll = scroll.clone();
+            let paint_scroll = scroll.clone();
+            let container_bounds = container_bounds.clone();
+            let prepaint_applied = applied_target.clone();
+            let paint_handle = self.handle.clone();
+            items_card = items_card.child(
+                canvas(
+                    move |bounds: Bounds<Pixels>, _, _| {
+                        container_bounds.set(Some(bounds));
+                        let Some((index, center)) = pending_reveal else {
+                            return;
+                        };
+                        let offset_now = prepaint_scroll.offset().y;
+                        if let Some(target) = reveal_offset(
+                            &item_tops.borrow(),
+                            index,
+                            offset_now,
+                            bounds.size.height,
+                            bounds.origin.y,
+                            center,
+                        ) && (target - offset_now).abs() > px(0.5)
+                        {
+                            prepaint_applied.set(Some(target));
+                        }
+                    },
+                    move |_, (), window, _| {
+                        if let Some(target) = applied_target.take() {
+                            let current = paint_scroll.offset().y;
+                            paint_scroll.set_offset(point(current, target));
+                            // Consume the request so a later hover re-render
+                            // cannot yank the list back after manual scrolling.
+                            paint_handle.state.borrow_mut().pending_reveal = None;
+                            window.refresh();
+                        }
+                    },
+                )
+                .absolute()
+                .inset_0(),
+            );
         }
 
         root_card = root_card.child(items_card);
@@ -1390,6 +1542,8 @@ fn on_menu_key(
         state.active_submenu = None;
         state.submenu_highlighted = None;
         state.submenu_focused = false;
+        state.pending_reveal = Some((next, false));
+        drop(state);
         window.refresh();
         cx.stop_propagation();
         return;


### PR DESCRIPTION
### Summary

Adds UI and code font family selection to Appearance settings, while improving long-menu scrolling, keyboard navigation, and selection reveal behavior.

### Changes

- Added configurable UI and monospace font families.
- Persisted font selections with backward compatibility.
- Applied selected fonts to Markdown, code blocks, tool output, diffs, editors, and related surfaces.
- Added immediate refresh and layout remeasurement after font changes.
- Added bounded, vertically scrollable menus for long lists.
- Revealed the current selection when opening a menu.
- Added automatic scrolling during arrow-key navigation.
- Fixed GPUI menu scroll offset direction.
- Serialized global font-state tests.
- Added menu scroll and selection-reveal tests.

### Notes

Like the settings of other items on the appearance settings, font settings are published through immutable `AtomicPtr` snapshots too. Render paths perform only atomic reads and do not wait on locks. Old snapshots remain allocated for the lifetime of the process, trading a small amount of memory for lock-free rendering reads.