### PR TITLE
Prevent multiline tool titles from overlapping activity details

### DIFF
--- a/apps/web/src/lib/transcript-presentation.test.ts
+++ b/apps/web/src/lib/transcript-presentation.test.ts
@@ -75,6 +75,10 @@ describe('desktop transcript language', () => {
       ...activity('tool', true),
       title: 'Tool',
     }
+    const multiline = {
+      ...activity('tool', true),
+      title: "set -euo pipefail\necho 'first'\n\techo 'second'",
+    }
 
     expect(activityActionLabel(named)).toBe('Tool')
     expect(activityRowDetail(named)).toBe('Create thread')
@@ -84,6 +88,8 @@ describe('desktop transcript language', () => {
     expect(activityActionLabel(question)).toBe('Ask questions')
     expect(activityRowDetail(question)).toBe('')
     expect(activityDisplayTitle(question)).toBe('Ask questions')
+    expect(activityRowDetail(multiline)).toBe("set -euo pipefail echo 'first' echo 'second'")
+    expect(activityDisplayTitle(multiline)).toBe("set -euo pipefail echo 'first' echo 'second'")
   })
 
   test('derives the same provider-neutral activity titles as desktop', () => {

--- a/apps/web/src/lib/transcript-presentation.ts
+++ b/apps/web/src/lib/transcript-presentation.ts
@@ -589,7 +589,7 @@ function isAskUserQuestion(activity: ActivityItem) {
 
 function humanizeToolName(name: string) {
   const trimmed = name.trim()
-  if (/\s/.test(trimmed)) return trimmed
+  if (/\s/.test(trimmed)) return trimmed.replace(/\s+/g, ' ')
   const display = toolNameLeaf(trimmed)
     .replace(/[_-]+/g, ' ')
     .replace(/([a-z\d])([A-Z])/g, '$1 $2')

--- a/src/app/components.rs
+++ b/src/app/components.rs
@@ -958,7 +958,14 @@ fn is_ask_user_question(activity: &ActivityItem) -> bool {
 fn humanize_tool_name(name: &str) -> String {
     let name = name.trim();
     if name.chars().any(char::is_whitespace) {
-        return name.to_owned();
+        let mut display = String::with_capacity(name.len());
+        for word in name.split_whitespace() {
+            if !display.is_empty() {
+                display.push(' ');
+            }
+            display.push_str(word);
+        }
+        return display;
     }
 
     let leaf = tool_name_leaf(name);
@@ -1631,6 +1638,26 @@ mod message_time_tests {
         assert_eq!(activity_display_title(&named), "Create thread");
         assert_eq!(activity_action_label(&unnamed), "Tool");
         assert_eq!(activity_row_detail(&unnamed, false), "");
+    }
+
+    #[test]
+    fn generic_tool_rows_collapse_multiline_provider_names() {
+        let activity = ActivityItem::new(
+            Some("tool-1".into()),
+            crate::model::ActivityKind::Tool,
+            "set -euo pipefail\necho 'first'\n\techo 'second'",
+            None,
+            true,
+        );
+
+        assert_eq!(
+            activity_row_detail(&activity, false),
+            "set -euo pipefail echo 'first' echo 'second'"
+        );
+        assert_eq!(
+            activity_display_title(&activity),
+            "set -euo pipefail echo 'first' echo 'second'"
+        );
     }
 
     #[test]

--- a/src/app/transcript_view.rs
+++ b/src/app/transcript_view.rs
@@ -1905,6 +1905,8 @@ impl Waku {
                     .w_full()
                     .min_w_0()
                     .h(px(26.0))
+                    .flex_none()
+                    .overflow_hidden()
                     .flex()
                     .items_center()
                     .gap(px(6.0))
@@ -2062,6 +2064,8 @@ impl Waku {
                         // The parent owns a 1px border on each edge, so a
                         // 28px row makes the visible activity header 30px.
                         .h(px(28.0))
+                        .flex_none()
+                        .overflow_hidden()
                         .px(px(8.0))
                         .flex()
                         .items_center()


### PR DESCRIPTION
## Problem

Some providers can replace a tool's short display title with the complete command when the tool finishes. When that command contains newlines or tabs, Waku kept the whitespace-containing title verbatim.

Activity headers have a fixed height, but the title content was not constrained to that header. Collapsed cards happened to hide the overflow; expanding a card made the multiline title paint over the Arguments and Output sections.

## Solution

- Collapse whitespace runs in provider-supplied, human-readable tool names to a single space. This only changes the display title; the original activity payload, arguments, and output remain untouched.
- Keep both grouped and individual activity headers fixed and clipped so malformed provider labels cannot escape into adjacent content.
- Apply the same title normalization to the web transcript presentation and add regression coverage for newline/tab input.

## Verification

- `cargo test --package waku generic_tool_rows_collapse_multiline_provider_names --locked`
- `bun test apps/web/src/lib/transcript-presentation.test.ts`
- `bun run --filter @waku/web typecheck`
- Manually verified in `Waku Debug.app` with the persisted session that originally reproduced the overlap.
