### PR TITLE
fix(app): buffer live thinking text by default

### DIFF
--- a/crates/waku-client/src/persistence.rs
+++ b/crates/waku-client/src/persistence.rs
@@ -62,6 +62,11 @@ fn default_computer_use_enabled() -> bool {
     false
 }
 
+fn default_stream_thinking_live() -> bool {
+    // T3 Code parity: buffered by default (`enableLegacyTokenStreaming: false`).
+    false
+}
+
 fn default_ui_font_size() -> f32 {
     DEFAULT_UI_FONT_SIZE
 }
@@ -388,6 +393,12 @@ pub struct PersistedState {
     /// instead of source. One global mode, not per file.
     #[serde(default)]
     pub markdown_preview: bool,
+    /// Whether the live reasoning peek renders growing thinking text.
+    /// Some providers (e.g. GLM via OpenRouter) emit line-delimited reasoning
+    /// deltas whose joined text renders one token per line, which reads as
+    /// garbage mid-stream; buffering hides it until the block completes.
+    #[serde(default = "default_stream_thinking_live")]
+    pub stream_thinking_live: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub window_state: Option<PersistedWindowState>,
     #[serde(default = "default_computer_use_enabled")]
@@ -450,6 +461,7 @@ impl PersistedState {
             sidebar_ordering: SidebarOrdering::Newest,
             right_panel_width: DEFAULT_RIGHT_PANEL_WIDTH,
             markdown_preview: false,
+            stream_thinking_live: false,
             window_state: None,
             computer_use_enabled: false,
             computer_use_allowed_apps: Vec::new(),

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -337,6 +337,10 @@ settings.local_by_default_description:
   en: Projects, conversations, and settings are stored on this computer
 settings.local_by_default_web_description:
   en: Projects, conversations, and attachments stay on the connected daemon host. Waku Web preferences stay in this browser.
+settings.stream_thinking:
+  en: Legacy token streaming
+settings.stream_thinking_description:
+  en: Stream the model's reasoning text token by token while it thinks. When off, thinking appears once the model finishes.
 settings.automatic_updates:
   en: Automatic updates
 settings.automatic_updates_description:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -172,6 +172,8 @@ common.creating: 作成中…
 settings.local_by_default: デフォルトでローカルに保存
 settings.local_by_default_description: プロジェクト、会話、設定はこのコンピュータに保存されます
 settings.local_by_default_web_description: プロジェクト、会話、添付ファイルは接続先デーモンのホストに保存されます。Waku Web の設定はこのブラウザに保存されます。
+settings.stream_thinking: レガシートークンストリーミング
+settings.stream_thinking_description: モデルの思考テキストをトークン単位でリアルタイム表示します。オフの場合、思考内容はモデルの思考完了後に表示されます。
 settings.automatic_updates: 自動アップデート
 settings.automatic_updates_description: バックグラウンドで新しいバージョンを確認し、インストールを案内します
 settings.share_anonymous_usage_data: 匿名の使用状況データを共有

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -165,6 +165,8 @@ common.creating: 正在创建…
 settings.local_by_default: 默认存储在本地
 settings.local_by_default_description: 项目、对话和设置均存储在这台电脑上
 settings.local_by_default_web_description: 项目、对话和附件保留在所连接的守护进程主机上。Waku Web 的偏好设置保留在此浏览器中。
+settings.stream_thinking: 旧版逐字流式显示
+settings.stream_thinking_description: 在模型思考时逐字显示其推理文本。关闭时，思考内容会在模型思考完成后一次性显示。
 settings.automatic_updates: 自动更新
 settings.automatic_updates_description: 在后台检查新版本，并在发现更新时提示安装
 settings.share_anonymous_usage_data: 分享匿名使用数据

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -437,6 +437,15 @@ impl Waku {
             cx,
             move |this, _, cx| this.set_analytics_enabled(!analytics_enabled, cx),
         );
+        let stream_thinking_live = self.state.stream_thinking_live;
+        let stream_thinking_toggle = toggle_switch(
+            "stream-thinking-toggle",
+            stream_thinking_live,
+            false,
+            theme,
+            cx,
+            move |this, _, cx| this.set_stream_thinking_live(!stream_thinking_live, cx),
+        );
         div()
             .child(
                 div()
@@ -496,6 +505,40 @@ impl Waku {
                     )
                     .child(analytics_toggle),
             )
+            .child(
+                div()
+                    .mt(px(15.0))
+                    .w_full()
+                    .min_h(px(60.0))
+                    .px(px(20.0))
+                    .py(px(12.0))
+                    .rounded(px(13.0))
+                    .bg(theme.raised)
+                    .flex()
+                    .items_center()
+                    .gap(px(24.0))
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .child(
+                                div()
+                                    .text_size(sp(13.5))
+                                    .font_weight(FontWeight::MEDIUM)
+                                    .text_color(theme.text)
+                                    .child(tr!("settings.stream_thinking")),
+                            )
+                            .child(
+                                div()
+                                    .mt(px(5.0))
+                                    .text_size(sp(12.5))
+                                    .line_height(sp(18.0))
+                                    .text_color(theme.text_secondary)
+                                    .child(tr!("settings.stream_thinking_description")),
+                            ),
+                    )
+                    .child(stream_thinking_toggle),
+            )
             .when(updater_available, |column| {
                 let enabled = self.automatic_updates_enabled;
                 let toggle = toggle_switch(
@@ -547,6 +590,12 @@ impl Waku {
     fn set_analytics_enabled(&mut self, enabled: bool, cx: &mut Context<Self>) {
         self.state.analytics_enabled = enabled;
         self.analytics.set_enabled(enabled);
+        self.save();
+        cx.notify();
+    }
+
+    fn set_stream_thinking_live(&mut self, enabled: bool, cx: &mut Context<Self>) {
+        self.state.stream_thinking_live = enabled;
         self.save();
         cx.notify();
     }

--- a/src/app/transcript_view.rs
+++ b/src/app/transcript_view.rs
@@ -2156,7 +2156,12 @@ impl Waku {
                             }
                         })),
                 );
-            if item_expanded && let Some(reasoning) = reasoning {
+            if item_expanded
+                && let Some(reasoning) = reasoning
+                // Buffered thinking: while the block is live, only the header
+                // shows; the full text renders once the block settles.
+                && (!reasoning_live || self.state.stream_thinking_live)
+            {
                 // Reasoning remains model prose even though it now shares the
                 // activity stream, so keep selectable markdown rather than
                 // presenting it as monospace tool output.


### PR DESCRIPTION
## Problem

While a reasoning ("Think / Thinking") block streams, the thinking text could render as **one token per line** — each streamed chunk landed on its own line (or its own paragraph, with visible gaps) instead of flowing as continuous prose. It looked intermittent: some turns streamed cleanly.

## Root cause

Some providers emit **line-delimited reasoning deltas**. Verified against a raw provider stream (GLM `z-ai/glm-5.3-flash` via OpenRouter): the reasoning events alternate between a text chunk and a newline-only chunk:

```json
["The", "\n", " tracking", "\n", " got", "\n", " set", "\n", " to", "\n", " upstream", "\n", "/main", "\n"]
```

Worse turns accumulate `\n\n` / `\n\n\n` between tokens; clean turns have none — which explains the intermittency. Nothing injects the newlines client-side (the openai-completions path forwards thinking deltas verbatim); they are already in the provider stream.

Since text elements render literal `\n` as line breaks (and `\n\n` parses as a paragraph break), the joined text displays exactly as received: one token per line.

## Solution

Buffer the live reasoning peek by default, matching T3 Code's approach for the same class of streaming noise (`enableLegacyTokenStreaming: false` — buffered delivery):

- While a reasoning block is live, the expanded card shows only its header; the full markdown renders once the block settles. The "Thinking…" header + pulse already communicate live progress, so nothing is lost.
- A new persisted **"Legacy token streaming"** setting (`stream_thinking_live`, default **off**, General page) restores live token-by-token rendering for those who prefer it — mirroring the T3 Code naming for the same behavior.
- Existing state files decode to the new buffered default via serde default; no migration needed.

Screenshots of the broken mid-stream render (one token per line, and the paragraph-gap variant) are easy to reproduce by streaming a session with GLM via OpenRouter; happy to attach if useful.

## Checks

- `cargo fmt --package waku --package waku-protocol --package waku-client --package waku-core --package waku-daemon -- --check` — clean for all touched files (note: `main` currently has pre-existing fmt drift in unrelated files, so a repo-wide `--check` does not pass on a pristine checkout either; CI does not gate on fmt)
- `cargo +1.96.0 test --locked` — all green (358 + 10 + 19 + 354 + 3 + 57 tests across crates, 0 failed)
- `bun run protocol:check` — passed (no wire types changed)
- `bun run --filter @waku/client check` — passed
- `bun run --filter @waku/client test` — passed
- Manually validated in the freshly rebuilt debug app: toggle on = old streaming behavior, off (default) = header-only while streaming, full render on settle

## Limitations / follow-ups

- The provider artifact itself (newline-only delta chunks) is untouched; this only hides it from the live view. Settled thinking text from affected providers still contains the stray newlines in source (single `\n` renders as line breaks per the existing soft-break behavior).
- `#191` tracks the root cause.

Fixes #191
