### PR TITLE
Fix right-panel chooser clipping at larger UI font sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unreleased]
 
+- Fix right-panel surface chooser cards clipping their descriptions when the UI font size is increased
+
 ## 0.1.16
 
 - Import and continue conversations started in agent CLIs with `/resume` or the command palette across every provider, in both Waku and Waku Web

--- a/src/app/right_panel.rs
+++ b/src/app/right_panel.rs
@@ -1616,6 +1616,42 @@ mod tests {
         );
     }
 
+    /// Chooser cards mix chrome text (`sp`) with a fitted 112-unit stack.
+    /// Height, padding, and the gaps between icon/title/description have to
+    /// be rem-authored too: a `px` height stays 112px while the UI font size
+    /// setting scales the copy, and the second description line clips to a
+    /// sliver of glyphs.
+    #[test]
+    fn right_panel_chooser_cards_scale_with_ui_font_size() {
+        let source = include_str!("right_panel.rs");
+        let chooser = source
+            .split_once("\n    fn render_right_panel_chooser(")
+            .expect("right panel chooser renderer")
+            .1
+            .split_once("\n    fn render_right_panel_files(")
+            .expect("right panel chooser renderer end")
+            .0;
+
+        assert!(chooser.contains(".max_w(sp(420.0))"));
+        assert!(!chooser.contains(".max_w(px(420.0))"));
+
+        let card = source
+            .split_once("\n    fn render_right_panel_card(")
+            .expect("right panel chooser card renderer")
+            .1
+            .split_once("\n    fn render_right_panel_files(")
+            .expect("right panel chooser card renderer end")
+            .0;
+
+        assert!(card.contains(".h(sp(112.0))"));
+        assert!(!card.contains(".h(px(112.0))"));
+        assert!(card.contains(".p(sp(14.0))"));
+        assert!(card.contains(".mt(sp(12.0))"));
+        assert!(card.contains(".mt(sp(4.0))"));
+        assert!(card.contains(".text_size(sp(12.5))"));
+        assert!(card.contains(".line_height(sp(15.0))"));
+    }
+
     #[test]
     fn only_reuses_single_instance_surface_tabs() {
         let browser = RightPanelSurface::new_browser();
@@ -2586,7 +2622,7 @@ impl Waku {
             .child(
                 div()
                     .w_full()
-                    .max_w(px(420.0))
+                    .max_w(sp(420.0))
                     .flex()
                     .flex_col()
                     .items_center()
@@ -2655,10 +2691,10 @@ impl Waku {
                 "right-panel-card-{}",
                 label.to_lowercase()
             )))
-            .h(px(112.0))
+            .h(sp(112.0))
             .flex_1()
             .min_w_0()
-            .p(px(14.0))
+            .p(sp(14.0))
             .rounded(px(8.0))
             .border_1()
             .border_color(theme.border_strong)
@@ -2672,7 +2708,9 @@ impl Waku {
             .child(icon(icon_path, 18.0, theme.text_secondary))
             .child(
                 div()
-                    .mt(px(12.0))
+                    .mt(sp(12.0))
+                    .w_full()
+                    .min_w_0()
                     .text_size(sp(12.5))
                     .font_weight(FontWeight::MEDIUM)
                     .text_color(theme.text)
@@ -2680,7 +2718,9 @@ impl Waku {
             )
             .child(
                 div()
-                    .mt(px(4.0))
+                    .mt(sp(4.0))
+                    .w_full()
+                    .min_w_0()
                     .text_size(sp(12.5))
                     .line_height(sp(15.0))
                     .text_color(theme.text_tertiary)


### PR DESCRIPTION
## Problem

Increasing the UI font size setting scales chrome text and icons through `sp()` (rems whose window rem size is the setting). The right-panel surface chooser cards kept a fitted `px(112)` height and `px` padding, so at 16–20px the second description line was clipped to a sliver of glyphs:

| Terminal | Files |
| --- | --- |
| "Start a shell in this" + leftover dots | "Browse and read" + leftover dots |

Before (reported at a larger UI font size):

<img src="https://raw.githubusercontent.com/kotuke/waku/screenshots-right-panel-chooser/docs/pr/chooser-before.png" alt="Chooser cards with clipped Terminal and Files descriptions" width="520" />

## Solution

Author the chooser card stack in `sp()` so height, padding, and the icon/title/description gaps scale with the UI font size. The 2×2 max width also uses `sp()`, and title/description get `w_full()` / `min_w_0()` so wrapping uses the card width.

At default 14px this still resolves to the authored 112px. At 20px the second line is fully visible.

After (Waku Debug, UI font size **20px**):

<img src="https://raw.githubusercontent.com/kotuke/waku/screenshots-right-panel-chooser/docs/pr/chooser-after-20px.png" alt="Chooser cards at 20px with fully visible wrapped descriptions" width="520" />

Full window:

<img src="https://raw.githubusercontent.com/kotuke/waku/screenshots-right-panel-chooser/docs/pr/chooser-after-window-20px.png" alt="Waku Debug window with right-panel chooser at 20px" width="720" />

## Checks

- `cargo check --package waku`
- `cargo test --lib right_panel` (22 passed, including `right_panel_chooser_cards_scale_with_ui_font_size`)
- Visual check in `Waku Debug.app` with UI font size 20px (light theme)

Did not run the full CONTRIBUTING baseline (`protocol:check`, `@waku/client` tests). This change is desktop UI only.

## Notes

I did not reformat unrelated `rustfmt` diffs in `right_panel.rs`; the repo is not clean under the local rustfmt for the subscribe block around the file-editor focus handler.