### PR TITLE
Add reasoning effort selection for OpenCode models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ the original feature bullet instead of adding separate entries for them.
 
 ## [unreleased]
 
+- Add reasoning effort selection for OpenCode models, with an explicit Default option for the base model; switching model or effort now applies to the live session without restarting it
+
 ## [0.1.17]
 
 - Fix the OpenCode Resume list showing only sessions started outside a git checkout; it now lists sessions from every project

--- a/crates/waku-core/src/driver/opencode.rs
+++ b/crates/waku-core/src/driver/opencode.rs
@@ -41,6 +41,7 @@ enum CommandMessage {
     Prompt(String),
     Steer(String),
     Cancel,
+    Options(SessionOptions),
     Respond {
         request_id: String,
         option_id: String,
@@ -53,8 +54,10 @@ enum CommandMessage {
 }
 
 /// The prompt body both turn starts and steers post; the model rides on every
-/// prompt because the server has no session-level model setting.
-fn prompt_body(text: &str, model: Option<&str>, agent: &str) -> Value {
+/// prompt because the server has no session-level model setting. The variant
+/// rides alongside it as the top-level `variant` field (`PromptInput`), which
+/// is how OpenCode selects a model's reasoning-effort overlay.
+fn prompt_body(text: &str, model: Option<&str>, variant: Option<&str>, agent: &str) -> Value {
     let mut body = json!({
         "agent": agent,
         "parts": [{"type": "text", "text": text}]
@@ -62,6 +65,13 @@ fn prompt_body(text: &str, model: Option<&str>, agent: &str) -> Value {
     if let Some((provider_id, model_id)) = model.and_then(|model| model.split_once('/')) {
         body["model"] = json!({"providerID": provider_id, "modelID": model_id});
     }
+    // Omitting this field lets a matching `build` agent's configured variant
+    // take over. OpenCode uses `default` as the explicit base-model selection.
+    body["variant"] = json!(
+        variant
+            .filter(|variant| !variant.is_empty())
+            .unwrap_or("default")
+    );
     body
 }
 
@@ -102,7 +112,7 @@ impl OpenCodeDriver {
             cwd,
             mode,
             model,
-            reasoning_effort: _,
+            reasoning_effort,
             service_tier: _,
             context_window: _,
             agent_preset: _,
@@ -364,6 +374,11 @@ impl OpenCodeDriver {
         thread::Builder::new()
             .name("waku-opencode-driver".into())
             .spawn(move || {
+                // The model and variant ride on every prompt, so keep the
+                // latest options here and apply them to the next turn without
+                // restarting the resident server.
+                let mut current_model = model;
+                let mut current_variant = reasoning_effort;
                 while let Ok(message) = command_rx.recv() {
                     match message {
                         CommandMessage::Prompt(text) => {
@@ -379,7 +394,12 @@ impl OpenCodeDriver {
                                 "/session/{}/prompt_async",
                                 encode_path_segment(&worker_session)
                             );
-                            let body = prompt_body(&text, model.as_deref(), agent);
+                            let body = prompt_body(
+                                &text,
+                                current_model.as_deref(),
+                                current_variant.as_deref(),
+                                agent,
+                            );
                             if let Err(error) = worker_server.request("POST", &path, Some(&body)) {
                                 let _ = worker_events.send(DriverEvent::Error(tr!(
                                     "errors.provider_rejected_prompt_detail",
@@ -424,7 +444,12 @@ impl OpenCodeDriver {
                                 "/session/{}/prompt_async",
                                 encode_path_segment(&worker_session)
                             );
-                            let body = prompt_body(&text, model.as_deref(), agent);
+                            let body = prompt_body(
+                                &text,
+                                current_model.as_deref(),
+                                current_variant.as_deref(),
+                                agent,
+                            );
                             match worker_server.request("POST", &path, Some(&body)) {
                                 Ok(_) => {
                                     let _ = worker_events
@@ -452,6 +477,10 @@ impl OpenCodeDriver {
                                     error = error
                                 )));
                             }
+                        }
+                        CommandMessage::Options(options) => {
+                            current_model = options.model;
+                            current_variant = options.reasoning_effort;
                         }
                         CommandMessage::Respond {
                             request_id,
@@ -555,9 +584,13 @@ impl DriverControl for OpenCodeDriver {
     }
 
     fn apply_options(&self, options: SessionOptions) -> bool {
-        // The model rides on each prompt, but access is installed when the
-        // driver starts, so changing it restarts the driver.
-        options.mode == self.mode
+        // The model and variant ride on each prompt, so they apply to the
+        // live session. Access is installed when the driver starts, so a mode
+        // change restarts the driver.
+        if options.mode != self.mode {
+            return false;
+        }
+        self.commands.send(CommandMessage::Options(options)).is_ok()
     }
 
     fn rollback(&self, turns: usize) -> anyhow::Result<Option<ProviderResumeCursor>> {
@@ -1332,6 +1365,7 @@ mod tests {
             prompt_body(
                 "Inspect the failure",
                 Some("opencode-go/deepseek-v4-flash"),
+                None,
                 "build",
             ),
             json!({
@@ -1340,9 +1374,36 @@ mod tests {
                     "providerID": "opencode-go",
                     "modelID": "deepseek-v4-flash",
                 },
+                "variant": "default",
                 "parts": [{"type": "text", "text": "Inspect the failure"}],
             })
         );
+    }
+
+    #[test]
+    fn prompts_carry_the_variant_as_reasoning_effort() {
+        assert_eq!(
+            prompt_body(
+                "Inspect the failure",
+                Some("openai/gpt-5.4"),
+                Some("high"),
+                "build",
+            ),
+            json!({
+                "agent": "build",
+                "model": {
+                    "providerID": "openai",
+                    "modelID": "gpt-5.4",
+                },
+                "variant": "high",
+                "parts": [{"type": "text", "text": "Inspect the failure"}],
+            })
+        );
+        // Empty and absent variants both explicitly select the base model.
+        let body = prompt_body("hi", None, Some(""), "build");
+        assert_eq!(body.get("variant"), Some(&json!("default")));
+        let body = prompt_body("hi", None, None, "build");
+        assert_eq!(body.get("variant"), Some(&json!("default")));
     }
 
     #[test]

--- a/crates/waku-core/src/model_catalog.rs
+++ b/crates/waku-core/src/model_catalog.rs
@@ -340,11 +340,28 @@ fn parse_cursor_models(output: &str) -> Vec<ProviderModel> {
 }
 
 fn discover_opencode_models(binary: &Path) -> Vec<ProviderModel> {
+    // `--verbose` prints one JSON document per model after its bare
+    // `provider/model` id, including the `variants` map that carries the
+    // reasoning-effort choices. Prefer it so the picker can offer effort
+    // levels; fall back to the plain listing for older CLIs.
+    let mut verbose = crate::command_env::command(binary);
+    let verbose = verbose.args(["models", "--verbose"]);
+    if let Ok(output) = crate::command_env::output(verbose)
+        && output.status.success()
+    {
+        let models = parse_opencode_verbose_models(&String::from_utf8_lossy(&output.stdout));
+        if !models.is_empty() {
+            return models;
+        }
+    }
     let mut command = crate::command_env::command(binary);
     let command = command.arg("models");
     let Ok(output) = crate::command_env::output(command) else {
         return Vec::new();
     };
+    if !output.status.success() {
+        return Vec::new();
+    }
     parse_opencode_models(&String::from_utf8_lossy(&output.stdout))
 }
 
@@ -522,20 +539,167 @@ fn parse_opencode_models(output: &str) -> Vec<ProviderModel> {
     output
         .lines()
         .filter_map(|line| {
-            let id = strip_ansi(line).trim().to_owned();
-            if id.is_empty() || id.split_whitespace().count() != 1 || !id.contains('/') {
-                return None;
-            }
+            let id = opencode_model_id(line)?;
             let (provider, model) = id.split_once('/')?;
-            if provider.is_empty() || model.is_empty() {
-                return None;
-            }
             Some(
                 ProviderModel::new(id.clone(), display_name_from_slug(model))
                     .sub_provider(display_name_from_slug(provider)),
             )
         })
         .collect()
+}
+
+fn opencode_model_id(line: &str) -> Option<String> {
+    let id = strip_ansi(line).trim().to_owned();
+    if id.is_empty() || id.split_whitespace().count() != 1 {
+        return None;
+    }
+    let (provider, model) = id.split_once('/')?;
+    if provider.is_empty()
+        || model.is_empty()
+        || matches!(id.chars().next(), Some('{' | '[' | '"' | '\''))
+    {
+        return None;
+    }
+    Some(id)
+}
+
+/// Canonical effort ladder for ordering OpenCode variant keys. Unknown ids
+/// sort after the known ladder alphabetically so the picker stays stable even
+/// when a provider invents a new overlay name.
+const OPENCODE_EFFORT_ORDER: [&str; 10] = [
+    "none",
+    "minimal",
+    "off",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+    "ultra",
+    "ultracode",
+];
+
+fn opencode_effort_rank(effort: &str) -> (usize, &str) {
+    (
+        OPENCODE_EFFORT_ORDER
+            .iter()
+            .position(|known| *known == effort)
+            .unwrap_or(OPENCODE_EFFORT_ORDER.len()),
+        effort,
+    )
+}
+
+fn opencode_reasoning_options(variants: &Value) -> Vec<ProviderModelOption> {
+    let mut efforts: Vec<String> = if let Some(map) = variants.as_object() {
+        map.keys().cloned().collect()
+    } else if let Some(list) = variants.as_array() {
+        list.iter()
+            .filter_map(|entry| {
+                entry
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                    .map(str::to_owned)
+                    .or_else(|| {
+                        entry
+                            .as_str()
+                            .map(str::trim)
+                            .filter(|id| !id.is_empty())
+                            .map(str::to_owned)
+                    })
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    efforts.retain(|effort| !effort.trim().is_empty());
+    efforts.sort_by(|left, right| opencode_effort_rank(left).cmp(&opencode_effort_rank(right)));
+    efforts.dedup();
+    efforts
+        .into_iter()
+        .map(|effort| ProviderModelOption::new(effort.clone(), reasoning_effort_label(&effort)))
+        .collect()
+}
+
+fn parse_opencode_verbose_models(output: &str) -> Vec<ProviderModel> {
+    // `--verbose` prints `provider/model` on its own line followed by one JSON
+    // document for that model. Let serde frame each document so arbitrary
+    // string values cannot be mistaken for the next model id.
+    let mut remaining = output;
+    let mut models = Vec::new();
+    while !remaining.is_empty() {
+        let (line, rest) = remaining
+            .split_once('\n')
+            .map_or((remaining, ""), |(line, rest)| (line, rest));
+        remaining = rest;
+        let Some(id) = opencode_model_id(line) else {
+            continue;
+        };
+
+        let document = remaining.trim_start();
+        if document.starts_with('{') {
+            let mut values = serde_json::Deserializer::from_str(document).into_iter::<Value>();
+            if let Some(Ok(value)) = values.next() {
+                remaining = &document[values.byte_offset()..];
+                models.push(parse_opencode_verbose_model(&id, Some(&value)));
+                continue;
+            }
+        }
+        // A bare id or malformed document still yields a selectable model.
+        // Leaving `remaining` in place lets the outer scan resynchronize at a
+        // later valid header.
+        models.push(parse_opencode_verbose_model(&id, None));
+    }
+    models.into_iter().flatten().collect()
+}
+
+fn parse_opencode_verbose_model(id: &str, value: Option<&Value>) -> Option<ProviderModel> {
+    let (fallback_provider, fallback_model) = id.split_once('/')?;
+    if fallback_provider.is_empty() || fallback_model.is_empty() {
+        return None;
+    }
+    let plain = || {
+        ProviderModel::new(id.to_owned(), display_name_from_slug(fallback_model))
+            .sub_provider(display_name_from_slug(fallback_provider))
+    };
+    let Some(value) = value else {
+        return Some(plain());
+    };
+    let provider_id = value
+        .get("providerID")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|provider| !provider.is_empty())
+        .unwrap_or(fallback_provider);
+    let model_id = value
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .unwrap_or(fallback_model);
+    if provider_id.is_empty() || model_id.is_empty() {
+        return None;
+    }
+    let slug = format!("{provider_id}/{model_id}");
+    let name = value
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(|| display_name_from_slug(model_id));
+    let mut model =
+        ProviderModel::new(slug, name).sub_provider(display_name_from_slug(provider_id));
+    // OpenCode publishes no per-model default variant. Its explicit `default`
+    // selection uses family-specific base settings, so guessing one effort
+    // would be wrong as often as right. Keep the catalog default unset and let
+    // the picker's Default row represent that sentinel.
+    if let Some(variants) = value.get("variants") {
+        model.reasoning_efforts = opencode_reasoning_options(variants);
+    }
+    Some(model)
 }
 
 fn discover_grok_models(binary: &Path) -> Vec<ProviderModel> {
@@ -1385,6 +1549,173 @@ printf '%s\n' '{"type":"control_response","response":{"request_id":"waku-initial
         assert_eq!(models[1].id, "github-copilot/gpt-5.4");
         assert_eq!(models[1].name, "GPT-5.4");
         assert_eq!(models[1].sub_provider.as_deref(), Some("Github Copilot"));
+    }
+
+    #[test]
+    fn parses_opencode_verbose_variants_as_reasoning_efforts() {
+        let output = concat!(
+            "opencode/big-pickle\n",
+            "{\"id\":\"big-pickle\",\"providerID\":\"opencode\",\"name\":\"Big Pickle\",\"variants\":{}}\n",
+            "opencode/gpt-5.3-codex\n",
+            "{\"id\":\"gpt-5.3-codex\",\"providerID\":\"opencode\",\"name\":\"GPT-5.3 Codex\",",
+            "\"variants\":{\"xhigh\":{},\"low\":{},\"high\":{},\"medium\":{},\"none\":{}}}\n",
+            "openai/gpt-5.4\n",
+            "{\"id\":\"gpt-5.4\",\"providerID\":\"openai\",\"name\":\"GPT-5.4\",",
+            "\"variants\":{\"low\":{\"reasoningEffort\":\"low\"},\"high\":{\"reasoningEffort\":\"high\"}}}\n",
+        );
+        let models = parse_opencode_verbose_models(output);
+        assert_eq!(models.len(), 3);
+        assert_eq!(models[0].id, "opencode/big-pickle");
+        assert_eq!(models[0].name, "Big Pickle");
+        assert!(models[0].reasoning_efforts.is_empty());
+        assert_eq!(models[0].default_reasoning_effort, None);
+        // Variant keys arrive in any JSON order; the picker sees the effort ladder.
+        assert_eq!(
+            models[1]
+                .reasoning_efforts
+                .iter()
+                .map(|option| option.id.as_str())
+                .collect::<Vec<_>>(),
+            ["none", "low", "medium", "high", "xhigh"]
+        );
+        assert_eq!(models[1].default_reasoning_effort, None);
+        assert_eq!(models[2].id, "openai/gpt-5.4");
+        assert_eq!(models[2].sub_provider.as_deref(), Some("Openai"));
+        assert_eq!(
+            models[2]
+                .reasoning_efforts
+                .iter()
+                .map(|option| option.id.as_str())
+                .collect::<Vec<_>>(),
+            ["low", "high"]
+        );
+        assert_eq!(models[2].default_reasoning_effort, None);
+    }
+
+    #[test]
+    fn opencode_verbose_leaves_the_default_unset() {
+        // OpenCode does not identify which variant, if any, matches the base
+        // model settings, so the picker's explicit Default row owns the reset.
+        let output = concat!(
+            "opencode/flash\n",
+            "{\"id\":\"flash\",\"providerID\":\"opencode\",\"name\":\"Flash\",",
+            "\"variants\":{\"low\":{},\"medium\":{},\"high\":{}}}\n",
+        );
+        let models = parse_opencode_verbose_models(output);
+        assert_eq!(models.len(), 1);
+        assert_eq!(
+            models[0]
+                .reasoning_efforts
+                .iter()
+                .map(|option| option.id.as_str())
+                .collect::<Vec<_>>(),
+            ["low", "medium", "high"]
+        );
+        assert_eq!(models[0].default_reasoning_effort, None);
+    }
+
+    #[test]
+    fn opencode_verbose_keeps_bare_ids_when_documents_are_malformed() {
+        let models = parse_opencode_verbose_models(concat!(
+            "opencode/gpt-5.4\nnot json\n",
+            "openai/recovered\n",
+            "{\"id\":\"recovered\",\"providerID\":\"openai\",\"variants\":{\"low\":{}}}\n",
+        ));
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].id, "opencode/gpt-5.4");
+        assert_eq!(models[0].name, "GPT-5.4");
+        assert!(models[0].reasoning_efforts.is_empty());
+        assert_eq!(models[1].id, "openai/recovered");
+        assert_eq!(models[1].reasoning_efforts[0].id, "low");
+    }
+
+    #[test]
+    fn opencode_verbose_keeps_slash_strings_inside_their_json_document() {
+        let output = r#"custom/model-a
+{
+  "id": "model-a",
+  "providerID": "custom",
+  "name": "Model A",
+  "options": {
+    "stopSequences": [
+      "</think>",
+      "application/pdf"
+    ]
+  },
+  "variants": {
+    "low": {},
+    "high": {}
+  }
+}
+custom/model-b
+{
+  "id": "model-b",
+  "providerID": "custom",
+  "name": "Model B",
+  "variants": {}
+}
+"#;
+
+        let models = parse_opencode_verbose_models(output);
+
+        assert_eq!(
+            models
+                .iter()
+                .map(|model| model.id.as_str())
+                .collect::<Vec<_>>(),
+            ["custom/model-a", "custom/model-b"]
+        );
+        assert_eq!(
+            models[0]
+                .reasoning_efforts
+                .iter()
+                .map(|option| option.id.as_str())
+                .collect::<Vec<_>>(),
+            ["low", "high"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opencode_discovery_falls_back_after_a_failed_verbose_command() {
+        let binary = write_fake_model_cli(
+            "opencode-verbose-fallback",
+            r#"#!/bin/sh
+if [ "$2" = "--verbose" ]; then
+  printf '%s\n' 'openai/partial'
+  printf '%s\n' '{"id":"partial","providerID":"openai","variants":{"high":{}}}'
+  exit 1
+fi
+printf '%s\n' 'openai/fallback'
+"#,
+        );
+
+        let models = discover_opencode_models(&binary);
+
+        let _ = std::fs::remove_file(binary);
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "openai/fallback");
+        assert!(models[0].reasoning_efforts.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opencode_discovery_rejects_a_failed_plain_command() {
+        let binary = write_fake_model_cli(
+            "opencode-failed-plain",
+            r#"#!/bin/sh
+if [ "$2" = "--verbose" ]; then
+  exit 1
+fi
+printf '%s\n' 'openai/partial'
+exit 1
+"#,
+        );
+
+        let models = discover_opencode_models(&binary);
+
+        let _ = std::fs::remove_file(binary);
+        assert!(models.is_empty());
     }
 
     #[test]

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -944,6 +944,8 @@ models.remove_favorite:
   en: Remove from favorites
 models.standard:
   en: Standard
+models.default:
+  en: Default
 models.reasoning:
   en: Reasoning
 models.service_tier:

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -486,6 +486,7 @@ models.favorites: お気に入り
 models.add_favorite: お気に入りに追加
 models.remove_favorite: お気に入りから削除
 models.standard: 標準
+models.default: デフォルト
 models.reasoning: 推論レベル
 models.service_tier: サービスティア
 models.context_window: コンテキストウィンドウ

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -461,6 +461,7 @@ models.favorites: 收藏
 models.add_favorite: 添加到收藏
 models.remove_favorite: 从收藏中移除
 models.standard: 标准
+models.default: 默认
 models.reasoning: 推理强度
 models.service_tier: 服务等级
 models.context_window: 上下文窗口

--- a/src/app/composer.rs
+++ b/src/app/composer.rs
@@ -1415,7 +1415,8 @@ impl Waku {
             return None;
         }
 
-        let selected_effort = session
+        let supports_default_reset = supports_reasoning_default_reset(session.provider);
+        let mut selected_effort = session
             .reasoning_effort
             .as_deref()
             .filter(|selected| {
@@ -1424,21 +1425,28 @@ impl Waku {
                     .iter()
                     .any(|option| option.id == *selected)
             })
-            .or(model.default_reasoning_effort.as_deref())
-            .or_else(|| {
+            .map(str::to_owned);
+        if selected_effort.is_none() && !supports_default_reset {
+            selected_effort = model.default_reasoning_effort.clone().or_else(|| {
                 model
                     .reasoning_efforts
                     .first()
-                    .map(|option| option.id.as_str())
+                    .map(|option| option.id.clone())
+            });
+        }
+        let effort_label = if model.reasoning_efforts.is_empty() {
+            None
+        } else if selected_effort.is_none() {
+            Some(tr!("models.default"))
+        } else {
+            selected_effort.as_deref().and_then(|selected| {
+                model
+                    .reasoning_efforts
+                    .iter()
+                    .find(|option| option.id == selected)
+                    .map(|option| option.label.clone())
             })
-            .map(str::to_owned);
-        let effort_label = selected_effort.as_deref().and_then(|selected| {
-            model
-                .reasoning_efforts
-                .iter()
-                .find(|option| option.id == selected)
-                .map(|option| option.label.clone())
-        });
+        };
 
         let selected_tier = session
             .service_tier
@@ -1527,6 +1535,22 @@ impl Waku {
                 let mut items = Vec::new();
                 if !reasoning_efforts.is_empty() {
                     items.push(MenuItem::Header(tr!("models.reasoning").into()));
+                    if supports_default_reset {
+                        let weak_default = weak.clone();
+                        items.push(
+                            traits_choice(
+                                theme,
+                                tr!("models.default"),
+                                false,
+                                selected_effort.is_none(),
+                            )
+                            .on_click(move |_, cx| {
+                                let _ = weak_default.update(cx, |this, cx| {
+                                    this.clear_reasoning_effort(cx);
+                                });
+                            }),
+                        );
+                    }
                     for option in reasoning_efforts.clone() {
                         let weak = weak.clone();
                         let effort = option.id;
@@ -3841,6 +3865,10 @@ pub(super) fn model_picker_subtitle(provider: ProviderKind, sub_provider: Option
         Some(name) => format!("{name} · {provider_name}"),
         None => provider_name.to_owned(),
     }
+}
+
+pub(super) fn supports_reasoning_default_reset(provider: ProviderKind) -> bool {
+    provider == ProviderKind::OpenCode
 }
 
 /// Whether the picker has nothing left to offer, so the composer's trigger

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -1073,6 +1073,23 @@ impl Waku {
         }
     }
 
+    /// Clears an explicitly chosen OpenCode variant back to its base-model
+    /// `default` selection.
+    pub(super) fn clear_reasoning_effort(&mut self, cx: &mut Context<Self>) {
+        if let Some(session) = self.selected_session_mut()
+            && super::composer::supports_reasoning_default_reset(session.provider)
+            && session.reasoning_effort.is_some()
+        {
+            let session_id = session.id;
+            session.reasoning_effort = None;
+            self.state.last_reasoning_effort = None;
+            self.remember_selected_model_traits();
+            self.apply_session_options(session_id, cx);
+            self.save();
+            cx.notify();
+        }
+    }
+
     pub(super) fn set_service_tier(&mut self, tier: String, cx: &mut Context<Self>) {
         if let Some(session) = self.selected_session_mut()
             && session.service_tier.as_deref() != Some(tier.as_str())

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1,6 +1,6 @@
 use super::composer::{
     ComposerSubmitAction, composer_submit_action, dropped_file_mention, merged_submission,
-    next_picker_highlight, visible_branch_entries,
+    next_picker_highlight, supports_reasoning_default_reset, visible_branch_entries,
 };
 use super::runtime::{merge_remote_session_catalog, session_has_active_provider_turn};
 use super::settings::visible_settings_pages;
@@ -1862,6 +1862,16 @@ fn model_picker_highlight_wraps_at_both_ends() {
 
     // An empty result list has nothing to land on.
     assert_eq!(next_picker_highlight(None, 0, "down"), None);
+}
+
+#[test]
+fn only_opencode_offers_an_explicit_reasoning_default_reset() {
+    assert!(supports_reasoning_default_reset(ProviderKind::OpenCode));
+    for provider in ProviderKind::ALL {
+        if provider != ProviderKind::OpenCode {
+            assert!(!supports_reasoning_default_reset(provider));
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #211.

- Discover OpenCode per-model variants via `opencode models --verbose` (plain-listing fallback) and expose them as reasoning-effort options, ordered on a canonical effort ladder with unknown ids sorted stably after it.
- Send the selection as the top-level `variant` on every prompt (`default` selects the base model); model and variant now apply to the live session without restarting the driver (only access-mode changes restart it).
- Add an explicit Default row to the model picker for OpenCode (localized in en/ja/zh-CN) that clears the effort back to the base model; other providers keep the previous auto-select behavior.