### PR TITLE
Flesh out the text field's key bindings

### DIFF
--- a/docs/text-field-keys.md
+++ b/docs/text-field-keys.md
@@ -1,0 +1,138 @@
+# Text field key bindings
+
+Every chord `TextInput` binds ([`input::init`](../src/input.rs)), what it
+does, and where that behaviour comes from. The composer is a multi-line field,
+so most chords are defined by the unit they operate on:
+
+| Unit | Meaning |
+| --- | --- |
+| character | one grapheme |
+| word | a Unicode word boundary, whitespace skipped |
+| row | one *rendered* row: a soft wrap counts, a hard `\n` counts |
+| paragraph | the text between hard `\n` breaks; soft wraps are ignored |
+| document | the whole field |
+
+GPUI matches modifiers exactly, so a chord with no binding is swallowed rather
+than falling back to the unmodified key. That is why the modified deletes are
+bound explicitly.
+
+## macOS
+
+The reference is AppKit's `StandardKeyBinding.dict`
+(`/System/Library/Frameworks/AppKit.framework/Resources/`), the table every
+native text view consults. The selector column names the AppKit action a chord
+maps to there; a row with no selector is a Waku decision, explained inline.
+
+### Caret
+
+| Chord | Does | AppKit selector |
+| --- | --- | --- |
+| `left` / `right` | one character; with a selection, collapse to its near edge | `moveLeft:` / `moveRight:` |
+| `ctrl-b` / `ctrl-f` | one character | `moveBackward:` / `moveForward:` |
+| `alt-left` / `alt-right` | one word | `moveWordLeft:` / `moveWordRight:` |
+| `ctrl-alt-b` / `ctrl-alt-f` | one word | `moveWordBackward:` / `moveWordForward:` |
+| `up` / `down` | one row, keeping the column goal across a short row; at the first or last row the key propagates | `moveUp:` / `moveDown:` |
+| `ctrl-p` / `ctrl-n` | one row | `moveUp:` / `moveDown:` |
+| `cmd-left` / `cmd-right` | row start / end | `moveToLeftEndOfLine:` / `moveToRightEndOfLine:` |
+| `ctrl-a` / `ctrl-e` | paragraph start / end; stays put on repeat | `moveToBeginningOfParagraph:` / `moveToEndOfParagraph:` |
+| `alt-up` / `alt-down` | paragraph start / end; on repeat, the previous / next paragraph | `moveParagraphBackward:` / `moveParagraphForward:` |
+| `cmd-up` / `cmd-down` | document start / end | `moveToBeginningOfDocument:` / `moveToEndOfDocument:` |
+| `home` / `end` | document start / end. Native views only scroll here; Waku moves the caret, as most editors do | — |
+
+### Selection
+
+Each chord extends from the selection's moving end.
+
+| Chord | Extends to | AppKit selector |
+| --- | --- | --- |
+| `shift-left` / `shift-right` | one character | `moveLeftAndModifySelection:` |
+| `ctrl-shift-b` / `ctrl-shift-f` | one character | `moveBackwardAndModifySelection:` |
+| `alt-shift-left` / `alt-shift-right` | one word | `moveWordLeftAndModifySelection:` |
+| `ctrl-alt-shift-b` / `ctrl-alt-shift-f` | one word | `moveWordBackwardAndModifySelection:` |
+| `shift-up` / `shift-down` | one row; past the first or last row, the document edge | `moveUpAndModifySelection:` |
+| `ctrl-shift-p` / `ctrl-shift-n` | one row | `moveUpAndModifySelection:` |
+| `cmd-shift-left` / `cmd-shift-right` | row start / end | `moveToLeftEndOfLineAndModifySelection:` |
+| `ctrl-shift-left` / `ctrl-shift-right` | row start / end | `moveToLeftEndOfLineAndModifySelection:` |
+| `ctrl-shift-a` / `ctrl-shift-e` | paragraph start / end | `moveToBeginningOfParagraphAndModifySelection:` |
+| `alt-shift-up` / `alt-shift-down` | paragraph start / end, stepping on repeat | `moveParagraphBackwardAndModifySelection:` |
+| `cmd-shift-up` / `cmd-shift-down` | document start / end | `moveToBeginningOfDocumentAndModifySelection:` |
+| `shift-home` / `shift-end` | document start / end | `moveToBeginningOfDocumentAndModifySelection:` |
+| `cmd-a` | everything | `selectAll:` |
+
+### Deleting
+
+| Chord | Deletes | AppKit selector |
+| --- | --- | --- |
+| `backspace` / `delete` | one character back / forward, or the selection | `deleteBackward:` / `deleteForward:` |
+| `shift-`, `ctrl-`, `ctrl-shift-` + either | the same one character; the modifiers are ignored | `deleteBackward:` / `deleteForward:` (`ctrl-backspace` is `deleteBackwardByDecomposingPreviousCharacter:`, which Waku approximates) |
+| `ctrl-h` / `ctrl-d` | one character back / forward | `deleteBackward:` / `deleteForward:` |
+| `alt-backspace`, `ctrl-alt-backspace` | one word back | `deleteWordBackward:` |
+| `alt-delete` | one word forward | `deleteWordForward:` |
+| `cmd-backspace` | to the row start; nothing at a row start | `deleteToBeginningOfLine:` |
+| `cmd-delete` | to the row end. Unbound natively; mirrors `cmd-backspace` | — |
+| `ctrl-k` | to the paragraph end; parked on a `\n`, takes the break and joins the next line up | `deleteToEndOfParagraph:` |
+| `ctrl-u` | to the paragraph start; nothing at a paragraph start. Unbound natively; readline's `unix-line-discard` | — |
+
+Every kill falls back to the hard line break when the field has no current
+layout to read a row from, so a stale row can never cost more than the line.
+
+### Enter, undo, escape
+
+| Chord | Does |
+| --- | --- |
+| `enter` | submits; while a turn is running, queues a follow-up |
+| `shift-enter`, `ctrl-enter`, `alt-enter` | insert a line break (`insertLineBreak:` / `insertNewlineIgnoringFieldEditor:`) |
+| `cmd-enter` | steers with the draft, or injects the oldest queued follow-up |
+| `cmd-z` / `cmd-shift-z` | undo / redo |
+| `cmd-c` / `cmd-x` / `cmd-v` | copy / cut / paste |
+| `escape` | clears fields that opt in via `clear_on_escape` (the search fields); otherwise propagates. The composer does not opt in: its clear also drops undo history, so Escape stops the turn or dismisses a popup instead |
+
+### Deliberately unbound
+
+| Chord | Why |
+| --- | --- |
+| `pageup` / `pagedown` | native views only scroll on these; leaving them unbound lets the transcript page |
+| `shift-pageup` / `shift-pagedown`, `alt-pageup` / `alt-pagedown`, `ctrl-v` | page-wise caret motion needs the field's viewport height; not implemented yet |
+| `ctrl-o`, `ctrl-t`, `ctrl-y`, `ctrl-l` | open-line, transpose, yank, centre; rare, and yank needs a kill ring |
+| `ctrl-j` | AppKit's `insertNewline:`, the same selector as Enter, which would send |
+
+## Windows and Linux
+
+The shared desktop convention: `ctrl` for word motion, Home and End on the
+row, the document ends one modifier up.
+
+| Chord | Does |
+| --- | --- |
+| `home` / `end`, `shift-home` / `shift-end` | row start / end, move or select |
+| `ctrl-home` / `ctrl-end`, `ctrl-shift-home` / `ctrl-shift-end` | document start / end, move or select |
+| `ctrl-left` / `ctrl-right`, `ctrl-shift-left` / `ctrl-shift-right` | one word, move or select |
+| `ctrl-backspace` / `ctrl-delete` | one word back / forward |
+| `ctrl-y` | redo, alongside `ctrl-shift-z` |
+
+Everything in the platform-neutral block above (arrows, shift-arrows, alt word
+motion, the modified deletes, Enter and its variants, the clipboard chords)
+applies here too.
+
+## Popup contexts
+
+While the composer's autocomplete popup is open (`ComposerAutocomplete >
+TextInput`), `up`, `down`, `ctrl-p` and `ctrl-n` move its highlight, `enter`
+and `tab` accept, and `escape` dismisses. The command palette, skills, model,
+branch and settings search fields bind their list navigation the same way at
+their own contexts.
+
+## Checking by hand
+
+Paste three paragraphs into the composer, the first long enough to soft-wrap
+onto three rows, the second a few characters, and narrow the window:
+
+```
+The quick brown fox jumps over the lazy dog while the composer wraps this first paragraph across several rendered rows in a narrow window
+short line
+Third paragraph ends the draft
+```
+
+`cmd-right` from the start of the first paragraph must stop at the wrap;
+`ctrl-e` must reach the `\n`. `down` from the end of the first row, through
+`short line`, and back `up` must return to the same column. `ctrl-k` at
+column 4 of the first paragraph must leave `The ` followed by the break.

--- a/src/app/autocomplete.rs
+++ b/src/app/autocomplete.rs
@@ -41,6 +41,10 @@ pub fn init(cx: &mut App) {
     cx.bind_keys([
         KeyBinding::new("down", SelectNextEntry, Some(AUTOCOMPLETE_CONTEXT)),
         KeyBinding::new("up", SelectPreviousEntry, Some(AUTOCOMPLETE_CONTEXT)),
+        // The field binds the emacs spelling of the arrows too; while the
+        // popup owns them they must move the highlight, not the caret.
+        KeyBinding::new("ctrl-n", SelectNextEntry, Some(AUTOCOMPLETE_CONTEXT)),
+        KeyBinding::new("ctrl-p", SelectPreviousEntry, Some(AUTOCOMPLETE_CONTEXT)),
         KeyBinding::new("enter", ConfirmEntry, Some(AUTOCOMPLETE_CONTEXT)),
         KeyBinding::new("tab", ConfirmEntry, Some(AUTOCOMPLETE_CONTEXT)),
         KeyBinding::new("escape", DismissMenu, Some(AUTOCOMPLETE_CONTEXT)),

--- a/src/input.rs
+++ b/src/input.rs
@@ -37,6 +37,8 @@ actions!(
         LineEnd,
         ParagraphStart,
         ParagraphEnd,
+        ParagraphBackward,
+        ParagraphForward,
         MoveToPreviousWord,
         MoveToNextWord,
         SelectToStart,
@@ -45,10 +47,14 @@ actions!(
         SelectToLineEnd,
         SelectToParagraphStart,
         SelectToParagraphEnd,
+        SelectParagraphBackward,
+        SelectParagraphForward,
         SelectToPreviousWord,
         SelectToNextWord,
         DeleteToLineStart,
         DeleteToLineEnd,
+        DeleteToParagraphStart,
+        DeleteToParagraphEnd,
         DeleteToPreviousWord,
         DeleteToNextWord,
         Paste,
@@ -66,6 +72,8 @@ actions!(
 const CURSOR_BLINK_INTERVAL: Duration = Duration::from_millis(500);
 const CURSOR_BLINK_PAUSE: Duration = Duration::from_millis(300);
 
+/// The full table, with the AppKit selector each chord answers to, is in
+/// `docs/text-field-keys.md`.
 pub fn init(cx: &mut App) {
     cx.bind_keys([
         KeyBinding::new("backspace", Backspace, Some("TextInput")),
@@ -101,6 +109,10 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("secondary-shift-z", Redo, Some("TextInput")),
         KeyBinding::new("enter", Enter, Some("TextInput")),
         KeyBinding::new("shift-enter", Newline, Some("TextInput")),
+        // Native field editors take ctrl-enter and alt-enter as a literal line
+        // break where Enter itself would submit.
+        KeyBinding::new("ctrl-enter", Newline, Some("TextInput")),
+        KeyBinding::new("alt-enter", Newline, Some("TextInput")),
         // While a turn is running, Enter queues a follow-up; the platform's
         // primary modifier + Enter injects it when the provider supports it.
         KeyBinding::new("secondary-enter", SubmitSteer, Some("TextInput")),
@@ -132,10 +144,21 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("ctrl-delete", Delete, Some("TextInput")),
         KeyBinding::new("ctrl-shift-backspace", Backspace, Some("TextInput")),
         KeyBinding::new("ctrl-shift-delete", Delete, Some("TextInput")),
-        // The emacs kill pair is line-scoped everywhere it comes from —
-        // readline, NSTextView — so it stops at the line ends here too.
-        KeyBinding::new("ctrl-u", DeleteToLineStart, Some("TextInput")),
-        KeyBinding::new("ctrl-k", DeleteToLineEnd, Some("TextInput")),
+        // The emacs kills work on the logical line — `deleteToEndOfParagraph:`
+        // in AppKit, the whole input line in readline — so a soft wrap does
+        // not stop them; only cmd-backspace/cmd-delete are row-scoped.
+        KeyBinding::new("ctrl-u", DeleteToParagraphStart, Some("TextInput")),
+        KeyBinding::new("ctrl-k", DeleteToParagraphEnd, Some("TextInput")),
+        // Emacs word motion and the ctrl-alt spelling of the word backspace.
+        KeyBinding::new(
+            "ctrl-alt-backspace",
+            DeleteToPreviousWord,
+            Some("TextInput"),
+        ),
+        KeyBinding::new("ctrl-alt-b", MoveToPreviousWord, Some("TextInput")),
+        KeyBinding::new("ctrl-alt-f", MoveToNextWord, Some("TextInput")),
+        KeyBinding::new("ctrl-alt-shift-b", SelectToPreviousWord, Some("TextInput")),
+        KeyBinding::new("ctrl-alt-shift-f", SelectToNextWord, Some("TextInput")),
         KeyBinding::new("ctrl-b", Left, Some("TextInput")),
         KeyBinding::new("ctrl-f", Right, Some("TextInput")),
         // The vertical half of the emacs motion set, bound system-wide on
@@ -146,22 +169,31 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("cmd-right", LineEnd, Some("TextInput")),
         KeyBinding::new("cmd-up", Home, Some("TextInput")),
         KeyBinding::new("cmd-down", End, Some("TextInput")),
-        KeyBinding::new("ctrl-a", LineStart, Some("TextInput")),
-        KeyBinding::new("ctrl-e", LineEnd, Some("TextInput")),
-        KeyBinding::new("alt-up", ParagraphStart, Some("TextInput")),
-        KeyBinding::new("alt-down", ParagraphEnd, Some("TextInput")),
+        // Like the kills, ctrl-a/ctrl-e are paragraph motion in AppKit
+        // (`moveToBeginningOfParagraph:`, which stays put at a start); the row
+        // ends belong to cmd-left/right. alt-up/alt-down are the stepping
+        // pair (`moveParagraphBackward:`) that keeps going from a start.
+        KeyBinding::new("ctrl-a", ParagraphStart, Some("TextInput")),
+        KeyBinding::new("ctrl-e", ParagraphEnd, Some("TextInput")),
+        KeyBinding::new("alt-up", ParagraphBackward, Some("TextInput")),
+        KeyBinding::new("alt-down", ParagraphForward, Some("TextInput")),
         KeyBinding::new("shift-cmd-left", SelectToLineStart, Some("TextInput")),
         KeyBinding::new("shift-cmd-right", SelectToLineEnd, Some("TextInput")),
         KeyBinding::new("cmd-shift-up", SelectToStart, Some("TextInput")),
         KeyBinding::new("cmd-shift-down", SelectToEnd, Some("TextInput")),
-        KeyBinding::new("ctrl-shift-a", SelectToLineStart, Some("TextInput")),
-        KeyBinding::new("ctrl-shift-e", SelectToLineEnd, Some("TextInput")),
-        KeyBinding::new("alt-shift-up", SelectToParagraphStart, Some("TextInput")),
-        KeyBinding::new("alt-shift-down", SelectToParagraphEnd, Some("TextInput")),
-        // Word-wise selection on the control chords too, mirroring the
-        // alt-shift pair (and the ctrl-shift convention elsewhere).
-        KeyBinding::new("ctrl-shift-left", SelectToPreviousWord, Some("TextInput")),
-        KeyBinding::new("ctrl-shift-right", SelectToNextWord, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-a", SelectToParagraphStart, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-e", SelectToParagraphEnd, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-b", SelectLeft, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-f", SelectRight, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-p", SelectUp, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-n", SelectDown, Some("TextInput")),
+        KeyBinding::new("alt-shift-up", SelectParagraphBackward, Some("TextInput")),
+        KeyBinding::new("alt-shift-down", SelectParagraphForward, Some("TextInput")),
+        // AppKit's ctrl-shift-left/right select to the row ends
+        // (`moveToLeftEndOfLineAndModifySelection:`); word-wise selection on
+        // ctrl-shift is the Windows and Linux convention, bound below.
+        KeyBinding::new("ctrl-shift-left", SelectToLineStart, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-right", SelectToLineEnd, Some("TextInput")),
     ]);
 
     // The chords Windows and the Linux desktops share: word motion on ctrl,
@@ -1137,7 +1169,11 @@ impl TextInput {
                 // The field is one row, so there is no row to step to, but a
                 // native one-line field still extends to its own end here.
                 let edge = if down { self.content.len() } else { 0 };
-                self.select_to(edge, cx);
+                if self.cursor_offset() == edge {
+                    cx.propagate();
+                } else {
+                    self.select_to(edge, cx);
+                }
                 return;
             }
             cx.propagate();
@@ -1269,9 +1305,13 @@ impl TextInput {
     /// counting a soft wrap as a row the way the vertical motion above does.
     fn move_to_row_edge(&mut self, to_end: bool, extend: bool, cx: &mut Context<Self>) {
         let Some((offset, affinity)) = self.row_edge(to_end) else {
-            // One row, or no layout to consult: the field's own ends are the
-            // only line ends there are.
-            let offset = if to_end { self.content.len() } else { 0 };
+            // One row, or no layout to consult: fall back to the hard line
+            // breaks, which need no geometry and are never wider than a row.
+            let offset = if to_end {
+                self.hard_line_end()
+            } else {
+                self.hard_line_start()
+            };
             if extend {
                 self.select_to(offset, cx);
             } else {
@@ -1338,12 +1378,14 @@ impl TextInput {
         ))
     }
 
+    /// ctrl-a: AppKit's `moveToBeginningOfParagraph:`. It stops at the start
+    /// of the caret's own paragraph and stays there on a repeat.
     fn paragraph_start(&mut self, _: &ParagraphStart, _: &mut Window, cx: &mut Context<Self>) {
-        self.move_to(self.paragraph_start_offset(), cx);
+        self.move_to(self.hard_line_start(), cx);
     }
 
     fn paragraph_end(&mut self, _: &ParagraphEnd, _: &mut Window, cx: &mut Context<Self>) {
-        self.move_to(self.paragraph_end_offset(), cx);
+        self.move_to(self.hard_line_end(), cx);
     }
 
     fn select_to_paragraph_start(
@@ -1352,12 +1394,45 @@ impl TextInput {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.select_to(self.paragraph_start_offset(), cx);
+        self.select_to(self.hard_line_start(), cx);
     }
 
     fn select_to_paragraph_end(
         &mut self,
         _: &SelectToParagraphEnd,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(self.hard_line_end(), cx);
+    }
+
+    /// alt-up: AppKit's `moveParagraphBackward:`, which steps to the previous
+    /// paragraph when the caret already sits at a start.
+    fn paragraph_backward(
+        &mut self,
+        _: &ParagraphBackward,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.move_to(self.paragraph_start_offset(), cx);
+    }
+
+    fn paragraph_forward(&mut self, _: &ParagraphForward, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to(self.paragraph_end_offset(), cx);
+    }
+
+    fn select_paragraph_backward(
+        &mut self,
+        _: &SelectParagraphBackward,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(self.paragraph_start_offset(), cx);
+    }
+
+    fn select_paragraph_forward(
+        &mut self,
+        _: &SelectParagraphForward,
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -1375,6 +1450,23 @@ impl TextInput {
             Some(index) => before[..index].rfind('\n').map_or(0, |index| index + 1),
             None => 0,
         }
+    }
+
+    /// Start of the newline-delimited line holding the caret, with no
+    /// stepping to the previous one: the kill and fallback bound.
+    fn hard_line_start(&self) -> usize {
+        self.content[..self.cursor_offset()]
+            .rfind('\n')
+            .map_or(0, |index| index + 1)
+    }
+
+    /// End of the newline-delimited line holding the caret, the offset of its
+    /// `\n` or the end of the field.
+    fn hard_line_end(&self) -> usize {
+        let cursor = self.cursor_offset();
+        self.content[cursor..]
+            .find('\n')
+            .map_or(self.content.len(), |index| cursor + index)
     }
 
     /// End of the paragraph holding the caret, or of the next one when the
@@ -1493,7 +1585,11 @@ impl TextInput {
         cx: &mut Context<Self>,
     ) {
         if self.selected_range.is_empty() {
-            let offset = self.row_edge(false).map_or(0, |(offset, _)| offset);
+            // Without a trustworthy layout the hard line break is the bound:
+            // a stale row must never cost more than the line.
+            let offset = self
+                .row_edge(false)
+                .map_or_else(|| self.hard_line_start(), |(offset, _)| offset);
             self.select_to(offset, cx);
         }
         self.replace_text_in_range(None, "", window, cx);
@@ -1506,18 +1602,51 @@ impl TextInput {
         cx: &mut Context<Self>,
     ) {
         if self.selected_range.is_empty() {
-            let cursor = self.cursor_offset();
-            let mut offset = self
+            let offset = self
                 .row_edge(true)
-                .map_or(self.content.len(), |(offset, _)| offset);
-            if offset == cursor && self.content[cursor..].starts_with('\n') {
-                // Standing on the break itself, the kill takes it and joins
-                // the next line up, the way readline and NSTextView do.
-                offset = cursor + 1;
-            }
+                .map_or_else(|| self.hard_line_end(), |(offset, _)| offset);
+            self.select_to(self.kill_end_taking_the_break(offset), cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    /// ctrl-u: kill to the start of the logical line, readline's
+    /// `unix-line-discard`. At the line start there is nothing to take.
+    fn delete_to_paragraph_start(
+        &mut self,
+        _: &DeleteToParagraphStart,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            self.select_to(self.hard_line_start(), cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    /// ctrl-k: AppKit's `deleteToEndOfParagraph:`, which ignores soft wraps.
+    fn delete_to_paragraph_end(
+        &mut self,
+        _: &DeleteToParagraphEnd,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            let offset = self.kill_end_taking_the_break(self.hard_line_end());
             self.select_to(offset, cx);
         }
         self.replace_text_in_range(None, "", window, cx);
+    }
+
+    /// Standing on the break itself, a forward kill takes it and joins the
+    /// next line up, the way readline and NSTextView do.
+    fn kill_end_taking_the_break(&self, offset: usize) -> usize {
+        let cursor = self.cursor_offset();
+        if offset == cursor && self.content[cursor..].starts_with('\n') {
+            cursor + 1
+        } else {
+            offset
+        }
     }
 
     fn delete_to_previous_word(
@@ -2654,6 +2783,8 @@ impl Render for TextInput {
             .on_action(cx.listener(Self::line_end))
             .on_action(cx.listener(Self::paragraph_start))
             .on_action(cx.listener(Self::paragraph_end))
+            .on_action(cx.listener(Self::paragraph_backward))
+            .on_action(cx.listener(Self::paragraph_forward))
             .on_action(cx.listener(Self::move_to_previous_word))
             .on_action(cx.listener(Self::move_to_next_word))
             .on_action(cx.listener(Self::select_to_start))
@@ -2662,10 +2793,14 @@ impl Render for TextInput {
             .on_action(cx.listener(Self::select_to_line_end))
             .on_action(cx.listener(Self::select_to_paragraph_start))
             .on_action(cx.listener(Self::select_to_paragraph_end))
+            .on_action(cx.listener(Self::select_paragraph_backward))
+            .on_action(cx.listener(Self::select_paragraph_forward))
             .on_action(cx.listener(Self::select_to_previous_word))
             .on_action(cx.listener(Self::select_to_next_word))
             .on_action(cx.listener(Self::delete_to_line_start))
             .on_action(cx.listener(Self::delete_to_line_end))
+            .on_action(cx.listener(Self::delete_to_paragraph_start))
+            .on_action(cx.listener(Self::delete_to_paragraph_end))
             .on_action(cx.listener(Self::delete_to_previous_word))
             .on_action(cx.listener(Self::delete_to_next_word))
             .on_action(cx.listener(Self::paste))
@@ -2972,11 +3107,11 @@ mod tests {
 
     use super::TokenClass;
     use super::{
-        ComposerEvent, ComposerInput, DeleteToLineEnd, EditHistory, FieldMode, SearchPaint,
-        TextInput, UNDO_GROUP_INTERVAL, UNDO_HISTORY_CAP, cursor_should_be_visible,
-        input_text_runs, media_paste_entries, next_word_boundary, pasted_text_for_mode,
-        previous_word_boundary, single_line_scroll, trimmed_splice, visual_row_count,
-        word_range_at,
+        ComposerEvent, ComposerInput, DeleteToLineEnd, DeleteToLineStart, DeleteToParagraphEnd,
+        EditHistory, FieldMode, SearchPaint, TextInput, UNDO_GROUP_INTERVAL, UNDO_HISTORY_CAP,
+        cursor_should_be_visible, input_text_runs, media_paste_entries, next_word_boundary,
+        pasted_text_for_mode, previous_word_boundary, single_line_scroll, trimmed_splice,
+        visual_row_count, word_range_at,
     };
 
     struct InputHarness {
@@ -3206,21 +3341,139 @@ mod tests {
     fn killing_to_the_line_end_stops_there_and_then_takes_the_break(cx: &mut TestAppContext) {
         let (input, cx) = setup_input(cx, "first\nsecond", px(300.));
 
-        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(2..2, cx)));
-        cx.update(|window, cx| {
-            input.update(cx, |input, cx| {
-                input.delete_to_line_end(&DeleteToLineEnd, window, cx);
-            })
-        });
-        cx.read_entity(&input, |input, _| assert_eq!(input.content(), "fi\nsecond"));
+        // Both the row kill (cmd-delete) and the paragraph kill (ctrl-k)
+        // behave the same on an unwrapped line.
+        for paragraph_kill in [false, true] {
+            let kill = |input: &mut TextInput, window: &mut Window, cx: &mut Context<TextInput>| {
+                if paragraph_kill {
+                    input.delete_to_paragraph_end(&DeleteToParagraphEnd, window, cx);
+                } else {
+                    input.delete_to_line_end(&DeleteToLineEnd, window, cx);
+                }
+            };
+            cx.update(|_, cx| input.update(cx, |input, cx| input.set_content("first\nsecond", cx)));
+            cx.run_until_parked();
+            cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(2..2, cx)));
+            cx.update(|window, cx| input.update(cx, |input, cx| kill(input, window, cx)));
+            cx.read_entity(&input, |input, _| assert_eq!(input.content(), "fi\nsecond"));
 
-        // Standing on the break itself, the kill joins the next line up.
+            // Standing on the break itself, the kill joins the next line up.
+            cx.update(|window, cx| input.update(cx, |input, cx| kill(input, window, cx)));
+            cx.read_entity(&input, |input, _| assert_eq!(input.content(), "fisecond"));
+        }
+    }
+
+    #[gpui::test]
+    fn the_paragraph_kill_ignores_a_soft_wrap(cx: &mut TestAppContext) {
+        let text = "one two three four five six seven eight nine ten\nlast";
+        let (input, cx) = setup_input(cx, text, px(90.));
+        cx.read_entity(&input, |input, _| {
+            assert!(
+                visual_row_count(input.last_layout.as_ref().unwrap()) >= 4,
+                "fixture must soft-wrap the first paragraph"
+            );
+        });
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(4..4, cx)));
+
+        // cmd-delete is row-scoped and stops at the wrap.
         cx.update(|window, cx| {
             input.update(cx, |input, cx| {
                 input.delete_to_line_end(&DeleteToLineEnd, window, cx);
             })
         });
-        cx.read_entity(&input, |input, _| assert_eq!(input.content(), "fisecond"));
+        cx.read_entity(&input, |input, _| {
+            assert!(input.content().starts_with("one "));
+            assert!(
+                input.content().len() > "one \nlast".len(),
+                "the row kill must leave the rest of the paragraph: {:?}",
+                input.content()
+            );
+        });
+
+        // ctrl-k is paragraph-scoped and runs to the hard break.
+        cx.update(|_, cx| input.update(cx, |input, cx| input.set_content(text, cx)));
+        cx.run_until_parked();
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(4..4, cx)));
+        cx.update(|window, cx| {
+            input.update(cx, |input, cx| {
+                input.delete_to_paragraph_end(&DeleteToParagraphEnd, window, cx);
+            })
+        });
+        cx.read_entity(&input, |input, _| assert_eq!(input.content(), "one \nlast"));
+    }
+
+    #[gpui::test]
+    fn a_row_kill_without_a_current_layout_stops_at_the_hard_break(cx: &mut TestAppContext) {
+        let (input, cx) = setup_input(cx, "first\nsecond", px(300.));
+
+        // Replace the content and kill before the next paint: the stale layout
+        // must not send the kill to the start of the field.
+        cx.update(|window, cx| {
+            input.update(cx, |input, cx| {
+                input.set_content("first\nsecond\nthird", cx);
+                input.select_range(9..9, cx);
+                assert_ne!(
+                    input.last_layout.as_ref().unwrap().len(),
+                    input.content.len()
+                );
+                input.delete_to_line_start(&DeleteToLineStart, window, cx);
+            })
+        });
+        cx.read_entity(&input, |input, _| {
+            assert_eq!(input.content(), "first\nond\nthird")
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[gpui::test]
+    fn ctrl_a_stops_at_the_paragraph_start_while_alt_up_keeps_stepping(cx: &mut TestAppContext) {
+        // "first" 0..5, break at 5, "second" 6..12.
+        let (input, cx) = setup_input(cx, "first\nsecond\nthird", px(300.));
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(9..9, cx)));
+
+        cx.simulate_keystrokes("ctrl-a");
+        cx.read_entity(&input, |input, _| assert_eq!(input.cursor(), 6));
+        cx.simulate_keystrokes("ctrl-a");
+        cx.read_entity(&input, |input, _| assert_eq!(input.cursor(), 6));
+
+        cx.simulate_keystrokes("alt-up");
+        cx.read_entity(&input, |input, _| assert_eq!(input.cursor(), 0));
+
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(9..9, cx)));
+        cx.simulate_keystrokes("ctrl-e");
+        cx.read_entity(&input, |input, _| assert_eq!(input.cursor(), 12));
+        cx.simulate_keystrokes("ctrl-e");
+        cx.read_entity(&input, |input, _| assert_eq!(input.cursor(), 12));
+        cx.simulate_keystrokes("alt-down");
+        cx.read_entity(&input, |input, _| assert_eq!(input.cursor(), 18));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[gpui::test]
+    fn the_emacs_line_chords_reach_the_paragraph_ends_across_a_soft_wrap(cx: &mut TestAppContext) {
+        let text = "one two three four five six seven eight nine ten\nlast";
+        let (input, cx) = setup_input(cx, text, px(90.));
+        let break_at = text.find('\n').unwrap();
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(4..4, cx)));
+
+        cx.simulate_keystrokes("ctrl-e");
+        cx.read_entity(&input, |input, _| assert_eq!(input.cursor(), break_at));
+
+        cx.simulate_keystrokes("ctrl-a");
+        cx.read_entity(&input, |input, _| assert_eq!(input.cursor(), 0));
+
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(4..4, cx)));
+        cx.simulate_keystrokes("ctrl-shift-e");
+        cx.read_entity(&input, |input, _| {
+            assert_eq!(input.selected_range, 4..break_at)
+        });
+
+        // cmd-right stays on the rendered row.
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(0..0, cx)));
+        cx.simulate_keystrokes("cmd-right");
+        cx.read_entity(&input, |input, _| {
+            assert!(input.cursor() > 0 && input.cursor() < break_at);
+        });
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -28,17 +28,27 @@ actions!(
         Down,
         SelectLeft,
         SelectRight,
+        SelectUp,
+        SelectDown,
         SelectAll,
         Home,
         End,
+        LineStart,
+        LineEnd,
+        ParagraphStart,
+        ParagraphEnd,
         MoveToPreviousWord,
         MoveToNextWord,
         SelectToStart,
         SelectToEnd,
+        SelectToLineStart,
+        SelectToLineEnd,
+        SelectToParagraphStart,
+        SelectToParagraphEnd,
         SelectToPreviousWord,
         SelectToNextWord,
-        DeleteToStart,
-        DeleteToEnd,
+        DeleteToLineStart,
+        DeleteToLineEnd,
         DeleteToPreviousWord,
         DeleteToNextWord,
         Paste,
@@ -60,6 +70,10 @@ pub fn init(cx: &mut App) {
     cx.bind_keys([
         KeyBinding::new("backspace", Backspace, Some("TextInput")),
         KeyBinding::new("delete", Delete, Some("TextInput")),
+        // Bindings match modifiers exactly, so an unbound shift chord would
+        // swallow the keystroke; native fields treat it as a plain delete.
+        KeyBinding::new("shift-backspace", Backspace, Some("TextInput")),
+        KeyBinding::new("shift-delete", Delete, Some("TextInput")),
         KeyBinding::new("alt-backspace", DeleteToPreviousWord, Some("TextInput")),
         KeyBinding::new("alt-delete", DeleteToNextWord, Some("TextInput")),
         KeyBinding::new("left", Left, Some("TextInput")),
@@ -68,17 +82,16 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("down", Down, Some("TextInput")),
         KeyBinding::new("shift-left", SelectLeft, Some("TextInput")),
         KeyBinding::new("shift-right", SelectRight, Some("TextInput")),
-        KeyBinding::new("home", Home, Some("TextInput")),
-        KeyBinding::new("end", End, Some("TextInput")),
-        KeyBinding::new("shift-home", SelectToStart, Some("TextInput")),
-        KeyBinding::new("shift-end", SelectToEnd, Some("TextInput")),
+        // Home and End are platform-split below: macOS points them at the
+        // document, Windows and the Linux desktops at the line.
+        //
+        // Shift extends by one rendered row, and past the first or last row it
+        // reaches the field's own start or end the way a native field does.
+        KeyBinding::new("shift-up", SelectUp, Some("TextInput")),
+        KeyBinding::new("shift-down", SelectDown, Some("TextInput")),
         KeyBinding::new("alt-left", MoveToPreviousWord, Some("TextInput")),
         KeyBinding::new("alt-right", MoveToNextWord, Some("TextInput")),
-        KeyBinding::new(
-            "alt-shift-left",
-            SelectToPreviousWord,
-            Some("TextInput"),
-        ),
+        KeyBinding::new("alt-shift-left", SelectToPreviousWord, Some("TextInput")),
         KeyBinding::new("alt-shift-right", SelectToNextWord, Some("TextInput")),
         KeyBinding::new("secondary-a", SelectAll, Some("TextInput")),
         KeyBinding::new("secondary-v", Paste, Some("TextInput")),
@@ -100,45 +113,77 @@ pub fn init(cx: &mut App) {
 
     #[cfg(target_os = "macos")]
     cx.bind_keys([
-        KeyBinding::new("cmd-backspace", DeleteToStart, Some("TextInput")),
-        KeyBinding::new("cmd-delete", DeleteToEnd, Some("TextInput")),
+        // Home and End reach the document ends on macOS; the line ends live on
+        // the cmd and emacs chords below.
+        KeyBinding::new("home", Home, Some("TextInput")),
+        KeyBinding::new("end", End, Some("TextInput")),
+        KeyBinding::new("shift-home", SelectToStart, Some("TextInput")),
+        KeyBinding::new("shift-end", SelectToEnd, Some("TextInput")),
+        // cmd-backspace clears the line, not the whole field: a stray chord in
+        // a long draft should cost one line, not the draft.
+        KeyBinding::new("cmd-backspace", DeleteToLineStart, Some("TextInput")),
+        KeyBinding::new("cmd-delete", DeleteToLineEnd, Some("TextInput")),
         KeyBinding::new("ctrl-h", Backspace, Some("TextInput")),
         KeyBinding::new("ctrl-d", Delete, Some("TextInput")),
-        KeyBinding::new("ctrl-u", DeleteToStart, Some("TextInput")),
-        KeyBinding::new("ctrl-k", DeleteToEnd, Some("TextInput")),
+        // Native macOS maps ctrl-backspace to a (decomposing) backspace and
+        // ctrl-forward-delete to a plain forward delete; with shift held as
+        // well the chord still deletes.
+        KeyBinding::new("ctrl-backspace", Backspace, Some("TextInput")),
+        KeyBinding::new("ctrl-delete", Delete, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-backspace", Backspace, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-delete", Delete, Some("TextInput")),
+        // The emacs kill pair is line-scoped everywhere it comes from —
+        // readline, NSTextView — so it stops at the line ends here too.
+        KeyBinding::new("ctrl-u", DeleteToLineStart, Some("TextInput")),
+        KeyBinding::new("ctrl-k", DeleteToLineEnd, Some("TextInput")),
         KeyBinding::new("ctrl-b", Left, Some("TextInput")),
         KeyBinding::new("ctrl-f", Right, Some("TextInput")),
-        KeyBinding::new("cmd-left", Home, Some("TextInput")),
-        KeyBinding::new("cmd-right", End, Some("TextInput")),
+        // The vertical half of the emacs motion set, bound system-wide on
+        // macOS and previously the only part of it missing here.
+        KeyBinding::new("ctrl-p", Up, Some("TextInput")),
+        KeyBinding::new("ctrl-n", Down, Some("TextInput")),
+        KeyBinding::new("cmd-left", LineStart, Some("TextInput")),
+        KeyBinding::new("cmd-right", LineEnd, Some("TextInput")),
         KeyBinding::new("cmd-up", Home, Some("TextInput")),
         KeyBinding::new("cmd-down", End, Some("TextInput")),
-        KeyBinding::new("ctrl-a", Home, Some("TextInput")),
-        KeyBinding::new("ctrl-e", End, Some("TextInput")),
-        KeyBinding::new("shift-cmd-left", SelectToStart, Some("TextInput")),
-        KeyBinding::new("shift-cmd-right", SelectToEnd, Some("TextInput")),
+        KeyBinding::new("ctrl-a", LineStart, Some("TextInput")),
+        KeyBinding::new("ctrl-e", LineEnd, Some("TextInput")),
+        KeyBinding::new("alt-up", ParagraphStart, Some("TextInput")),
+        KeyBinding::new("alt-down", ParagraphEnd, Some("TextInput")),
+        KeyBinding::new("shift-cmd-left", SelectToLineStart, Some("TextInput")),
+        KeyBinding::new("shift-cmd-right", SelectToLineEnd, Some("TextInput")),
         KeyBinding::new("cmd-shift-up", SelectToStart, Some("TextInput")),
         KeyBinding::new("cmd-shift-down", SelectToEnd, Some("TextInput")),
-        KeyBinding::new("ctrl-shift-a", SelectToStart, Some("TextInput")),
-        KeyBinding::new("ctrl-shift-e", SelectToEnd, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-a", SelectToLineStart, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-e", SelectToLineEnd, Some("TextInput")),
+        KeyBinding::new("alt-shift-up", SelectToParagraphStart, Some("TextInput")),
+        KeyBinding::new("alt-shift-down", SelectToParagraphEnd, Some("TextInput")),
+        // Word-wise selection on the control chords too, mirroring the
+        // alt-shift pair (and the ctrl-shift convention elsewhere).
+        KeyBinding::new("ctrl-shift-left", SelectToPreviousWord, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-right", SelectToNextWord, Some("TextInput")),
     ]);
 
-    // The word-motion chords Windows and the Linux desktops share.
+    // The chords Windows and the Linux desktops share: word motion on ctrl,
+    // the line ends on Home/End, and the document ends one modifier up.
     #[cfg(not(target_os = "macos"))]
     cx.bind_keys([
-        KeyBinding::new(
-            "ctrl-backspace",
-            DeleteToPreviousWord,
-            Some("TextInput"),
-        ),
+        KeyBinding::new("home", LineStart, Some("TextInput")),
+        KeyBinding::new("end", LineEnd, Some("TextInput")),
+        KeyBinding::new("shift-home", SelectToLineStart, Some("TextInput")),
+        KeyBinding::new("shift-end", SelectToLineEnd, Some("TextInput")),
+        KeyBinding::new("ctrl-home", Home, Some("TextInput")),
+        KeyBinding::new("ctrl-end", End, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-home", SelectToStart, Some("TextInput")),
+        KeyBinding::new("ctrl-shift-end", SelectToEnd, Some("TextInput")),
+        KeyBinding::new("ctrl-backspace", DeleteToPreviousWord, Some("TextInput")),
         KeyBinding::new("ctrl-delete", DeleteToNextWord, Some("TextInput")),
         KeyBinding::new("ctrl-left", MoveToPreviousWord, Some("TextInput")),
         KeyBinding::new("ctrl-right", MoveToNextWord, Some("TextInput")),
-        KeyBinding::new(
-            "ctrl-shift-left",
-            SelectToPreviousWord,
-            Some("TextInput"),
-        ),
+        KeyBinding::new("ctrl-shift-left", SelectToPreviousWord, Some("TextInput")),
         KeyBinding::new("ctrl-shift-right", SelectToNextWord, Some("TextInput")),
+        // The redo chord those platforms carry alongside ctrl-shift-z.
+        KeyBinding::new("ctrl-y", Redo, Some("TextInput")),
     ]);
 }
 
@@ -1067,24 +1112,43 @@ impl TextInput {
     }
 
     fn up(&mut self, _: &Up, _: &mut Window, cx: &mut Context<Self>) {
-        self.move_vertically(false, cx);
+        self.move_vertically(false, false, cx);
     }
 
     fn down(&mut self, _: &Down, _: &mut Window, cx: &mut Context<Self>) {
-        self.move_vertically(true, cx);
+        self.move_vertically(true, false, cx);
     }
 
-    /// Move by one rendered row, not merely one newline-delimited line. This
-    /// is the textarea convention: soft wraps count, and the original x goal
-    /// survives a shorter row between two longer ones.
-    fn move_vertically(&mut self, down: bool, cx: &mut Context<Self>) {
+    fn select_up(&mut self, _: &SelectUp, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_vertically(false, true, cx);
+    }
+
+    fn select_down(&mut self, _: &SelectDown, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_vertically(true, true, cx);
+    }
+
+    /// Move or extend by one rendered row, not merely one newline-delimited
+    /// line. This is the textarea convention: soft wraps count, and the
+    /// original x goal survives a shorter row between two longer ones.
+    fn move_vertically(&mut self, down: bool, extend: bool, cx: &mut Context<Self>) {
         if self.mode == FieldMode::SingleLine {
             self.vertical_navigation = None;
+            if extend {
+                // The field is one row, so there is no row to step to, but a
+                // native one-line field still extends to its own end here.
+                let edge = if down { self.content.len() } else { 0 };
+                self.select_to(edge, cx);
+                return;
+            }
             cx.propagate();
             return;
         }
 
-        let anchor = if down {
+        // Extending grows from the moving end of the selection; a plain move
+        // collapses to the near edge of whatever is selected.
+        let anchor = if extend {
+            self.cursor_offset()
+        } else if down {
             self.selected_range.end
         } else {
             self.selected_range.start
@@ -1110,7 +1174,7 @@ impl TextInput {
 
         let bounds = layout.bounds();
         let layout_width = bounds.size.width;
-        let continuing = if self.selected_range.is_empty() {
+        let continuing = if extend || self.selected_range.is_empty() {
             self.vertical_navigation.filter(|navigation| {
                 navigation.cursor_offset == anchor
                     && navigation.layout_width == layout_width
@@ -1135,6 +1199,19 @@ impl TextInput {
         } else {
             current_row.saturating_sub(1)
         };
+
+        // Past the first or last row the caret has nowhere to step, but a
+        // selection keeps going to the field's own edge, as native does.
+        if extend && target_row == current_row {
+            let edge = if down { self.content.len() } else { 0 };
+            if self.cursor_offset() == edge {
+                cx.propagate();
+            } else {
+                self.select_to(edge, cx);
+            }
+            return;
+        }
+
         let Some((offset, cursor_x)) = visual_row_offset_for_x(layout, target_row, goal_x) else {
             self.vertical_navigation = None;
             cx.propagate();
@@ -1143,13 +1220,17 @@ impl TextInput {
 
         let previous_range = self.selected_range.clone();
         let previous_row = continuing.map(|navigation| navigation.visual_row);
-        self.selected_range = offset..offset;
-        self.selection_reversed = false;
+        if extend {
+            self.extend_selection_to(offset);
+        } else {
+            self.selected_range = offset..offset;
+            self.selection_reversed = false;
+        }
         self.vertical_navigation = Some(VerticalNavigation {
             goal_x,
             visual_row: target_row,
             cursor_x,
-            cursor_offset: offset,
+            cursor_offset: self.cursor_offset(),
             layout_width,
         });
         self.pause_blink_cursor(cx);
@@ -1160,6 +1241,155 @@ impl TextInput {
         // gets a chance to use the arrow.
         if previous_range == self.selected_range && previous_row == Some(target_row) {
             cx.propagate();
+        }
+    }
+
+    fn line_start(&mut self, _: &LineStart, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to_row_edge(false, false, cx);
+    }
+
+    fn line_end(&mut self, _: &LineEnd, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to_row_edge(true, false, cx);
+    }
+
+    fn select_to_line_start(
+        &mut self,
+        _: &SelectToLineStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.move_to_row_edge(false, true, cx);
+    }
+
+    fn select_to_line_end(&mut self, _: &SelectToLineEnd, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to_row_edge(true, true, cx);
+    }
+
+    /// Move or extend to the near end of the rendered row holding the caret,
+    /// counting a soft wrap as a row the way the vertical motion above does.
+    fn move_to_row_edge(&mut self, to_end: bool, extend: bool, cx: &mut Context<Self>) {
+        let Some((offset, affinity)) = self.row_edge(to_end) else {
+            // One row, or no layout to consult: the field's own ends are the
+            // only line ends there are.
+            let offset = if to_end { self.content.len() } else { 0 };
+            if extend {
+                self.select_to(offset, cx);
+            } else {
+                self.move_to(offset, cx);
+            }
+            return;
+        };
+        if extend {
+            self.select_to(offset, cx);
+        } else {
+            self.move_to(offset, cx);
+        }
+        // Both calls above drop the soft-wrap affinity, and a caret landing on
+        // a wrap boundary belongs to the row it was sent to rather than the
+        // one that boundary is shared with. Restore it for the paint.
+        if self.cursor_offset() == offset {
+            self.vertical_navigation = Some(affinity);
+        }
+    }
+
+    /// Byte offset of one end of the caret's rendered row, with the affinity
+    /// that pins it to that row. `None` when the row is the whole field.
+    fn row_edge(&self, to_end: bool) -> Option<(usize, VerticalNavigation)> {
+        if self.mode == FieldMode::SingleLine {
+            return None;
+        }
+        let layout = self
+            .last_layout
+            .as_ref()
+            .filter(|layout| layout.len() == self.content.len())?;
+        let row_count = visual_row_count(layout);
+        if row_count == 0 {
+            return None;
+        }
+        let bounds = layout.bounds();
+        let layout_width = bounds.size.width;
+        let cursor = self.cursor_offset();
+        // An earlier vertical motion already knows which row the caret is on,
+        // which is the one answer a wrap boundary cannot be read back from.
+        let row = self
+            .vertical_navigation
+            .filter(|navigation| {
+                navigation.cursor_offset == cursor
+                    && navigation.layout_width == layout_width
+                    && navigation.visual_row < row_count
+            })
+            .map(|navigation| navigation.visual_row)
+            .or_else(|| {
+                let position = layout.position_for_index(cursor)?;
+                let row = ((position.y - bounds.top()) / layout.line_height()) as usize;
+                Some(row.min(row_count - 1))
+            })?;
+        let goal_x = if to_end { layout_width } else { px(0.) };
+        let (offset, cursor_x) = visual_row_offset_for_x(layout, row, goal_x)?;
+        Some((
+            offset,
+            VerticalNavigation {
+                goal_x: cursor_x,
+                visual_row: row,
+                cursor_x,
+                cursor_offset: offset,
+                layout_width,
+            },
+        ))
+    }
+
+    fn paragraph_start(&mut self, _: &ParagraphStart, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to(self.paragraph_start_offset(), cx);
+    }
+
+    fn paragraph_end(&mut self, _: &ParagraphEnd, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to(self.paragraph_end_offset(), cx);
+    }
+
+    fn select_to_paragraph_start(
+        &mut self,
+        _: &SelectToParagraphStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(self.paragraph_start_offset(), cx);
+    }
+
+    fn select_to_paragraph_end(
+        &mut self,
+        _: &SelectToParagraphEnd,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(self.paragraph_end_offset(), cx);
+    }
+
+    /// Start of the newline-delimited paragraph holding the caret, or of the
+    /// one before it when the caret already sits at a start — repeating the
+    /// chord has to keep moving.
+    fn paragraph_start_offset(&self) -> usize {
+        let cursor = self.cursor_offset();
+        let before = &self.content[..cursor];
+        match before.rfind('\n') {
+            Some(index) if index + 1 < cursor => index + 1,
+            Some(index) => before[..index].rfind('\n').map_or(0, |index| index + 1),
+            None => 0,
+        }
+    }
+
+    /// End of the paragraph holding the caret, or of the next one when the
+    /// caret already sits at an end.
+    fn paragraph_end_offset(&self) -> usize {
+        let cursor = self.cursor_offset();
+        match self.content[cursor..].find('\n') {
+            Some(0) => {
+                let next = cursor + 1;
+                self.content[next..]
+                    .find('\n')
+                    .map_or(self.content.len(), |index| next + index)
+            }
+            Some(index) => cursor + index,
+            None => self.content.len(),
         }
     }
 
@@ -1256,16 +1486,36 @@ impl TextInput {
         self.replace_text_in_range(None, "", window, cx);
     }
 
-    fn delete_to_start(&mut self, _: &DeleteToStart, window: &mut Window, cx: &mut Context<Self>) {
+    fn delete_to_line_start(
+        &mut self,
+        _: &DeleteToLineStart,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if self.selected_range.is_empty() {
-            self.select_to(0, cx);
+            let offset = self.row_edge(false).map_or(0, |(offset, _)| offset);
+            self.select_to(offset, cx);
         }
         self.replace_text_in_range(None, "", window, cx);
     }
 
-    fn delete_to_end(&mut self, _: &DeleteToEnd, window: &mut Window, cx: &mut Context<Self>) {
+    fn delete_to_line_end(
+        &mut self,
+        _: &DeleteToLineEnd,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if self.selected_range.is_empty() {
-            self.select_to(self.content.len(), cx);
+            let cursor = self.cursor_offset();
+            let mut offset = self
+                .row_edge(true)
+                .map_or(self.content.len(), |(offset, _)| offset);
+            if offset == cursor && self.content[cursor..].starts_with('\n') {
+                // Standing on the break itself, the kill takes it and joins
+                // the next line up, the way readline and NSTextView do.
+                offset = cursor + 1;
+            }
+            self.select_to(offset, cx);
         }
         self.replace_text_in_range(None, "", window, cx);
     }
@@ -1556,6 +1806,14 @@ impl TextInput {
 
     fn select_to(&mut self, offset: usize, cx: &mut Context<Self>) {
         self.vertical_navigation = None;
+        self.extend_selection_to(offset);
+        self.pause_blink_cursor(cx);
+        cx.notify();
+    }
+
+    /// Move the selection's live end to `offset`, keeping the soft-wrap
+    /// affinity for callers that track a row themselves.
+    fn extend_selection_to(&mut self, offset: usize) {
         if self.selection_reversed {
             self.selected_range.start = offset;
         } else {
@@ -1569,8 +1827,6 @@ impl TextInput {
             self.selected_range.start = self.selected_range.start.min(word_range.start);
             self.selected_range.end = self.selected_range.end.max(word_range.end);
         }
-        self.pause_blink_cursor(cx);
-        cx.notify();
     }
 
     fn offset_from_utf16(&self, offset: usize) -> usize {
@@ -2389,17 +2645,27 @@ impl Render for TextInput {
             .on_action(cx.listener(Self::down))
             .on_action(cx.listener(Self::select_left))
             .on_action(cx.listener(Self::select_right))
+            .on_action(cx.listener(Self::select_up))
+            .on_action(cx.listener(Self::select_down))
             .on_action(cx.listener(Self::select_all))
             .on_action(cx.listener(Self::home))
             .on_action(cx.listener(Self::end))
+            .on_action(cx.listener(Self::line_start))
+            .on_action(cx.listener(Self::line_end))
+            .on_action(cx.listener(Self::paragraph_start))
+            .on_action(cx.listener(Self::paragraph_end))
             .on_action(cx.listener(Self::move_to_previous_word))
             .on_action(cx.listener(Self::move_to_next_word))
             .on_action(cx.listener(Self::select_to_start))
             .on_action(cx.listener(Self::select_to_end))
+            .on_action(cx.listener(Self::select_to_line_start))
+            .on_action(cx.listener(Self::select_to_line_end))
+            .on_action(cx.listener(Self::select_to_paragraph_start))
+            .on_action(cx.listener(Self::select_to_paragraph_end))
             .on_action(cx.listener(Self::select_to_previous_word))
             .on_action(cx.listener(Self::select_to_next_word))
-            .on_action(cx.listener(Self::delete_to_start))
-            .on_action(cx.listener(Self::delete_to_end))
+            .on_action(cx.listener(Self::delete_to_line_start))
+            .on_action(cx.listener(Self::delete_to_line_end))
             .on_action(cx.listener(Self::delete_to_previous_word))
             .on_action(cx.listener(Self::delete_to_next_word))
             .on_action(cx.listener(Self::paste))
@@ -2618,7 +2884,8 @@ impl ComposerInput {
     }
 
     pub fn set_content(&mut self, content: impl Into<SharedString>, cx: &mut Context<Self>) {
-        self.input.update(cx, |input, cx| input.set_content(content, cx));
+        self.input
+            .update(cx, |input, cx| input.set_content(content, cx));
     }
 
     pub fn set_placeholder(
@@ -2705,10 +2972,11 @@ mod tests {
 
     use super::TokenClass;
     use super::{
-        ComposerEvent, ComposerInput, EditHistory, FieldMode, SearchPaint, TextInput,
-        UNDO_GROUP_INTERVAL, UNDO_HISTORY_CAP, cursor_should_be_visible, input_text_runs,
-        media_paste_entries, next_word_boundary, pasted_text_for_mode, previous_word_boundary,
-        single_line_scroll, trimmed_splice, visual_row_count, word_range_at,
+        ComposerEvent, ComposerInput, DeleteToLineEnd, EditHistory, FieldMode, SearchPaint,
+        TextInput, UNDO_GROUP_INTERVAL, UNDO_HISTORY_CAP, cursor_should_be_visible,
+        input_text_runs, media_paste_entries, next_word_boundary, pasted_text_for_mode,
+        previous_word_boundary, single_line_scroll, trimmed_splice, visual_row_count,
+        word_range_at,
     };
 
     struct InputHarness {
@@ -2849,6 +3117,110 @@ mod tests {
                 "the wrap-boundary affinity must not leave the caret stuck"
             );
         });
+    }
+
+    #[gpui::test]
+    fn shift_arrows_extend_by_one_rendered_row(cx: &mut TestAppContext) {
+        let (input, cx) = setup_input(cx, "abcdef\nx\nabcdef", px(300.));
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(5..5, cx)));
+
+        // The short middle row clamps the column, and the goal survives it.
+        cx.simulate_keystrokes("shift-down");
+        cx.read_entity(&input, |input, _| assert_eq!(input.selected_range, 5..8));
+
+        cx.simulate_keystrokes("shift-down");
+        cx.read_entity(&input, |input, _| assert_eq!(input.selected_range, 5..14));
+    }
+
+    #[gpui::test]
+    fn shift_arrows_past_the_end_row_take_the_rest_of_the_field(cx: &mut TestAppContext) {
+        let (input, cx) = setup_input(cx, "abcdef\nx\nabcdef", px(300.));
+
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(5..5, cx)));
+        cx.simulate_keystrokes("shift-up");
+        cx.read_entity(&input, |input, _| assert_eq!(input.selected_range, 0..5));
+
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(14..14, cx)));
+        cx.simulate_keystrokes("shift-down");
+        cx.read_entity(&input, |input, _| assert_eq!(input.selected_range, 14..15));
+    }
+
+    #[gpui::test]
+    fn the_line_ends_are_the_row_ends_not_the_field_ends(cx: &mut TestAppContext) {
+        let (input, cx) = setup_input(cx, "abcdef\nx\nabcdef", px(300.));
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(12..12, cx)));
+
+        cx.update(|_, cx| input.update(cx, |input, cx| input.move_to_row_edge(false, false, cx)));
+        cx.read_entity(&input, |input, _| assert_eq!(input.cursor(), 9));
+
+        cx.update(|_, cx| input.update(cx, |input, cx| input.move_to_row_edge(true, false, cx)));
+        cx.read_entity(&input, |input, _| assert_eq!(input.cursor(), 15));
+    }
+
+    #[gpui::test]
+    fn a_soft_wrapped_row_has_its_own_ends(cx: &mut TestAppContext) {
+        let text = "one two three four five six seven eight nine ten eleven twelve";
+        let (input, cx) = setup_input(cx, text, px(90.));
+        cx.read_entity(&input, |input, _| {
+            assert!(
+                visual_row_count(input.last_layout.as_ref().unwrap()) >= 3,
+                "fixture must wrap across at least three visual rows"
+            );
+        });
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(0..0, cx)));
+
+        cx.update(|_, cx| input.update(cx, |input, cx| input.move_to_row_edge(true, false, cx)));
+        cx.read_entity(&input, |input, _| {
+            let cursor = input.cursor();
+            assert!(
+                cursor > 0 && cursor < text.len(),
+                "the end of a wrapped row is not the end of the field, got {cursor}"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn paragraph_motion_steps_between_the_line_breaks(cx: &mut TestAppContext) {
+        // "first" 0..5, break at 5, "second" 6..12, break at 12, "third" 13..18.
+        let (input, cx) = setup_input(cx, "first\nsecond\nthird", px(300.));
+
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(9..9, cx)));
+        cx.read_entity(&input, |input, _| {
+            assert_eq!(input.paragraph_start_offset(), 6);
+            assert_eq!(input.paragraph_end_offset(), 12);
+        });
+
+        // Already parked on an end, the chord has to keep going.
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(6..6, cx)));
+        cx.read_entity(&input, |input, _| {
+            assert_eq!(input.paragraph_start_offset(), 0)
+        });
+
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(12..12, cx)));
+        cx.read_entity(&input, |input, _| {
+            assert_eq!(input.paragraph_end_offset(), 18)
+        });
+    }
+
+    #[gpui::test]
+    fn killing_to_the_line_end_stops_there_and_then_takes_the_break(cx: &mut TestAppContext) {
+        let (input, cx) = setup_input(cx, "first\nsecond", px(300.));
+
+        cx.update(|_, cx| input.update(cx, |input, cx| input.select_range(2..2, cx)));
+        cx.update(|window, cx| {
+            input.update(cx, |input, cx| {
+                input.delete_to_line_end(&DeleteToLineEnd, window, cx);
+            })
+        });
+        cx.read_entity(&input, |input, _| assert_eq!(input.content(), "fi\nsecond"));
+
+        // Standing on the break itself, the kill joins the next line up.
+        cx.update(|window, cx| {
+            input.update(cx, |input, cx| {
+                input.delete_to_line_end(&DeleteToLineEnd, window, cx);
+            })
+        });
+        cx.read_entity(&input, |input, _| assert_eq!(input.content(), "fisecond"));
     }
 
     #[test]


### PR DESCRIPTION
Bindings match modifiers exactly, so a chord with no binding swallows the keystroke instead of falling back, and several chords a native field handles did nothing in `TextInput`. The ones that *were* bound treated the field as a single line, which the composer has not been for a while.

This supersedes #199, which fixed the modified delete chords alone.

The reference throughout is AppKit's `StandardKeyBinding.dict`, the table every native macOS text view consults. Every chord, the selector it answers to, and the few deliberate deviations are listed in the new [`docs/text-field-keys.md`](https://github.com/shreeve/waku/blob/feat/flesh-out-key-bindings/docs/text-field-keys.md), which also carries a fixture for checking by hand.

### Let the modified delete chords delete

Shift- and ctrl-modified backspace and forward-delete were unbound, so a shift still held from selecting text turned the next backspace into a no-op. They are plain deletes now, which is what the dict maps them to (`ctrl-backspace` is nominally the decomposing variant; Waku deletes the grapheme).

### Give each chord the unit the dict gives it

The dict splits the "line" chords by unit. The cmd chords work on the **rendered row**: `cmd-left`/`cmd-right` are `moveToLeftEndOfLine:`/`moveToRightEndOfLine:`, `cmd-backspace` is `deleteToBeginningOfLine:`. The emacs chords work on the **paragraph**, the text between hard line breaks: `ctrl-a`/`ctrl-e` are `moveToBeginningOfParagraph:`/`moveToEndOfParagraph:`, `ctrl-k` is `deleteToEndOfParagraph:`.

Before this PR every one of them moved to the ends of the whole field, so `cmd-left` in the third line of a draft jumped to the top of it, and `ctrl-k` deleted the rest of the *draft*, which is a lot to lose to a mistyped chord.

- `cmd-left`/`cmd-right` and their shift variants stop at the ends of the rendered row, counting a soft wrap as a row the way the vertical arrows already do. `cmd-backspace` kills to the row start; `cmd-delete`, unbound natively, mirrors it to the row end.
- `ctrl-a`/`ctrl-e` and their shift variants stop at the paragraph ends and stay put on repeat. `ctrl-k` kills to the paragraph end across every soft wrap, and parked on a line break takes the break itself, joining the next line up the way readline and NSTextView do. `ctrl-u` kills to the paragraph start.
- `alt-up`/`alt-down` are the *stepping* paragraph pair: the dict spells them as `moveBackward:` then `moveToBeginningOfParagraph:`, so a repeat from a paragraph start moves to the previous paragraph. They get their own `ParagraphBackward`/`ParagraphForward` actions, distinct from the `ctrl-a` pair.
- `cmd-up`/`cmd-down` keep the document ends.

When the field has no current layout to read a row from, the row kills and `cmd-left`/`cmd-right` fall back to the hard line break rather than the field's ends, so a stale row can never cost more than the line.

### Select by row

`shift-up`/`shift-down` had no row-wise selection to bind to, so they jumped to the ends of the field. They now extend by one rendered row, and past the first or last row they take the rest of the field, as a native field does. Reusing the existing vertical motion keeps the column goal across a short row, so the selection tracks what the caret would have done.

### Chords that were simply absent

- `ctrl-p`/`ctrl-n` — the vertical half of an emacs motion set that was otherwise complete, plus `ctrl-shift-p`/`ctrl-shift-n` for row-wise selection and `ctrl-shift-b`/`ctrl-shift-f` for character-wise.
- `ctrl-alt-b`/`ctrl-alt-f` and their shift variants — the dict's spelling of emacs word motion — and `ctrl-alt-backspace` for the word delete.
- `alt-up`/`alt-down` and their shift variants — paragraph motion, as above.
- `ctrl-shift-left`/`ctrl-shift-right` — on macOS these select to the row ends (`moveToLeftEndOfLineAndModifySelection:`); the word-wise reading is the Windows and Linux convention and stays there.
- `ctrl-enter`/`alt-enter` — a line break where Enter submits, as in a native field editor.
- `ctrl-home`/`ctrl-end` and `ctrl-shift-home`/`end` on Windows and Linux, where Home and End belong to the line and the document ends live one modifier up.
- `ctrl-y` — the redo chord those platforms carry alongside `ctrl-shift-z`.

`DeleteToStart` and `DeleteToEnd` go with the field-scoped kills: nothing binds them on any platform now.

### Notes

- The autocomplete popup binds `ctrl-p`/`ctrl-n` alongside the arrows, so the emacs spelling moves its highlight rather than the caret. The palette, skills, model, branch and settings search fields already bind their navigation at more specific contexts.
- Page up/down were deliberately left unbound — native views only scroll on them, and the composer holds focus most of the time, so binding them there would swallow the transcript's own paging. Home/End move the caret to the document ends where a native view would only scroll; that predates this PR and matches most editors.
- Ten tests added covering row-wise selection and its field-edge behaviour, the row ends under soft wrap, paragraph motion, the row and paragraph kills, the stale-layout fallback, and the `ctrl-a`/`alt-up` distinction. `cargo test -p waku --lib`: 371 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
