### PR TITLE
Give each queued follow-up its own row

### DIFF
--- a/src/app/composer.rs
+++ b/src/app/composer.rs
@@ -2415,7 +2415,7 @@ impl Waku {
         let theme = Theme::current(cx);
         let steerable = self.session_can_steer(session);
         let mut list = div().flex().flex_col().py(px(4.0));
-        for message in &session.queued_messages {
+        for (index, message) in session.queued_messages.iter().enumerate() {
             let message_id = message.id;
             let content = if message.visible_content().trim().is_empty() {
                 message
@@ -2508,29 +2508,41 @@ impl Waku {
             list = list.child(
                 div()
                     .id(SharedString::from(format!("queued-message-{message_id}")))
-                    .h(px(30.0))
+                    .min_h(px(30.0))
+                    .overflow_hidden()
+                    .when(index > 0, |row| row.border_t_1().border_color(theme.border))
                     .pl(px(12.0))
                     .pr(px(6.0))
                     .flex()
-                    .items_center()
+                    .items_start()
                     .gap(px(9.0))
                     .cursor_default()
                     .tab_index(0)
                     .focus_visible(|style| style.border_1().border_color(theme.accent))
                     .hover(|element| element.bg(theme.overlay))
                     .tooltip(Tooltip::text(tr!("composer.edit_in_composer")))
-                    .child(icon("icons/queue.svg", 12.0, theme.text_tertiary))
+                    .child(div().h(px(30.0)).flex().items_center().child(icon(
+                        "icons/queue.svg",
+                        12.0,
+                        theme.text_tertiary,
+                    )))
                     .child(
                         div()
                             .flex_1()
                             .min_w_0()
-                            .truncate()
+                            // Three lines is enough to recognise a prompt without
+                            // the queue becoming a second transcript.
+                            .py(px(6.0))
+                            .line_height(sp(18.0))
+                            .line_clamp(3)
+                            .text_ellipsis()
                             .text_size(sp(12.5))
                             .text_color(theme.text)
                             .child(SharedString::from(content)),
                     )
                     .child(
                         div()
+                            .h(px(30.0))
                             .flex()
                             .items_center()
                             .gap(px(2.0))


### PR DESCRIPTION
## Summary

Queued follow-ups in the composer painted over each other whenever one of them spanned more than one line.

Each row in the queued-message card was a fixed 30px box with its content vertically centred and `truncate` to keep the text on one line. `truncate` only stops soft wrapping: a hard newline still breaks the text into several lines, and centring those in 30px draws the extra lines over the rows above and below, and past the card's top edge. Any pasted terminal output or file tree in a follow-up did this.

This PR makes each row its own box:

- the row grows to its text and clips anything past that, so it can never paint over its neighbours;
- the queue icon and the controls are top-aligned with the first line instead of centred;
- a hairline rule separates consecutive rows;
- the text keeps its hard line breaks and wraps long lines, up to three lines with an ellipsis on the last, so a prompt is recognisable without the queue turning into a second transcript.

A one-line row still measures 30px, so the common case looks exactly as it did.

## Before

Three queued prompts, the first two multi-line. Rows overlap and the first spills above the card:

![before](https://raw.githubusercontent.com/shreeve/waku/pr-assets/queued-prompt-rows/before.png)

## After

Same three prompts with this change. Each row is bounded, top-aligned, and separated by a rule; the file tree is clamped to three lines:

![after](https://raw.githubusercontent.com/shreeve/waku/pr-assets/queued-prompt-rows/after.png)

## Test plan

- [x] `cargo test --lib`: 372 passed
- [x] Reproduced in `Waku Debug.app` on main with three queued prompts (two multi-line), then confirmed the layout above after the rebuild with the same queue
- [x] Single-line queued prompts unchanged at 30px
