### PR TITLE
Drop the Chrome apt source before installing Linux dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,8 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+          # Google's Chrome apt mirror intermittently fails its hash check and takes apt-get update down; nothing here needs it.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install --yes \
             clang \
@@ -143,6 +145,8 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+          # Google's Chrome apt mirror intermittently fails its hash check and takes apt-get update down; nothing here needs it.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install --yes \
             clang \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
+          # Google's Chrome apt mirror intermittently fails its hash check and takes apt-get update down; nothing here needs it.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*
           sudo apt-get update
           sudo apt-get install --yes \
             clang \


### PR DESCRIPTION
## Summary

Every Ubuntu job on GitHub-hosted runners has been failing in "Install Linux dependencies" before any Rust runs:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
E: Some index files failed to download. They have been ignored, or old ones used instead.
##[error]Process completed with exit code 100.
```

The runner image enables Google's Chrome apt repository, and its mirror intermittently serves a `Packages` index that does not match the release file. `apt-get update` then exits 100 and fails the job. Two consecutive runs of #219 hit it (https://github.com/egoist/waku/actions/runs/34383640369, https://github.com/egoist/waku/actions/runs/34384018344).

Nothing in these jobs needs Chrome, so this removes the source list before `apt-get update` in the test workflow and in both Linux release jobs.

## Test plan

- [x] On a fork, with this change, the Ubuntu "Install Linux dependencies" step passed (https://github.com/shreeve/waku/actions/runs/34384210632) where the same step had failed twice without it.
