### PR TITLE
fix(input): correct IME candidate popup positioning by clamping composition range

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -2182,22 +2182,40 @@ impl EntityInputHandler for TextInput {
         _: &mut Window,
         _: &mut Context<Self>,
     ) -> Option<Bounds<Pixels>> {
-        let layout = self.last_layout.as_ref()?;
-        let range = self.range_from_utf16(&range_utf16);
-        let start = layout.position_for_index(range.start)?;
-        let end = layout.position_for_index(range.end)?;
+        let layout = match self.last_layout.as_ref() {
+            Some(l) => l,
+            None => return Some(Bounds::new(bounds.origin, size(px(2.0), px(22.0)))),
+        };
+
         let line_height = layout.line_height();
-        if start.y == end.y {
-            Some(Bounds::from_corners(
-                start,
-                point(end.x, end.y + line_height),
-            ))
+        let range = self.range_from_utf16(&range_utf16);
+        let layout_len = layout.len();
+
+        let start_idx = range.start.min(layout_len);
+        let end_idx = range.end.min(layout_len);
+
+        let start = layout
+            .position_for_index(start_idx)
+            .unwrap_or(bounds.origin);
+        let end = if start_idx == end_idx {
+            start
         } else {
-            Some(Bounds::from_corners(
-                point(bounds.left(), start.y),
-                point(bounds.right(), end.y + line_height),
-            ))
-        }
+            layout
+                .position_for_index(end_idx)
+                .unwrap_or(start)
+        };
+
+        let res = if start.y == end.y {
+            let width = (end.x - start.x).max(px(2.0));
+            Bounds::new(start, size(width, line_height))
+        } else {
+            Bounds::from_corners(
+                start,
+                point(bounds.right(), start.y + line_height),
+            )
+        };
+
+        Some(res)
     }
 
     fn character_index_for_point(


### PR DESCRIPTION
### Problem

When typing with an input method editor (such as Chinese Pinyin, Japanese, or other CJK IMEs) on macOS, the candidate selection window frequently pops up at the bottom-left corner of the screen `(0, 0)` instead of following the text insertion caret.

### Root Cause

During IME composition:
1. macOS `NSTextInputClient` calls `firstRectForCharacterRange:` synchronously right after `setMarkedText:selectedRange:replacementRange:`.
2. At this moment, GPUI's frame render loop has not yet produced a new `TextLayout` for the newly inserted/replaced composition text, so `self.last_layout` only reflects the text before the current composition step.
3. As a result, the requested range's end index `range.end` can exceed `layout.len()`. Previously, `layout.position_for_index(range.end)?` failed and returned `None`.
4. In `crates/gpui_macos/src/window.rs`, `first_rect_for_character_range` maps `None` to `NSRect::new(NSPoint::new(0., 0.), NSSize::new(0., 0.))` (the bottom-left of the display).

### Solution

- Clamp `start_idx` and `end_idx` to `layout.len()` so that `position_for_index` safely resolves to the valid insertion point even if layout has not refreshed yet.
- If `last_layout` is not available, return a fallback caret rect anchored at `bounds.origin` instead of returning `None`.
- Ensure single-line bounds calculate width as `(end.x - start.x).max(px(2.0))` with proper `line_height`.

Tested on macOS with Chinese Pinyin IME; candidate window now consistently follows the insertion caret.